### PR TITLE
Add VA plugin from gst-plugins-bad

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,7 @@ H265
 ```
 
 4. Run the test suite (or a number of them) for all decoders (or a number of
-   them). By default, hardware-accelerated decoders run tests sequentially,
-   while software decoders run them in parallel. By default it uses the same
+   them). By default, decoder test are run in parallel. By default it uses the same
    amount of parallel jobs as number of cores, but it can be configured using
    the `-j` option. You can pass `-d` to filter only the decoders that you want
    to run, `-ts` for the test suites and `-tv` for the test vectors. Examples:

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -117,6 +117,15 @@ class GStreamerVaapiH265Gst10Decoder(GStreamer10):
 
 
 @register_decoder
+class GStreamerVaH265Gst10Decoder(GStreamer10):
+    '''GStreamer H.265 VA decoder implementation for GStreamer 1.0'''
+    codec = Codec.H265
+    decoder_bin = ' h265parse ! vah265dec '
+    api = 'VA'
+    hw_acceleration = True
+
+
+@register_decoder
 class GStreamerMsdkH265Gst10Decoder(GStreamer10):
     '''GStreamer H.265 Intel MSDK decoder implementation for GStreamer 1.0'''
     codec = Codec.H265
@@ -149,6 +158,15 @@ class GStreamerVaapiH264Gst10Decoder(GStreamer10):
     codec = Codec.H264
     decoder_bin = ' h264parse ! vaapih264dec '
     api = 'VAAPI'
+    hw_acceleration = True
+
+
+@register_decoder
+class GStreamerVaH264Gst10Decoder(GStreamer10):
+    '''GStreamer H.264 VA decoder implementation for GStreamer 1.0'''
+    codec = Codec.H264
+    decoder_bin = ' h264parse ! vah264dec '
+    api = 'VA'
     hw_acceleration = True
 
 

--- a/fluster/test_suite.py
+++ b/fluster/test_suite.py
@@ -262,13 +262,6 @@ class TestSuite:
         if not tests:
             return None
 
-        # decoders using hardware acceleration cannot be easily parallelized
-        # reliably and may case issues. Thus, we execute them sequentially
-        if ctx.decoder.hw_acceleration and ctx.jobs > 1:
-            ctx.jobs = 1
-            print(
-                f'Decoder {ctx.decoder.name} uses hardware acceleration, using 1 job automatically')
-
         print('*' * 100)
         string = f'Running test suite {self.name} with decoder {ctx.decoder.name}\n'
         if ctx.test_vectors:


### PR DESCRIPTION
This plugin is under development but in the long term aims to replace gstreamer-vaapi. It uses the private library libgstcodecs share among other accelerator API in order to implement VA decoders. This add two new decoders:

p.s. I have also removed the hack preventing to use multiple jobs for HW decoder, let me know if you prefer are separate PR to discuss this. The hack makes it impossible to change the number of jobs and have no practical justification. It does slow down the testing process.