### PR TITLE
Mark tests with timeout differently

### DIFF
--- a/fluster/fluster.py
+++ b/fluster/fluster.py
@@ -242,7 +242,12 @@ class Fluster:
             output += f'\n|{test_vector.name}|'
             for test_suite in test_suites:
                 tvector = test_suite.test_vectors[test_vector.name]
-                output += '✔️|' if not tvector.errors else '❌|'
+                if not tvector.errors:
+                    output += '✔️|'
+                elif tvector.timeout:
+                    output += '⌛|'
+                else:
+                    output += '❌|'
         output += _global_stats(results, test_suites, False)
         output += '\n'
         if ctx.summary_output:

--- a/fluster/test.py
+++ b/fluster/test.py
@@ -18,6 +18,7 @@
 # Boston, MA 02111-1307, USA.
 
 import os
+from subprocess import TimeoutExpired
 import unittest
 
 from fluster.decoder import Decoder
@@ -51,8 +52,13 @@ class Test(unittest.TestCase):
         output_filepath = normalize_path(output_filepath)
         input_filepath = normalize_path(input_filepath)
 
-        result = self.decoder.decode(
-            input_filepath, output_filepath, self.test_vector.output_format, self.timeout, self.verbose)
+        try:
+            result = self.decoder.decode(
+                input_filepath, output_filepath, self.test_vector.output_format, self.timeout, self.verbose)
+        except TimeoutExpired:
+            self.test_suite.test_vectors[self.test_vector.name].timeout = True
+            raise
+
         if not self.keep_files and os.path.exists(output_filepath) and \
                 os.path.isfile(output_filepath):
             os.remove(output_filepath)

--- a/fluster/test_vector.py
+++ b/fluster/test_vector.py
@@ -22,15 +22,20 @@ from fluster.codec import PixelFormat
 
 class TestVector:
     '''Test vector'''
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(self, name: str, source: str, source_checksum: str, input_file: str,
                  output_format: PixelFormat, result: str):
+        # JSON members
         self.name = name
         self.source = source
         self.source_checksum = source_checksum
         self.input_file = input_file
         self.output_format = output_format
         self.result = result
+
+        # Not included in JSON
+        self.timeout = False
         self.errors = []
 
     @classmethod
@@ -45,6 +50,7 @@ class TestVector:
     def data_to_serialize(self):
         '''Return the data to be serialized'''
         data = self.__dict__.copy()
+        data.pop('timeout')
         data.pop('errors')
         data['output_format'] = str(self.output_format.value)
         return data


