### PR TITLE
Revert "Ignore exit code of decoders on Windows"

### DIFF
--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -20,7 +20,6 @@
 
 import shlex
 from functools import lru_cache
-import platform
 
 from fluster.codec import Codec, PixelFormat
 from fluster.decoder import Decoder, register_decoder
@@ -54,8 +53,7 @@ class GStreamer(Decoder):
         '''Decode the test vector and do the checksum'''
         pipeline = self.gen_pipeline(
             input_filepath, output_filepath, output_format)
-        run_command(shlex.split(pipeline), timeout=timeout,
-                    verbose=verbose, check=(platform.system() != 'Windows'))
+        run_command(shlex.split(pipeline), timeout=timeout, verbose=verbose)
         return file_checksum(output_filepath)
 
     @lru_cache(maxsize=None)


### PR DESCRIPTION
This reverts commit 056d47884e4fe0a75bd0c0d610d3655125653752.
There is no need to ignore anymore the exit code since the
Windows decoder already works correctly.