### PR TITLE
Add --no-emoji option to report in plain text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,14 @@ check: ## check that very basic tests run
 	@echo "Running dummy test..."
 	$(FLUSTER) list
 	$(FLUSTER) list -c
+	$(FLUSTER) -ne list -c
 	$(FLUSTER) list -ts dummy -tv
 	$(FLUSTER) download dummy
 	$(FLUSTER) run -ts dummy -tv one
 	$(FLUSTER) reference Dummy dummy
 	$(FLUSTER) run -ts dummy -tv one -j1
 	$(FLUSTER) run -ts dummy -s
+	$(FLUSTER) -ne run -ts dummy -s
 	$(FLUSTER) run -ts dummy -so summary.log && cat summary.log && rm -rf summary.log
 	$(FLUSTER) run -ts dummy -j1 -s
 	$(FLUSTER) run -ts dummy -th 1

--- a/fluster/fluster.py
+++ b/fluster/fluster.py
@@ -67,11 +67,27 @@ class Context:
         return ts_context
 
 
+EMOJI_RESULT = {
+    TestVectorResult.Success: '✔️',
+    TestVectorResult.Failure: '❌',
+    TestVectorResult.Timeout: '⌛',
+    TestVectorResult.Error: '☠'
+}
+
+TEXT_RESULT = {
+    TestVectorResult.Success: 'OK️',
+    TestVectorResult.Failure: 'KO',
+    TestVectorResult.Timeout: 'TO',
+    TestVectorResult.Error: 'ER'
+}
+
+
 class Fluster:
     '''Main class for fluster'''
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(self, test_suites_dir: str, decoders_dir: str, resources_dir: str,
-                 results_dir: str, verbose: bool = False):
+                 results_dir: str, verbose: bool = False, use_emoji: bool = True):
         self.test_suites_dir = test_suites_dir
         self.decoders_dir = decoders_dir
         self.resources_dir = resources_dir
@@ -79,6 +95,7 @@ class Fluster:
         self.verbose = verbose
         self.test_suites = []
         self.decoders = DECODERS
+        self.emoji = EMOJI_RESULT if use_emoji else TEXT_RESULT
 
     @lru_cache(maxsize=None)
     def _load_test_suites(self):
@@ -106,7 +123,8 @@ class Fluster:
             for decoder in decoders_dict[codec]:
                 string = f'{decoder}'
                 if check:
-                    string += ' ✔️' if decoder.check(verbose) else ' ❌'
+                    string += '... ' + (self.emoji[TestVectorResult.Success] if decoder.check(
+                        verbose) else self.emoji[TestVectorResult.Failure])
                 print(string)
 
     def list_test_suites(self, show_test_vectors: bool = False, test_suites: list = None):
@@ -243,14 +261,7 @@ class Fluster:
             output += f'\n|{test_vector.name}|'
             for test_suite in test_suites:
                 tvector = test_suite.test_vectors[test_vector.name]
-                if tvector.test_result == TestVectorResult.Success:
-                    output += '✔️|'
-                elif tvector.test_result == TestVectorResult.Failure:
-                    output += '❌|'
-                elif tvector.test_result == TestVectorResult.Timeout:
-                    output += '⌛|'
-                elif tvector.test_result == TestVectorResult.Error:
-                    output += '☠|'
+                output += self.emoji[tvector.test_result] + '|'
         output += _global_stats(results, test_suites, False)
         output += '\n'
         if ctx.summary_output:

--- a/fluster/main.py
+++ b/fluster/main.py
@@ -50,10 +50,12 @@ class Main:
         '''Runs Fluster'''
         args = self.parser.parse_args()
         if hasattr(args, 'func'):
-            fluster = Fluster(self.test_suites_dir,
-                              self.decoders_dir,
-                              args.resources,
-                              args.output)
+            fluster = Fluster(test_suites_dir=self.test_suites_dir,
+                              decoders_dir=self.decoders_dir,
+                              resources_dir=args.resources,
+                              results_dir=args.output,
+                              use_emoji=not args.no_emoji
+                              )
             args.func(args, fluster)
         else:
             self.parser.print_help()
@@ -64,6 +66,9 @@ class Main:
             '-r', '--resources', help='set the directory where resources are taken from', default=RESOURCES_DIR)
         parser.add_argument(
             '-o', '--output', help='set the directory where test results will be stored', default=RESULTS_DIR)
+        parser.add_argument(
+            '-ne', '--no-emoji', help='set to use plain text instead of emojis', action='store_true'
+        )
         subparsers = parser.add_subparsers(title='subcommands')
         self._add_list_cmd(subparsers)
         self._add_run_cmd(subparsers)


### PR DESCRIPTION
```./fluster.py run -ts h265short -d FFmpeg-H.265 -s -t 2```

|Test|FFmpeg-H.265|
|-|-|
|TOTAL|4/10|
|-|-|
|AMP_A_Samsung_7|⌛|
|AMP_B_Samsung_7|⌛|
|AMP_D_Hisilicon_3|⌛|
|AMP_E_Hisilicon_3|⌛|
|AMP_F_Hisilicon_3|⌛|
|AMVP_A_MTK_4|✔️|
|AMVP_B_MTK_4|✔️|
|AMVP_C_Samsung_7|✔️|
|BUMPING_A_ericsson_1|❌|
|CAINIT_A_SHARP_4|✔️|
|-|-|
|Test|FFmpeg-H.265|
|TOTAL|4/10|

```./fluster.py -ne run -ts h265short -d FFmpeg-H.265 -s -t 2```

|Test|FFmpeg-H.265|
|-|-|
|TOTAL|7/10|
|-|-|
|AMP_A_Samsung_7|OK️|
|AMP_B_Samsung_7|OK️|
|AMP_D_Hisilicon_3|TO|
|AMP_E_Hisilicon_3|OK️|
|AMP_F_Hisilicon_3|TO|
|AMVP_A_MTK_4|OK️|
|AMVP_B_MTK_4|OK️|
|AMVP_C_Samsung_7|OK️|
|BUMPING_A_ericsson_1|KO|
|CAINIT_A_SHARP_4|OK️|
|-|-|
|Test|FFmpeg-H.265|
|TOTAL|7/10|