### PR DESCRIPTION
```
./fluster.py run -ts h265short -d FFmpeg-H.265 -s -t 1
****************************************************************************************************
Running test suite h265short with decoder FFmpeg-H.265
Using 8 parallel job(s)
****************************************************************************************************

...FEEEEE.

=======================================================================
FAIL: AMP_A_Samsung_7 (FFmpeg-H.265.h265short)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pablo/Fluendo/fluster/fluster/test.py", line 56, in _test
    result = self.decoder.decode(
  File "/home/pablo/Fluendo/fluster/fluster/decoders/ffmpeg.py", line 53, in decode
    run_command(cmd, timeout=timeout, verbose=verbose)
  File "/home/pablo/Fluendo/fluster/fluster/utils.py", line 59, in run_command
    subprocess.run(command, stdout=sout, stderr=serr,
  File "/usr/lib/python3.8/subprocess.py", line 491, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1024, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1892, in _communicate
    self.wait(timeout=self._remaining_time(endtime))
  File "/usr/lib/python3.8/subprocess.py", line 1079, in wait
    return self._wait(timeout=timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1796, in _wait
    raise TimeoutExpired(self.args, timeout)
subprocess.TimeoutExpired: Command '['ffmpeg', '-i', 'resources/h265short/AMP_A_Samsung_7/AMP_A_Samsung_7.bin', '-vf', 'format=pix_fmts=yuv420p', 'results/h265short/AMP_A_Samsung_7.yuv']' timed out after 0.9999068090110086 seconds

=======================================================================
FAIL: AMP_B_Samsung_7 (FFmpeg-H.265.h265short)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pablo/Fluendo/fluster/fluster/test.py", line 56, in _test
    result = self.decoder.decode(
  File "/home/pablo/Fluendo/fluster/fluster/decoders/ffmpeg.py", line 53, in decode
    run_command(cmd, timeout=timeout, verbose=verbose)
  File "/home/pablo/Fluendo/fluster/fluster/utils.py", line 59, in run_command
    subprocess.run(command, stdout=sout, stderr=serr,
  File "/usr/lib/python3.8/subprocess.py", line 491, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1024, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1892, in _communicate
    self.wait(timeout=self._remaining_time(endtime))
  File "/usr/lib/python3.8/subprocess.py", line 1079, in wait
    return self._wait(timeout=timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1796, in _wait
    raise TimeoutExpired(self.args, timeout)
subprocess.TimeoutExpired: Command '['ffmpeg', '-i', 'resources/h265short/AMP_B_Samsung_7/AMP_B_Samsung_7.bin', '-vf', 'format=pix_fmts=yuv420p', 'results/h265short/AMP_B_Samsung_7.yuv']' timed out after 0.9999125589965843 seconds

=======================================================================
FAIL: AMP_D_Hisilicon_3 (FFmpeg-H.265.h265short)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pablo/Fluendo/fluster/fluster/test.py", line 56, in _test
    result = self.decoder.decode(
  File "/home/pablo/Fluendo/fluster/fluster/decoders/ffmpeg.py", line 53, in decode
    run_command(cmd, timeout=timeout, verbose=verbose)
  File "/home/pablo/Fluendo/fluster/fluster/utils.py", line 59, in run_command
    subprocess.run(command, stdout=sout, stderr=serr,
  File "/usr/lib/python3.8/subprocess.py", line 491, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1024, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1892, in _communicate
    self.wait(timeout=self._remaining_time(endtime))
  File "/usr/lib/python3.8/subprocess.py", line 1079, in wait
    return self._wait(timeout=timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1796, in _wait
    raise TimeoutExpired(self.args, timeout)
subprocess.TimeoutExpired: Command '['ffmpeg', '-i', 'resources/h265short/AMP_D_Hisilicon_3/AMP_D_Hisilicon.bit', '-vf', 'format=pix_fmts=yuv420p', 'results/h265short/AMP_D_Hisilicon_3.yuv']' timed out after 0.9998983140103519 seconds

=======================================================================
FAIL: AMP_E_Hisilicon_3 (FFmpeg-H.265.h265short)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pablo/Fluendo/fluster/fluster/test.py", line 56, in _test
    result = self.decoder.decode(
  File "/home/pablo/Fluendo/fluster/fluster/decoders/ffmpeg.py", line 53, in decode
    run_command(cmd, timeout=timeout, verbose=verbose)
  File "/home/pablo/Fluendo/fluster/fluster/utils.py", line 59, in run_command
    subprocess.run(command, stdout=sout, stderr=serr,
  File "/usr/lib/python3.8/subprocess.py", line 491, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1024, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1892, in _communicate
    self.wait(timeout=self._remaining_time(endtime))
  File "/usr/lib/python3.8/subprocess.py", line 1079, in wait
    return self._wait(timeout=timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1796, in _wait
    raise TimeoutExpired(self.args, timeout)
subprocess.TimeoutExpired: Command '['ffmpeg', '-i', 'resources/h265short/AMP_E_Hisilicon_3/AMP_E_Hisilicon.bit', '-vf', 'format=pix_fmts=yuv420p', 'results/h265short/AMP_E_Hisilicon_3.yuv']' timed out after 0.9998954809852876 seconds

=======================================================================
FAIL: AMP_F_Hisilicon_3 (FFmpeg-H.265.h265short)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pablo/Fluendo/fluster/fluster/test.py", line 56, in _test
    result = self.decoder.decode(
  File "/home/pablo/Fluendo/fluster/fluster/decoders/ffmpeg.py", line 53, in decode
    run_command(cmd, timeout=timeout, verbose=verbose)
  File "/home/pablo/Fluendo/fluster/fluster/utils.py", line 59, in run_command
    subprocess.run(command, stdout=sout, stderr=serr,
  File "/usr/lib/python3.8/subprocess.py", line 491, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1024, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1892, in _communicate
    self.wait(timeout=self._remaining_time(endtime))
  File "/usr/lib/python3.8/subprocess.py", line 1079, in wait
    return self._wait(timeout=timeout)
  File "/usr/lib/python3.8/subprocess.py", line 1796, in _wait
    raise TimeoutExpired(self.args, timeout)
subprocess.TimeoutExpired: Command '['ffmpeg', '-i', 'resources/h265short/AMP_F_Hisilicon_3/AMP_F_Hisilicon_3.bit', '-vf', 'format=pix_fmts=yuv420p', 'results/h265short/AMP_F_Hisilicon_3.yuv']' timed out after 0.9998810680117458 seconds

=======================================================================
FAIL: BUMPING_A_ericsson_1 (FFmpeg-H.265.h265short)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pablo/Fluendo/fluster/fluster/test.py", line 67, in _test
    self.assertEqual(self.test_vector.result.lower(), result.lower(),
AssertionError: '64f213eb1cf45614f0eeb50fd1b725bf' != '17807f3f614eeca0d77a3d03359af457'
- 64f213eb1cf45614f0eeb50fd1b725bf
+ 17807f3f614eeca0d77a3d03359af457
 : BUMPING_A_ericsson_1.bit

Ran 4/10 tests successfully with 5 timeout(s) in 1.222 secs
Generating summary for test suite h265short and decoders FFmpeg-H.265:

|Test|FFmpeg-H.265|
|-|-|
|TOTAL|4/10|
|-|-|
|AMP_A_Samsung_7|⌛|
|AMP_B_Samsung_7|⌛|
|AMP_D_Hisilicon_3|⌛|
|AMP_E_Hisilicon_3|⌛|
|AMP_F_Hisilicon_3|⌛|
|AMVP_A_MTK_4|✔️|
|AMVP_B_MTK_4|✔️|
|AMVP_C_Samsung_7|✔️|
|BUMPING_A_ericsson_1|❌|
|CAINIT_A_SHARP_4|✔️|
|-|-|
|Test|FFmpeg-H.265|
|TOTAL|4/10|


```