### PR TITLE
Add VP8-TEST-VECTORS (fix #57)

### DIFF
--- a/fluster/codec.py
+++ b/fluster/codec.py
@@ -25,6 +25,7 @@ class Codec(Enum):
     Dummy = 'Dummy'
     H264 = 'H.264'
     H265 = 'H.265'
+    VP8 = 'VP8'
 
 
 class PixelFormat(Enum):

--- a/fluster/decoders/ffmpeg.py
+++ b/fluster/decoders/ffmpeg.py
@@ -83,6 +83,12 @@ class FFmpegH265Decoder(FFmpegDecoder):
     codec = Codec.H265
 
 
+@register_decoder
+class FFmpegVP8Decoder(FFmpegDecoder):
+    '''FFmpeg SW decoder for VP8'''
+    codec = Codec.VP8
+
+
 class FFmpegVaapiDecoder(FFmpegDecoder):
     '''Generic class for FFmpeg VAAPI decoder'''
     hw_acceleration = True
@@ -99,6 +105,12 @@ class FFmpegH264VaapiDecoder(FFmpegVaapiDecoder):
 class FFmpegH265VaapiDecoder(FFmpegVaapiDecoder):
     '''FFmpeg VAAPI decoder for H.265'''
     codec = Codec.H265
+
+
+@register_decoder
+class FFmpegVP8VaapiDecoder(FFmpegVaapiDecoder):
+    '''FFmpeg VAAPI decoder for VP8'''
+    codec = Codec.VP8
 
 
 class FFmpegVdpauDecoder(FFmpegDecoder):

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -218,6 +218,24 @@ class GStreamerV4l2CodecsH264Gst10Decoder(GStreamer10):
 
 
 @register_decoder
+class GStreamerLibvpxVP8(GStreamer10):
+    '''GStreamer VP8 Libvpx decoder implementation for GStreamer 1.0'''
+    codec = Codec.VP8
+    decoder_bin = ' ivfparse ! vp8dec '
+    api = 'libvpx'
+    hw_acceleration = False
+
+
+@register_decoder
+class GStreamerVaapiVP8Gst10Decoder(GStreamer10):
+    '''GStreamer VP8 VAAPI decoder implementation for GStreamer 1.0'''
+    codec = Codec.VP8
+    decoder_bin = ' ivfparse ! vaapivp8dec '
+    api = 'VAAPI'
+    hw_acceleration = True
+
+
+@register_decoder
 class FluendoH265Gst10Decoder(GStreamer10):
     '''Fluendo H.265 software decoder implementation for GStreamer 1.0'''
     codec = Codec.H265

--- a/fluster/decoders/libvpx.py
+++ b/fluster/decoders/libvpx.py
@@ -1,0 +1,39 @@
+# Fluster - testing framework for decoders conformance
+# Copyright (C) 2020, Fluendo, S.A.
+#  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
+#  Author: Andoni Morales Alastruey <amorales@fluendo.com>, Fluendo, S.A.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+from fluster.codec import Codec, PixelFormat
+from fluster.decoder import Decoder, register_decoder
+from fluster.utils import file_checksum, run_command
+
+
+@register_decoder
+class VP8Decoder(Decoder):
+    '''VP8 reference decoder implementation'''
+    name = "libvpx-VP8"
+    description = "VP8 reference decoder"
+    codec = Codec.VP8
+    binary = 'vpxdec'
+
+    def decode(self, input_filepath: str, output_filepath: str, output_format: PixelFormat, timeout: int,
+               verbose: bool) -> str:
+        '''Decodes input_filepath in output_filepath'''
+        run_command([self.binary, '--i420', input_filepath, '-o',
+                     output_filepath], timeout=timeout, verbose=verbose)
+        return file_checksum(output_filepath)

--- a/test_suites/vp8/VP8-TEST-VECTORS.json
+++ b/test_suites/vp8/VP8-TEST-VECTORS.json
@@ -3,7 +3,6 @@
     "codec": "VP8",
     "description": "VP8 Test Vector Catalogue from https://github.com/webmproject/vp8-test-vectors",
     "test_vectors": [
-
         {
             "name": "vp80-00-comprehensive-001",
             "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-001.ivf",

--- a/test_suites/vp8/VP8-TEST-VECTORS.json
+++ b/test_suites/vp8/VP8-TEST-VECTORS.json
@@ -1,0 +1,496 @@
+{
+    "name": "VP8-TEST-VECTORS",
+    "codec": "VP8",
+    "description": "VP8 Test Vector Catalogue from https://github.com/webmproject/vp8-test-vectors",
+    "test_vectors": [
+
+        {
+            "name": "vp80-00-comprehensive-001",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-001.ivf",
+            "source_checksum": "5db435f13b5c35004f51307aee1074eb",
+            "input_file": "vp80-00-comprehensive-001.ivf",
+            "output_format": "yuv420p",
+            "result": "fad126074e1bd5363d43b9d1cadddb71"
+        },
+        {
+            "name": "vp80-00-comprehensive-002",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-002.ivf",
+            "source_checksum": "75a157f300b584473a882341ee01c49e",
+            "input_file": "vp80-00-comprehensive-002.ivf",
+            "output_format": "yuv420p",
+            "result": "182f03dd264ebac04e24c7c9499d7cdb"
+        },
+        {
+            "name": "vp80-00-comprehensive-003",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-003.ivf",
+            "source_checksum": "d27546ff4e0ac0fabccd35ada8ae8097",
+            "input_file": "vp80-00-comprehensive-003.ivf",
+            "output_format": "yuv420p",
+            "result": "e5fe668b033900022c3eb0ba76a44bd1"
+        },
+        {
+            "name": "vp80-00-comprehensive-004",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-004.ivf",
+            "source_checksum": "e50def0f2a86f232fe04be70f5b8cd7f",
+            "input_file": "vp80-00-comprehensive-004.ivf",
+            "output_format": "yuv420p",
+            "result": "95097ce9808c1d47e03f99c48ad111ec"
+        },
+        {
+            "name": "vp80-00-comprehensive-005",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-005.ivf",
+            "source_checksum": "763ac10a8f18859e3f3b1c59e039ddbc",
+            "input_file": "vp80-00-comprehensive-005.ivf",
+            "output_format": "yuv420p",
+            "result": "0f469e4fd1dea533e5580688b2d242ff"
+        },
+        {
+            "name": "vp80-00-comprehensive-006",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-006.ivf",
+            "source_checksum": "bc44062a750e4aef0a1d102c68310c7e",
+            "input_file": "vp80-00-comprehensive-006.ivf",
+            "output_format": "yuv420p",
+            "result": "2d5fa3ec2f88404ae7b305c1074036f4"
+        },
+        {
+            "name": "vp80-00-comprehensive-007",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-007.ivf",
+            "source_checksum": "53454591d2f0fd0b5c5752e0a2d8df05",
+            "input_file": "vp80-00-comprehensive-007.ivf",
+            "output_format": "yuv420p",
+            "result": "92526913d89b6a9b00f2d602def08bce"
+        },
+        {
+            "name": "vp80-00-comprehensive-008",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-008.ivf",
+            "source_checksum": "c420cdaceabdca4eb84b8840fda011e0",
+            "input_file": "vp80-00-comprehensive-008.ivf",
+            "output_format": "yuv420p",
+            "result": "bd4d46a9d14fe5a7fc9cfc8deac2d34c"
+        },
+        {
+            "name": "vp80-00-comprehensive-009",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-009.ivf",
+            "source_checksum": "63b3efb510a2eb77e2a1d032e3d5f923",
+            "input_file": "vp80-00-comprehensive-009.ivf",
+            "output_format": "yuv420p",
+            "result": "19201a2d535bd82f41c1a5658def5379"
+        },
+        {
+            "name": "vp80-00-comprehensive-010",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-010.ivf",
+            "source_checksum": "6891ba00dceca891de112007da10b11d",
+            "input_file": "vp80-00-comprehensive-010.ivf",
+            "output_format": "yuv420p",
+            "result": "61d05919a9883d9f215eb3f2db63eb13"
+        },
+        {
+            "name": "vp80-00-comprehensive-011",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-011.ivf",
+            "source_checksum": "5a61cb69a0fe5177b499a6a651297e92",
+            "input_file": "vp80-00-comprehensive-011.ivf",
+            "output_format": "yuv420p",
+            "result": "1a0afe5e70512a03323a8f1176bcf022"
+        },
+        {
+            "name": "vp80-00-comprehensive-012",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-012.ivf",
+            "source_checksum": "a37ce859bd408e055e258b83af10bb08",
+            "input_file": "vp80-00-comprehensive-012.ivf",
+            "output_format": "yuv420p",
+            "result": "4ea997c80dc2087e6deec81f1ecf6668"
+        },
+        {
+            "name": "vp80-00-comprehensive-013",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-013.ivf",
+            "source_checksum": "4a6df6888e585997e0d90f0476f51d93",
+            "input_file": "vp80-00-comprehensive-013.ivf",
+            "output_format": "yuv420p",
+            "result": "93169305d3054327be3cc074f0773a75"
+        },
+        {
+            "name": "vp80-00-comprehensive-014",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-014.ivf",
+            "source_checksum": "a759db5460ccb8bdb333d0a7d1faa485",
+            "input_file": "vp80-00-comprehensive-014.ivf",
+            "output_format": "yuv420p",
+            "result": "7280a64c51dfa557c1b9552dc1e1fbed"
+        },
+        {
+            "name": "vp80-00-comprehensive-015",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-015.ivf",
+            "source_checksum": "1a2c1d7e8dde1cc5ad4a3a4bda4d10d7",
+            "input_file": "vp80-00-comprehensive-015.ivf",
+            "output_format": "yuv420p",
+            "result": "23b9cc582e344726e76cda092b416bcf"
+        },
+        {
+            "name": "vp80-00-comprehensive-016",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-016.ivf",
+            "source_checksum": "7928d7b875c09146c5bf411f8fd07883",
+            "input_file": "vp80-00-comprehensive-016.ivf",
+            "output_format": "yuv420p",
+            "result": "55e889d22f99718cf6936d55f8ade12b"
+        },
+        {
+            "name": "vp80-00-comprehensive-017",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-017.ivf",
+            "source_checksum": "43845635a9e16d9c8ff603b7bd01aa96",
+            "input_file": "vp80-00-comprehensive-017.ivf",
+            "output_format": "yuv420p",
+            "result": "95a68ffb228d1d8c6ee54f16a10fb9eb"
+        },
+        {
+            "name": "vp80-00-comprehensive-018",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-00-comprehensive-018.ivf",
+            "source_checksum": "e53d788311a24aab96ffa5c501120cf6",
+            "input_file": "vp80-00-comprehensive-018.ivf",
+            "output_format": "yuv420p",
+            "result": "4bd7da0109254c02e70a421ea720a43a"
+        },
+        {
+            "name": "vp80-01-intra-1400",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-01-intra-1400.ivf",
+            "source_checksum": "7b46e6afe9dd35c39478958794e9f3e7",
+            "input_file": "vp80-01-intra-1400.ivf",
+            "output_format": "yuv420p",
+            "result": "53b08ac91398a5dd948434e41b31b47e"
+        },
+        {
+            "name": "vp80-01-intra-1411",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-01-intra-1411.ivf",
+            "source_checksum": "21117d25f5a0603a112ff7ad3811962d",
+            "input_file": "vp80-01-intra-1411.ivf",
+            "output_format": "yuv420p",
+            "result": "8fa1762329e65c97245393a933cd0f00"
+        },
+        {
+            "name": "vp80-01-intra-1416",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-01-intra-1416.ivf",
+            "source_checksum": "3e386993b4d6ad18e9e00ba50d4419ea",
+            "input_file": "vp80-01-intra-1416.ivf",
+            "output_format": "yuv420p",
+            "result": "cffd1299fa7a0330264cb411d9482bb0"
+        },
+        {
+            "name": "vp80-01-intra-1417",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-01-intra-1417.ivf",
+            "source_checksum": "babcde452fc9d4f3a23f41fd83f2ebdd",
+            "input_file": "vp80-01-intra-1417.ivf",
+            "output_format": "yuv420p",
+            "result": "0e6c13a78a203d95fe12d206a432f642"
+        },
+        {
+            "name": "vp80-02-inter-1402",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-02-inter-1402.ivf",
+            "source_checksum": "53193b6135c96aeed8c28dc7948a20f1",
+            "input_file": "vp80-02-inter-1402.ivf",
+            "output_format": "yuv420p",
+            "result": "184ee9c5cd6e32f2fe7b2f5a463d37b3"
+        },
+        {
+            "name": "vp80-02-inter-1412",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-02-inter-1412.ivf",
+            "source_checksum": "7a4fc994d3597f5b959b1303cbe97dea",
+            "input_file": "vp80-02-inter-1412.ivf",
+            "output_format": "yuv420p",
+            "result": "6928dc8e7886914b0ba5825518e54bd7"
+        },
+        {
+            "name": "vp80-02-inter-1418",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-02-inter-1418.ivf",
+            "source_checksum": "4e088375a56171d20e1b190d00081ef4",
+            "input_file": "vp80-02-inter-1418.ivf",
+            "output_format": "yuv420p",
+            "result": "45302aa645ff5c139fe580ac30482245"
+        },
+        {
+            "name": "vp80-02-inter-1424",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-02-inter-1424.ivf",
+            "source_checksum": "98dca7dec929dbb988a08a1b5d6f0448",
+            "input_file": "vp80-02-inter-1424.ivf",
+            "output_format": "yuv420p",
+            "result": "4816cb607488b930ceadeb2cdb034c49"
+        },
+        {
+            "name": "vp80-03-segmentation-01",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-01.ivf",
+            "source_checksum": "8e56151345371043f8a2589209102ad2",
+            "input_file": "vp80-03-segmentation-01.ivf",
+            "output_format": "yuv420p",
+            "result": "db954c077b7a3f34a448ceaacf8f525c"
+        },
+        {
+            "name": "vp80-03-segmentation-02",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-02.ivf",
+            "source_checksum": "f9d534180226c8ee224fb32f18800734",
+            "input_file": "vp80-03-segmentation-02.ivf",
+            "output_format": "yuv420p",
+            "result": "4d2d65efeee1c83772c33a13446bd1a4"
+        },
+        {
+            "name": "vp80-03-segmentation-03",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-03.ivf",
+            "source_checksum": "59b799baa6e3e91c7c79601b9598d8a5",
+            "input_file": "vp80-03-segmentation-03.ivf",
+            "output_format": "yuv420p",
+            "result": "73d864433691f8db43257b88495ac8c3"
+        },
+        {
+            "name": "vp80-03-segmentation-04",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-04.ivf",
+            "source_checksum": "b7fab93dcfcc2fa74856b04fa1a563c8",
+            "input_file": "vp80-03-segmentation-04.ivf",
+            "output_format": "yuv420p",
+            "result": "7f846c8bd7cdfe61f8542f382f9d8eeb"
+        },
+        {
+            "name": "vp80-03-segmentation-1401",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1401.ivf",
+            "source_checksum": "8b2a927d3a27c3b92b592c216766b6c8",
+            "input_file": "vp80-03-segmentation-1401.ivf",
+            "output_format": "yuv420p",
+            "result": "f7acb74e99528568714129e2994ceca5"
+        },
+        {
+            "name": "vp80-03-segmentation-1403",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1403.ivf",
+            "source_checksum": "c9bbca64ae09624baa9bb6d34eeb9bef",
+            "input_file": "vp80-03-segmentation-1403.ivf",
+            "output_format": "yuv420p",
+            "result": "4e651f545a21863e97547185f93dbd7b"
+        },
+        {
+            "name": "vp80-03-segmentation-1407",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1407.ivf",
+            "source_checksum": "99fc581ea8818d57e678df17d164bd3d",
+            "input_file": "vp80-03-segmentation-1407.ivf",
+            "output_format": "yuv420p",
+            "result": "fa76612d673cbfcb8ec58eda08400388"
+        },
+        {
+            "name": "vp80-03-segmentation-1408",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1408.ivf",
+            "source_checksum": "96a83d30201582d5ea6b8894c50bd1a8",
+            "input_file": "vp80-03-segmentation-1408.ivf",
+            "output_format": "yuv420p",
+            "result": "886f15167bbdd5ea6c099e8b74452c7c"
+        },
+        {
+            "name": "vp80-03-segmentation-1409",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1409.ivf",
+            "source_checksum": "219ee70591ff0cfdfc6461f1ec533f05",
+            "input_file": "vp80-03-segmentation-1409.ivf",
+            "output_format": "yuv420p",
+            "result": "780cc4d060eecec04c2746c98065ec6f"
+        },
+        {
+            "name": "vp80-03-segmentation-1410",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1410.ivf",
+            "source_checksum": "e0d0ff4ab6327ca8e4b9b2a34d3a050e",
+            "input_file": "vp80-03-segmentation-1410.ivf",
+            "output_format": "yuv420p",
+            "result": "f3468778cd11642f095b4e5dcb19fbda"
+        },
+        {
+            "name": "vp80-03-segmentation-1413",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1413.ivf",
+            "source_checksum": "f30ee6207ccc47f7242c86746bb7f954",
+            "input_file": "vp80-03-segmentation-1413.ivf",
+            "output_format": "yuv420p",
+            "result": "6a0564ccc1a655d929390a72ff558db9"
+        },
+        {
+            "name": "vp80-03-segmentation-1414",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1414.ivf",
+            "source_checksum": "b1773331e882289631f75931bcacc644",
+            "input_file": "vp80-03-segmentation-1414.ivf",
+            "output_format": "yuv420p",
+            "result": "0f887b4bc1bb0aae670c50c9b7f0142f"
+        },
+        {
+            "name": "vp80-03-segmentation-1415",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1415.ivf",
+            "source_checksum": "6b6cb722e80e0ea87e89b80d9217e17d",
+            "input_file": "vp80-03-segmentation-1415.ivf",
+            "output_format": "yuv420p",
+            "result": "8b83e0a3ca0da9e8d7f47a06dc08e18b"
+        },
+        {
+            "name": "vp80-03-segmentation-1425",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1425.ivf",
+            "source_checksum": "ba633f3350d266dd54d9f31e28a56637",
+            "input_file": "vp80-03-segmentation-1425.ivf",
+            "output_format": "yuv420p",
+            "result": "96ffacf0c3eae59b58252be24a60e9b2"
+        },
+        {
+            "name": "vp80-03-segmentation-1426",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1426.ivf",
+            "source_checksum": "78412f91a3bba9f60d8b65af0f06358e",
+            "input_file": "vp80-03-segmentation-1426.ivf",
+            "output_format": "yuv420p",
+            "result": "ab1062e4e45e6802d80313da52028af2"
+        },
+        {
+            "name": "vp80-03-segmentation-1427",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1427.ivf",
+            "source_checksum": "84bccd906ffd94f810e99faa57f4cbdf",
+            "input_file": "vp80-03-segmentation-1427.ivf",
+            "output_format": "yuv420p",
+            "result": "761c3d8e23314516592a1f876865c22a"
+        },
+        {
+            "name": "vp80-03-segmentation-1432",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1432.ivf",
+            "source_checksum": "22e91565f27f7ef2183ceb8432b99bbc",
+            "input_file": "vp80-03-segmentation-1432.ivf",
+            "output_format": "yuv420p",
+            "result": "c5a7776fdfe8908fcc64e58c317c8cf3"
+        },
+        {
+            "name": "vp80-03-segmentation-1435",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1435.ivf",
+            "source_checksum": "a55fa0b322b4cc53fa2187e4416a9406",
+            "input_file": "vp80-03-segmentation-1435.ivf",
+            "output_format": "yuv420p",
+            "result": "36a77df963d0d8c3bc098827be403bdb"
+        },
+        {
+            "name": "vp80-03-segmentation-1436",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1436.ivf",
+            "source_checksum": "9061775e2d282e947c105575a8523a6e",
+            "input_file": "vp80-03-segmentation-1436.ivf",
+            "output_format": "yuv420p",
+            "result": "bfd17a557ee1ba347c755a18ce5a64a6"
+        },
+        {
+            "name": "vp80-03-segmentation-1437",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1437.ivf",
+            "source_checksum": "3bd9faad1398ed6a135ae4d9792ad3f0",
+            "input_file": "vp80-03-segmentation-1437.ivf",
+            "output_format": "yuv420p",
+            "result": "876e7c782ee4dd23866498b794856fd1"
+        },
+        {
+            "name": "vp80-03-segmentation-1441",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1441.ivf",
+            "source_checksum": "e36b42aed811748dba952c3bd5f52d38",
+            "input_file": "vp80-03-segmentation-1441.ivf",
+            "output_format": "yuv420p",
+            "result": "d7a1e99d0ec80ac2b95cc7277bf4db3c"
+        },
+        {
+            "name": "vp80-03-segmentation-1442",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-03-segmentation-1442.ivf",
+            "source_checksum": "425f9c67113d1290134c07e8f5d77e87",
+            "input_file": "vp80-03-segmentation-1442.ivf",
+            "output_format": "yuv420p",
+            "result": "1a23409897f51ad2920d5ddb999eac71"
+        },
+        {
+            "name": "vp80-04-partitions-1404",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-04-partitions-1404.ivf",
+            "source_checksum": "c43e6cef11aca52580a27908028b3186",
+            "input_file": "vp80-04-partitions-1404.ivf",
+            "output_format": "yuv420p",
+            "result": "27837df047de5b5ae2dc8f2e9d318cb3"
+        },
+        {
+            "name": "vp80-04-partitions-1405",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-04-partitions-1405.ivf",
+            "source_checksum": "646fdff5ba88ed22ffb735971105769b",
+            "input_file": "vp80-04-partitions-1405.ivf",
+            "output_format": "yuv420p",
+            "result": "12fb1d187ee70738265d8f3a0a70ef26"
+        },
+        {
+            "name": "vp80-04-partitions-1406",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-04-partitions-1406.ivf",
+            "source_checksum": "0cf98a4716f3357e9297dea66014b6e2",
+            "input_file": "vp80-04-partitions-1406.ivf",
+            "output_format": "yuv420p",
+            "result": "2da53f93a051dcb8290f884a55272dd9"
+        },
+        {
+            "name": "vp80-05-sharpness-1428",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-05-sharpness-1428.ivf",
+            "source_checksum": "a31daf9ab103d25c73257646e2c08ce5",
+            "input_file": "vp80-05-sharpness-1428.ivf",
+            "output_format": "yuv420p",
+            "result": "14b537dae40c6013079fd3d25cb16e7a"
+        },
+        {
+            "name": "vp80-05-sharpness-1429",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-05-sharpness-1429.ivf",
+            "source_checksum": "b8efcf9e7a79fe2a35eb626b3771e8c8",
+            "input_file": "vp80-05-sharpness-1429.ivf",
+            "output_format": "yuv420p",
+            "result": "e836423126f8a7de2c6c9777e0a84214"
+        },
+        {
+            "name": "vp80-05-sharpness-1430",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-05-sharpness-1430.ivf",
+            "source_checksum": "3de8f47c2a674849ad9cdc2ab1ca3d78",
+            "input_file": "vp80-05-sharpness-1430.ivf",
+            "output_format": "yuv420p",
+            "result": "51503f7a786032d2cbed84ed11430ff3"
+        },
+        {
+            "name": "vp80-05-sharpness-1431",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-05-sharpness-1431.ivf",
+            "source_checksum": "79836e920d59aad1eb0bce436c3b59f0",
+            "input_file": "vp80-05-sharpness-1431.ivf",
+            "output_format": "yuv420p",
+            "result": "7f7f534b2d6e28002e119ed269c8f282"
+        },
+        {
+            "name": "vp80-05-sharpness-1433",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-05-sharpness-1433.ivf",
+            "source_checksum": "a38497d6f3ffd41e7721206606045a52",
+            "input_file": "vp80-05-sharpness-1433.ivf",
+            "output_format": "yuv420p",
+            "result": "a2ff07ccbb019f48e020507ca5f5ee90"
+        },
+        {
+            "name": "vp80-05-sharpness-1434",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-05-sharpness-1434.ivf",
+            "source_checksum": "fc477d6568fe5e883770bdf4985ee6bb",
+            "input_file": "vp80-05-sharpness-1434.ivf",
+            "output_format": "yuv420p",
+            "result": "110a65e1729fc54e0a25dbf9cc367ccf"
+        },
+        {
+            "name": "vp80-05-sharpness-1438",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-05-sharpness-1438.ivf",
+            "source_checksum": "b16e8be2a0737fc4909e6d33894c9ab3",
+            "input_file": "vp80-05-sharpness-1438.ivf",
+            "output_format": "yuv420p",
+            "result": "cc468ac5ce042c85f04d62a8e09c97ff"
+        },
+        {
+            "name": "vp80-05-sharpness-1439",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-05-sharpness-1439.ivf",
+            "source_checksum": "7cd82c16a2067d2e5e237915279136a2",
+            "input_file": "vp80-05-sharpness-1439.ivf",
+            "output_format": "yuv420p",
+            "result": "ebfc41ade751e96220e74491bffda736"
+        },
+        {
+            "name": "vp80-05-sharpness-1440",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-05-sharpness-1440.ivf",
+            "source_checksum": "ec279fb33c49e3f1fc15682bc0e856e4",
+            "input_file": "vp80-05-sharpness-1440.ivf",
+            "output_format": "yuv420p",
+            "result": "903a267bcc69ad5f8d886db6478d997a"
+        },
+        {
+            "name": "vp80-05-sharpness-1443",
+            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/vp80-05-sharpness-1443.ivf",
+            "source_checksum": "0f487aa71d618885ffc9c939fee8a644",
+            "input_file": "vp80-05-sharpness-1443.ivf",
+            "output_format": "yuv420p",
+            "result": "3c5c3c66cad414d6b79de77e977f115b"
+        }
+    ]
+}


### PR DESCRIPTION
Current local results:
```
|Test|FFmpeg-VP8|FFmpeg-VP8-VAAPI|GStreamer-VP8-VAAPI-Gst1.0|GStreamer-VP8-libvpx-Gst1.0|
|TOTAL|44/61|39/61|57/61|57/61|
```

Test vectors from https://github.com/webmproject/vp8-test-vectors

Result hash from `vpxdec` tool.

JSON generated with:

```
set -eu

rm -rf templales/*out

echo '
        {
            "name": "__NAME__",
            "source": "https://github.com/webmproject/vp8-test-vectors/raw/master/__NAME__.ivf",
            "source_checksum": "__NAMEMD5__",
            "input_file": "__NAME__.ivf",
            "output_format": "yuv420p",
            "result": "__NAMEMD5OUT__"
        },
' > template

for in_file in $(ls *.ivf)
do
    echo ${in_file}
    in_file=${in_file%.ivf}
    echo ${in_file}
    sed "s/__NAME__/${in_file}/" template > "templates/${in_file}.out"
    NAMEMD5=`md5sum ${in_file}.ivf | awk '{ print $1 }'`
    sed -i "s/__NAMEMD5__/${NAMEMD5}/"  "templates/${in_file}.out"
    NAMEMD5OUT=`vpxdec --i420 ${in_file}.ivf -o - | md5sum - | awk '{ print $1 }'`
    sed -i "s/__NAMEMD5OUT__/${NAMEMD5OUT}/"  "templates/${in_file}.out"
done

cat templates/*out
```