### PR TITLE
Show summary in case of threshold failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ check: ## check that very basic tests run
 	$(FLUSTER) reference Dummy dummy
 	$(FLUSTER) run -ts dummy -tv one -j1
 	$(FLUSTER) run -ts dummy -s
+	$(FLUSTER) run -ts dummy -so summary.log && rm -rf summary.log
 	$(FLUSTER) run -ts dummy -j1 -s
 	$(FLUSTER) run -ts dummy -th 1
 	$(FLUSTER) run -ts dummy -tth 10

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ usage: fluster.py run [-h] [-j JOBS] [-t TIMEOUT] [-ff] [-q] [-ts TESTSUITES [TE
 
 optional arguments:
   -h, --help            show this help message and exit
-  -j JOBS, --jobs JOBS  number of parallel jobs to use. 1x logical cores by default.0 means all logical cores
+  -j JOBS, --jobs JOBS  number of parallel jobs to use. 1x logical cores by default. 0 means all logical cores
   -t TIMEOUT, --timeout TIMEOUT
                         timeout in secs for each decoding. Defaults to 30 secs
   -ff, --failfast       stop after first fail

--- a/fluster/main.py
+++ b/fluster/main.py
@@ -107,10 +107,12 @@ class Main:
         subparser.add_argument(
             '-s', '--summary', help='generate a summary in Markdown format for each test suite', action='store_true')
         subparser.add_argument(
+            '-so', '--summary-output', help='dump summary output to file')
+        subparser.add_argument(
             '-k', '--keep', help='keep output files generated during the test', action='store_true')
         subparser.add_argument(
             '-th', '--threshold', help='set exit code to 2 if threshold tests are not success. '
-            'exit code is 0 otherwise', type=float)
+            'exit code is 0 otherwise', type=int)
         subparser.add_argument(
             '-tth', '--time-threshold', help='set exit code to 3 if test suite takes longer than treshold seconds. '
             'exit code is 0 otherwise', type=float)
@@ -147,7 +149,7 @@ class Main:
         subparser.add_argument(
             '-k', '--keep', help="keep downloaded file after extracting", action='store_true')
         subparser.add_argument(
-            'testsuites', help='list of testsuites to download', nargs='*')
+            'testsuites', help='list of testsuites to download', nargs='+')
         subparser.set_defaults(func=self._download_cmd)
 
     def _list_cmd(self, args, fluster):
@@ -168,11 +170,12 @@ class Main:
                           test_vectors=args.testvectors,
                           failfast=args.failfast,
                           quiet=args.quiet,
-                          summary=args.summary,
+                          summary=args.summary or args.summary_output,
                           keep_files=args.keep,
                           threshold=args.threshold,
                           time_threshold=args.time_threshold,
-                          verbose=args.verbose
+                          verbose=args.verbose,
+                          summary_output=args.summary_output
                           )
         try:
             fluster.run_test_suites(context)


### PR DESCRIPTION
Before
```
./fluster.py run -d dummy -ts dummy -th 2 -s
****************************************************************************************************
Running test suite dummy with decoder Dummy
Using 8 parallel job(s)
****************************************************************************************************

.

Ran 1/1 tests successfully in 0.001 secs
Tests results below threshold: 1 vs 2.0
Reporting error through exit code 2
```

Now
```
./fluster.py run -d dummy -ts dummy -th 2 -s
****************************************************************************************************
Running test suite dummy with decoder Dummy
Using 8 parallel job(s)
****************************************************************************************************

.

Ran 1/1 tests successfully in 0.001 secs
Generating summary for test suite dummy and decoders Dummy:

|Test|Dummy|
|-|-|
|TOTAL|1/1|
|-|-|
|one|✔️|
|-|-|
|Test|Dummy|
|TOTAL|1/1|
Tests results below threshold: 1 vs 2
Reporting error through exit code 2
```