### PR TITLE
Add VP9 support

### DIFF
--- a/fluster/codec.py
+++ b/fluster/codec.py
@@ -26,6 +26,7 @@ class Codec(Enum):
     H264 = 'H.264'
     H265 = 'H.265'
     VP8 = 'VP8'
+    VP9 = 'VP9'
 
 
 class PixelFormat(Enum):

--- a/fluster/decoders/ffmpeg.py
+++ b/fluster/decoders/ffmpeg.py
@@ -89,6 +89,12 @@ class FFmpegVP8Decoder(FFmpegDecoder):
     codec = Codec.VP8
 
 
+@register_decoder
+class FFmpegVP9Decoder(FFmpegDecoder):
+    '''FFmpeg SW decoder for VP9'''
+    codec = Codec.VP9
+
+
 class FFmpegVaapiDecoder(FFmpegDecoder):
     '''Generic class for FFmpeg VAAPI decoder'''
     hw_acceleration = True

--- a/fluster/decoders/libvpx.py
+++ b/fluster/decoders/libvpx.py
@@ -23,13 +23,16 @@ from fluster.decoder import Decoder, register_decoder
 from fluster.utils import file_checksum, run_command
 
 
-@register_decoder
-class VP8Decoder(Decoder):
-    '''VP8 reference decoder implementation'''
-    name = "libvpx-VP8"
-    description = "VP8 reference decoder"
-    codec = Codec.VP8
+class VPXDecoder(Decoder):
+    '''Generic class for VPX reference decoder'''
+    name = None
+    description = None
     binary = 'vpxdec'
+
+    def __init__(self):
+        super().__init__()
+        self.name = f'libvpx-{self.codec.value}'
+        self.description = f'{self.codec.value} reference decoder'
 
     def decode(self, input_filepath: str, output_filepath: str, output_format: PixelFormat, timeout: int,
                verbose: bool) -> str:
@@ -37,3 +40,9 @@ class VP8Decoder(Decoder):
         run_command([self.binary, '--i420', input_filepath, '-o',
                      output_filepath], timeout=timeout, verbose=verbose)
         return file_checksum(output_filepath)
+
+
+@register_decoder
+class VP8Decoder(VPXDecoder):
+    '''VP8 reference decoder implementation'''
+    codec = Codec.VP8

--- a/fluster/decoders/libvpx.py
+++ b/fluster/decoders/libvpx.py
@@ -46,3 +46,9 @@ class VPXDecoder(Decoder):
 class VP8Decoder(VPXDecoder):
     '''VP8 reference decoder implementation'''
     codec = Codec.VP8
+
+
+@register_decoder
+class VP9Decoder(VPXDecoder):
+    '''VP9 reference decoder implementation'''
+    codec = Codec.VP9

--- a/test_suites/vp9/VP9-TEST-VECTORS.json
+++ b/test_suites/vp9/VP9-TEST-VECTORS.json
@@ -1,0 +1,2431 @@
+{
+    "name": "VP9-TEST-VECTORS",
+    "codec": "VP9",
+    "description": "VP9 Test Vector Catalogue from https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/",
+    "test_vectors": [
+        {
+            "name": "vp90-2-00-quantizer-00.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-00.webm",
+            "source_checksum": "a86cf9946f69363aecbf6da67adfa946",
+            "input_file": "vp90-2-00-quantizer-00.webm",
+            "output_format": "yuv420p",
+            "result": "e3b792ed5ed3a7c53d17db06bd437ad9"
+        },
+        {
+            "name": "vp90-2-00-quantizer-01.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-01.webm",
+            "source_checksum": "889f9a6bef83c81b3210ea6ef6fdbb43",
+            "input_file": "vp90-2-00-quantizer-01.webm",
+            "output_format": "yuv420p",
+            "result": "1d84c1962a9e56c9b28adf5ee3c60e66"
+        },
+        {
+            "name": "vp90-2-00-quantizer-02.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-02.webm",
+            "source_checksum": "d7a72271a55910b3bcc1a48f9d891978",
+            "input_file": "vp90-2-00-quantizer-02.webm",
+            "output_format": "yuv420p",
+            "result": "1aa8657d81e4659f7055a6c7d4098bb1"
+        },
+        {
+            "name": "vp90-2-00-quantizer-03.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-03.webm",
+            "source_checksum": "8830d87c2b7ffb08a75dc8329cf20d92",
+            "input_file": "vp90-2-00-quantizer-03.webm",
+            "output_format": "yuv420p",
+            "result": "b1b7d561d8c453372e154fceb1b4808d"
+        },
+        {
+            "name": "vp90-2-00-quantizer-04.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-04.webm",
+            "source_checksum": "e56ca177b0c83806daabf11dfc6ad0c0",
+            "input_file": "vp90-2-00-quantizer-04.webm",
+            "output_format": "yuv420p",
+            "result": "1813956a4e1cd4d4f2820e74d161a0c3"
+        },
+        {
+            "name": "vp90-2-00-quantizer-05.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-05.webm",
+            "source_checksum": "f5786f83f2dd8e2d81bf790501ab38a4",
+            "input_file": "vp90-2-00-quantizer-05.webm",
+            "output_format": "yuv420p",
+            "result": "1ffb69182fa45c8101c4fe16a587f131"
+        },
+        {
+            "name": "vp90-2-00-quantizer-06.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-06.webm",
+            "source_checksum": "74519ad19c5cb4d11cb21fb4f85034c7",
+            "input_file": "vp90-2-00-quantizer-06.webm",
+            "output_format": "yuv420p",
+            "result": "38c52c580a5fa1305b3fb2098260da61"
+        },
+        {
+            "name": "vp90-2-00-quantizer-07.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-07.webm",
+            "source_checksum": "5dba36b1f86da5bdb0b4d6a4f59f860f",
+            "input_file": "vp90-2-00-quantizer-07.webm",
+            "output_format": "yuv420p",
+            "result": "08437804c3537272c9cffdf8d6edc5bd"
+        },
+        {
+            "name": "vp90-2-00-quantizer-08.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-08.webm",
+            "source_checksum": "1008eedc93d7d8a6fb275fb459b55381",
+            "input_file": "vp90-2-00-quantizer-08.webm",
+            "output_format": "yuv420p",
+            "result": "4ddddf21b899fa870e0f5afa6a172598"
+        },
+        {
+            "name": "vp90-2-00-quantizer-09.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-09.webm",
+            "source_checksum": "cd9cfd4b6e68714db46d350173d80bee",
+            "input_file": "vp90-2-00-quantizer-09.webm",
+            "output_format": "yuv420p",
+            "result": "1b4ed73eedc6fc7c58d6d9059afd09ea"
+        },
+        {
+            "name": "vp90-2-00-quantizer-10.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-10.webm",
+            "source_checksum": "e9eb916f1f51701d46623f6d2944675e",
+            "input_file": "vp90-2-00-quantizer-10.webm",
+            "output_format": "yuv420p",
+            "result": "013064484be3dd09435439a8f7950849"
+        },
+        {
+            "name": "vp90-2-00-quantizer-11.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-11.webm",
+            "source_checksum": "0402cd5964c4b28febc6e79302c6a94b",
+            "input_file": "vp90-2-00-quantizer-11.webm",
+            "output_format": "yuv420p",
+            "result": "581a4197f206c84af73a8932522c43ed"
+        },
+        {
+            "name": "vp90-2-00-quantizer-12.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-12.webm",
+            "source_checksum": "ff09d77be27655eba0ba9e91bf9fc137",
+            "input_file": "vp90-2-00-quantizer-12.webm",
+            "output_format": "yuv420p",
+            "result": "6195732fde030691110813c297115bc2"
+        },
+        {
+            "name": "vp90-2-00-quantizer-13.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-13.webm",
+            "source_checksum": "773795e1dbbc2d0e7bb63e0fb66bb9b5",
+            "input_file": "vp90-2-00-quantizer-13.webm",
+            "output_format": "yuv420p",
+            "result": "2c1e721b0af764bdd8f3f1ee459287e0"
+        },
+        {
+            "name": "vp90-2-00-quantizer-14.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-14.webm",
+            "source_checksum": "4bd30b9b326da6c3f023e4ddb5ffd278",
+            "input_file": "vp90-2-00-quantizer-14.webm",
+            "output_format": "yuv420p",
+            "result": "cba81faa5e696f7a242aa94e14ad61d3"
+        },
+        {
+            "name": "vp90-2-00-quantizer-15.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-15.webm",
+            "source_checksum": "cabf31dfbcbbcf1dbe168f4d97037530",
+            "input_file": "vp90-2-00-quantizer-15.webm",
+            "output_format": "yuv420p",
+            "result": "6385da95530eb3f2581021012a3c3cf2"
+        },
+        {
+            "name": "vp90-2-00-quantizer-16.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-16.webm",
+            "source_checksum": "72d3235a0a468bd3671045900f28072f",
+            "input_file": "vp90-2-00-quantizer-16.webm",
+            "output_format": "yuv420p",
+            "result": "19d2ca4aaf1e06eb1e7fded38a2e3dd3"
+        },
+        {
+            "name": "vp90-2-00-quantizer-17.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-17.webm",
+            "source_checksum": "325f49a53ec0bdb97d8cbabf7da40c82",
+            "input_file": "vp90-2-00-quantizer-17.webm",
+            "output_format": "yuv420p",
+            "result": "5fa4bc315bde47f56d9ec55c20ea0cc4"
+        },
+        {
+            "name": "vp90-2-00-quantizer-18.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-18.webm",
+            "source_checksum": "e6a6ba088a399b6685cabdc6c31bd199",
+            "input_file": "vp90-2-00-quantizer-18.webm",
+            "output_format": "yuv420p",
+            "result": "711346f8f1f307673f40b7fa35506ee5"
+        },
+        {
+            "name": "vp90-2-00-quantizer-19.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-19.webm",
+            "source_checksum": "452c07c5a84cd8bddedbf0c11004ced2",
+            "input_file": "vp90-2-00-quantizer-19.webm",
+            "output_format": "yuv420p",
+            "result": "da5887084a524cdc5265002d215818cf"
+        },
+        {
+            "name": "vp90-2-00-quantizer-20.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-20.webm",
+            "source_checksum": "abbfe3b150f1708b84efbd053165ffb9",
+            "input_file": "vp90-2-00-quantizer-20.webm",
+            "output_format": "yuv420p",
+            "result": "7178e1942a881e80a78e3d45bd0b5284"
+        },
+        {
+            "name": "vp90-2-00-quantizer-21.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-21.webm",
+            "source_checksum": "193c64504ff6f4c6234d431eb0498664",
+            "input_file": "vp90-2-00-quantizer-21.webm",
+            "output_format": "yuv420p",
+            "result": "e26f1c18a458cc102a26844804bc36ed"
+        },
+        {
+            "name": "vp90-2-00-quantizer-22.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-22.webm",
+            "source_checksum": "0a0b9a50984266f8ab3fb88ab66e6d0a",
+            "input_file": "vp90-2-00-quantizer-22.webm",
+            "output_format": "yuv420p",
+            "result": "3114b7d71dfc2933695e9ff60461c1e7"
+        },
+        {
+            "name": "vp90-2-00-quantizer-23.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-23.webm",
+            "source_checksum": "3806855d5bb662ca2991057f5154ac28",
+            "input_file": "vp90-2-00-quantizer-23.webm",
+            "output_format": "yuv420p",
+            "result": "19880f44288bb8a32ebed8ec02bb45d1"
+        },
+        {
+            "name": "vp90-2-00-quantizer-24.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-24.webm",
+            "source_checksum": "63eea13035bfd5bc8d43d227335c7cae",
+            "input_file": "vp90-2-00-quantizer-24.webm",
+            "output_format": "yuv420p",
+            "result": "67c29e77e6c9464fba9ff3847f06112e"
+        },
+        {
+            "name": "vp90-2-00-quantizer-25.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-25.webm",
+            "source_checksum": "9e247302d013bcd75a88aad336291cd2",
+            "input_file": "vp90-2-00-quantizer-25.webm",
+            "output_format": "yuv420p",
+            "result": "a9a75d2a6f9b1161574ddf2bbb0df180"
+        },
+        {
+            "name": "vp90-2-00-quantizer-26.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-26.webm",
+            "source_checksum": "7ab4122c416e123f61fefb2c3835365c",
+            "input_file": "vp90-2-00-quantizer-26.webm",
+            "output_format": "yuv420p",
+            "result": "7b95b0f2ee1b69488a756e4cd7c3f77a"
+        },
+        {
+            "name": "vp90-2-00-quantizer-27.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-27.webm",
+            "source_checksum": "af9d95b82f34e711ec7fbf200d858fb2",
+            "input_file": "vp90-2-00-quantizer-27.webm",
+            "output_format": "yuv420p",
+            "result": "ae66dde6f93a0562ef8c1f2f85243bc4"
+        },
+        {
+            "name": "vp90-2-00-quantizer-28.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-28.webm",
+            "source_checksum": "7ab542b1b619da9dfa5d43ac20f7c50e",
+            "input_file": "vp90-2-00-quantizer-28.webm",
+            "output_format": "yuv420p",
+            "result": "587a2106648019f2db4db3c29b69def0"
+        },
+        {
+            "name": "vp90-2-00-quantizer-29.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-29.webm",
+            "source_checksum": "72d308ebd959f0ce4ba210567df52bc9",
+            "input_file": "vp90-2-00-quantizer-29.webm",
+            "output_format": "yuv420p",
+            "result": "3e2d90279f8e74293cb9cb9c8ae98050"
+        },
+        {
+            "name": "vp90-2-00-quantizer-30.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-30.webm",
+            "source_checksum": "0293e0144b4aa866c424d4c78dc8d668",
+            "input_file": "vp90-2-00-quantizer-30.webm",
+            "output_format": "yuv420p",
+            "result": "ca2d26cc02429f656c3c2a4fae520961"
+        },
+        {
+            "name": "vp90-2-00-quantizer-31.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-31.webm",
+            "source_checksum": "7abe7b0f63ae28018cd267f87e13918e",
+            "input_file": "vp90-2-00-quantizer-31.webm",
+            "output_format": "yuv420p",
+            "result": "447edbb2fd467dce1b3333e955d92d69"
+        },
+        {
+            "name": "vp90-2-00-quantizer-32.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-32.webm",
+            "source_checksum": "f5dd20e9dd835ea5ebe0f6bf3ff34ae8",
+            "input_file": "vp90-2-00-quantizer-32.webm",
+            "output_format": "yuv420p",
+            "result": "09e7b1a054f85dd53e143b5e358d74ac"
+        },
+        {
+            "name": "vp90-2-00-quantizer-33.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-33.webm",
+            "source_checksum": "3f2f349b2ace9c4c060b986c45553bae",
+            "input_file": "vp90-2-00-quantizer-33.webm",
+            "output_format": "yuv420p",
+            "result": "d2f9c26e35361348248ac605df96e5c6"
+        },
+        {
+            "name": "vp90-2-00-quantizer-34.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-34.webm",
+            "source_checksum": "d6bc980cf2e45dd22ccfa143585948ee",
+            "input_file": "vp90-2-00-quantizer-34.webm",
+            "output_format": "yuv420p",
+            "result": "49c97610705696f95ec3ff4c4fefa438"
+        },
+        {
+            "name": "vp90-2-00-quantizer-35.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-35.webm",
+            "source_checksum": "fdfb8452e2e80d57c0911e2b577f81e6",
+            "input_file": "vp90-2-00-quantizer-35.webm",
+            "output_format": "yuv420p",
+            "result": "fa856bab745e2b09bd8d48c8f812be2f"
+        },
+        {
+            "name": "vp90-2-00-quantizer-36.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-36.webm",
+            "source_checksum": "6f27388e5e3ba11659e38ccd8d88c840",
+            "input_file": "vp90-2-00-quantizer-36.webm",
+            "output_format": "yuv420p",
+            "result": "528dcfcdd2b93c80bb1abaf09ff55065"
+        },
+        {
+            "name": "vp90-2-00-quantizer-37.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-37.webm",
+            "source_checksum": "c93f5d4d854f44cbba0e75d7e215e153",
+            "input_file": "vp90-2-00-quantizer-37.webm",
+            "output_format": "yuv420p",
+            "result": "2be7ba06f5f2e250abe2cc98cf57b14d"
+        },
+        {
+            "name": "vp90-2-00-quantizer-38.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-38.webm",
+            "source_checksum": "986df0c86910f33ada19f5d6c32177d7",
+            "input_file": "vp90-2-00-quantizer-38.webm",
+            "output_format": "yuv420p",
+            "result": "b98a87047b1a86e3781cb121300b0e24"
+        },
+        {
+            "name": "vp90-2-00-quantizer-39.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-39.webm",
+            "source_checksum": "1c0cf07484653a0c7ad485f65b58cd26",
+            "input_file": "vp90-2-00-quantizer-39.webm",
+            "output_format": "yuv420p",
+            "result": "37a8e9daf1e75c84b7c4faf5bb062f72"
+        },
+        {
+            "name": "vp90-2-00-quantizer-40.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-40.webm",
+            "source_checksum": "c250f1e9370329cd52123c5b716b362d",
+            "input_file": "vp90-2-00-quantizer-40.webm",
+            "output_format": "yuv420p",
+            "result": "16f726490342a7e7ddc685baf91dc8b6"
+        },
+        {
+            "name": "vp90-2-00-quantizer-41.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-41.webm",
+            "source_checksum": "d6e4440179420efdf75f7fbb2df1f862",
+            "input_file": "vp90-2-00-quantizer-41.webm",
+            "output_format": "yuv420p",
+            "result": "f461942b47e1e66ad305e5f614aa21e7"
+        },
+        {
+            "name": "vp90-2-00-quantizer-42.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-42.webm",
+            "source_checksum": "76e76ba476ed3c1c19561819e05f159f",
+            "input_file": "vp90-2-00-quantizer-42.webm",
+            "output_format": "yuv420p",
+            "result": "adffb2d1233d4e6c468dd41989dff672"
+        },
+        {
+            "name": "vp90-2-00-quantizer-43.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-43.webm",
+            "source_checksum": "210dcfb9242dbf4d82a9de39490ab3eb",
+            "input_file": "vp90-2-00-quantizer-43.webm",
+            "output_format": "yuv420p",
+            "result": "a4c9166087d526e2339e9b403497c21e"
+        },
+        {
+            "name": "vp90-2-00-quantizer-44.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-44.webm",
+            "source_checksum": "83f5aca40fd44c1db5d3807709da35b8",
+            "input_file": "vp90-2-00-quantizer-44.webm",
+            "output_format": "yuv420p",
+            "result": "0c83cdcecffa83cca3697ca732bc6453"
+        },
+        {
+            "name": "vp90-2-00-quantizer-45.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-45.webm",
+            "source_checksum": "1368559194301c33d22d9028d9e541e1",
+            "input_file": "vp90-2-00-quantizer-45.webm",
+            "output_format": "yuv420p",
+            "result": "2b9f689dd496dba8e78db073b46ba7d4"
+        },
+        {
+            "name": "vp90-2-00-quantizer-46.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-46.webm",
+            "source_checksum": "9c630e77173091f8dbb6d527853aefb2",
+            "input_file": "vp90-2-00-quantizer-46.webm",
+            "output_format": "yuv420p",
+            "result": "2f530e64607290a2579e4df2cbbd23da"
+        },
+        {
+            "name": "vp90-2-00-quantizer-47.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-47.webm",
+            "source_checksum": "db54c09fc674b02b28a40d9cae08307c",
+            "input_file": "vp90-2-00-quantizer-47.webm",
+            "output_format": "yuv420p",
+            "result": "76dca70de9ba739eb8aebb133995a452"
+        },
+        {
+            "name": "vp90-2-00-quantizer-48.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-48.webm",
+            "source_checksum": "b961fc9e21e36392673acc287cc29920",
+            "input_file": "vp90-2-00-quantizer-48.webm",
+            "output_format": "yuv420p",
+            "result": "870b79169e587ae7e73e3604c890fc88"
+        },
+        {
+            "name": "vp90-2-00-quantizer-49.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-49.webm",
+            "source_checksum": "66f3cdf6a340d491bcfc176554b8a51c",
+            "input_file": "vp90-2-00-quantizer-49.webm",
+            "output_format": "yuv420p",
+            "result": "ce0c731a23aba957430cebf4bdb9837a"
+        },
+        {
+            "name": "vp90-2-00-quantizer-50.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-50.webm",
+            "source_checksum": "f4176e8d3a96d4e405d7a0fc4c29ec3d",
+            "input_file": "vp90-2-00-quantizer-50.webm",
+            "output_format": "yuv420p",
+            "result": "83e83e6d412944e1dd4c1aa3e7dbc05e"
+        },
+        {
+            "name": "vp90-2-00-quantizer-51.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-51.webm",
+            "source_checksum": "911bc58012973b6b79df208a3285a6fa",
+            "input_file": "vp90-2-00-quantizer-51.webm",
+            "output_format": "yuv420p",
+            "result": "b2c812c1a0eb3d40f49501c84e920404"
+        },
+        {
+            "name": "vp90-2-00-quantizer-52.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-52.webm",
+            "source_checksum": "eb626cd287cba1219cf2bbfd227aa440",
+            "input_file": "vp90-2-00-quantizer-52.webm",
+            "output_format": "yuv420p",
+            "result": "d066bc89586a43b190e19eea1ee2e303"
+        },
+        {
+            "name": "vp90-2-00-quantizer-53.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-53.webm",
+            "source_checksum": "5b263256fd3eb0d8a0ea269249b2c0e7",
+            "input_file": "vp90-2-00-quantizer-53.webm",
+            "output_format": "yuv420p",
+            "result": "b50ae79934ec93dfe69fe9df5377d9b5"
+        },
+        {
+            "name": "vp90-2-00-quantizer-54.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-54.webm",
+            "source_checksum": "edaf8ba30a097a1c84b525c832720e84",
+            "input_file": "vp90-2-00-quantizer-54.webm",
+            "output_format": "yuv420p",
+            "result": "12d104faaa1655a8f0be0b87321dab44"
+        },
+        {
+            "name": "vp90-2-00-quantizer-55.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-55.webm",
+            "source_checksum": "7827a365bf1c47a58f2807e200cfeafc",
+            "input_file": "vp90-2-00-quantizer-55.webm",
+            "output_format": "yuv420p",
+            "result": "5ab6a84aa01a397a2ae357471511aa98"
+        },
+        {
+            "name": "vp90-2-00-quantizer-56.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-56.webm",
+            "source_checksum": "2775d21389c318d8d6d4d7fd5838f47a",
+            "input_file": "vp90-2-00-quantizer-56.webm",
+            "output_format": "yuv420p",
+            "result": "23212a0a9fcc9320f2238e6595fef9be"
+        },
+        {
+            "name": "vp90-2-00-quantizer-57.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-57.webm",
+            "source_checksum": "d84818fb42e21a134308c07812ee6d1e",
+            "input_file": "vp90-2-00-quantizer-57.webm",
+            "output_format": "yuv420p",
+            "result": "74b5871e183a4d259547c71c87f35da1"
+        },
+        {
+            "name": "vp90-2-00-quantizer-58.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-58.webm",
+            "source_checksum": "50f8b00ad905e13f8260f87e10afecfe",
+            "input_file": "vp90-2-00-quantizer-58.webm",
+            "output_format": "yuv420p",
+            "result": "409be04f2bfa8f9495e4e83e23ef7b94"
+        },
+        {
+            "name": "vp90-2-00-quantizer-59.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-59.webm",
+            "source_checksum": "8378e06a87013812c40826f34125394d",
+            "input_file": "vp90-2-00-quantizer-59.webm",
+            "output_format": "yuv420p",
+            "result": "2336f3122f67f3c0fcf8e37730e83b63"
+        },
+        {
+            "name": "vp90-2-00-quantizer-60.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-60.webm",
+            "source_checksum": "304d2a88780042090bf81ab6165766a0",
+            "input_file": "vp90-2-00-quantizer-60.webm",
+            "output_format": "yuv420p",
+            "result": "9f38746cd53d5185fd26b440612986c0"
+        },
+        {
+            "name": "vp90-2-00-quantizer-61.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-61.webm",
+            "source_checksum": "4f461d65fe40f9f64e2665f543c89936",
+            "input_file": "vp90-2-00-quantizer-61.webm",
+            "output_format": "yuv420p",
+            "result": "6992869f9f38ea9354bb3ce9a886d377"
+        },
+        {
+            "name": "vp90-2-00-quantizer-62.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-62.webm",
+            "source_checksum": "ebf9c9ccbd3f346e76c4b4e902fa27e2",
+            "input_file": "vp90-2-00-quantizer-62.webm",
+            "output_format": "yuv420p",
+            "result": "1f541ef18a4dc8017541ea98296f6416"
+        },
+        {
+            "name": "vp90-2-00-quantizer-63.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-00-quantizer-63.webm",
+            "source_checksum": "f4d889a3bc2d2d7044fae32595154462",
+            "input_file": "vp90-2-00-quantizer-63.webm",
+            "output_format": "yuv420p",
+            "result": "8e8dedb818f27256ea5e03b4feccb1d8"
+        },
+        {
+            "name": "vp90-2-01-sharpness-1.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-01-sharpness-1.webm",
+            "source_checksum": "c3e66a4c0ccdb3878d1437ca49b6103f",
+            "input_file": "vp90-2-01-sharpness-1.webm",
+            "output_format": "yuv420p",
+            "result": "93933db89b51196bc742c3ffe9f1e1ac"
+        },
+        {
+            "name": "vp90-2-01-sharpness-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-01-sharpness-2.webm",
+            "source_checksum": "b82142a50ff9f429985c464e666004f9",
+            "input_file": "vp90-2-01-sharpness-2.webm",
+            "output_format": "yuv420p",
+            "result": "019995e68f2ef6ed183727f7755bdebe"
+        },
+        {
+            "name": "vp90-2-01-sharpness-3.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-01-sharpness-3.webm",
+            "source_checksum": "db2e0e652eda25f24791d41e9b64504a",
+            "input_file": "vp90-2-01-sharpness-3.webm",
+            "output_format": "yuv420p",
+            "result": "5fdf162f7c1d9b3f4925c85c56a2c686"
+        },
+        {
+            "name": "vp90-2-01-sharpness-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-01-sharpness-4.webm",
+            "source_checksum": "bd469ad1bd88d065ccab1c2d1882ab58",
+            "input_file": "vp90-2-01-sharpness-4.webm",
+            "output_format": "yuv420p",
+            "result": "31b74b56d6b416a0bef47945d00f41c1"
+        },
+        {
+            "name": "vp90-2-01-sharpness-5.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-01-sharpness-5.webm",
+            "source_checksum": "d972e2c990c130110d951db63c9dcfa8",
+            "input_file": "vp90-2-01-sharpness-5.webm",
+            "output_format": "yuv420p",
+            "result": "88773e02a8419643bd1848543cf22da9"
+        },
+        {
+            "name": "vp90-2-01-sharpness-6.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-01-sharpness-6.webm",
+            "source_checksum": "2f7d469af53b7fa192215f8b61d8553b",
+            "input_file": "vp90-2-01-sharpness-6.webm",
+            "output_format": "yuv420p",
+            "result": "4019ad1e487c347145a6a85a770eb425"
+        },
+        {
+            "name": "vp90-2-01-sharpness-7.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-01-sharpness-7.webm",
+            "source_checksum": "afe369d23c6cea98e2ce61fbd75a5d36",
+            "input_file": "vp90-2-01-sharpness-7.webm",
+            "output_format": "yuv420p",
+            "result": "3ea4efa850800f14192276aeb98a6de3"
+        },
+        {
+            "name": "vp90-2-02-size-08x08.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-08x08.webm",
+            "source_checksum": "08e5bb42c1817779f7c8a115b3c60a4d",
+            "input_file": "vp90-2-02-size-08x08.webm",
+            "output_format": "yuv420p",
+            "result": "c8536ec8e6a9e7c4e86820724bee574e"
+        },
+        {
+            "name": "vp90-2-02-size-08x10.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-08x10.webm",
+            "source_checksum": "d878d0db8ef6128bad732b3c8ad00309",
+            "input_file": "vp90-2-02-size-08x10.webm",
+            "output_format": "yuv420p",
+            "result": "df3cd73f66358f26bd2463bc1f328940"
+        },
+        {
+            "name": "vp90-2-02-size-08x16.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-08x16.webm",
+            "source_checksum": "208cf102757b9feec55773ec177d5d1f",
+            "input_file": "vp90-2-02-size-08x16.webm",
+            "output_format": "yuv420p",
+            "result": "119ed5b93765afe95f0af59d5e49e83a"
+        },
+        {
+            "name": "vp90-2-02-size-08x18.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-08x18.webm",
+            "source_checksum": "fa560383dcb042e9431df74f6680600c",
+            "input_file": "vp90-2-02-size-08x18.webm",
+            "output_format": "yuv420p",
+            "result": "9cb37121a24ff654bd42304d934e03d5"
+        },
+        {
+            "name": "vp90-2-02-size-08x32.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-08x32.webm",
+            "source_checksum": "9a3624f8be0af3536b9329c1f6531de7",
+            "input_file": "vp90-2-02-size-08x32.webm",
+            "output_format": "yuv420p",
+            "result": "485329784b3f34a0f88ee6d53b3a7e4d"
+        },
+        {
+            "name": "vp90-2-02-size-08x34.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-08x34.webm",
+            "source_checksum": "58ee15ad1a3f8b2434662dfe930be0bf",
+            "input_file": "vp90-2-02-size-08x34.webm",
+            "output_format": "yuv420p",
+            "result": "9d57d8ee18323e5c2e1661f797af0ac5"
+        },
+        {
+            "name": "vp90-2-02-size-08x64.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-08x64.webm",
+            "source_checksum": "72103f5ea77611a9fcfe0ab85cc0733c",
+            "input_file": "vp90-2-02-size-08x64.webm",
+            "output_format": "yuv420p",
+            "result": "0a477708efba024fa56c2e8f4d8489e1"
+        },
+        {
+            "name": "vp90-2-02-size-08x66.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-08x66.webm",
+            "source_checksum": "b98287639696987f4c3176a404dda98c",
+            "input_file": "vp90-2-02-size-08x66.webm",
+            "output_format": "yuv420p",
+            "result": "19e4b5cc7ccea38760e5d2f0ae071c63"
+        },
+        {
+            "name": "vp90-2-02-size-10x08.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-10x08.webm",
+            "source_checksum": "96299cc1a64eecae0c6aa977b6dc0828",
+            "input_file": "vp90-2-02-size-10x08.webm",
+            "output_format": "yuv420p",
+            "result": "d29f93efe8d35724dbbf635fa0ef4402"
+        },
+        {
+            "name": "vp90-2-02-size-10x10.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-10x10.webm",
+            "source_checksum": "853e8959312d54d3e9272cc1d0516f97",
+            "input_file": "vp90-2-02-size-10x10.webm",
+            "output_format": "yuv420p",
+            "result": "0b5b714158fb49f2373305e98441b4d3"
+        },
+        {
+            "name": "vp90-2-02-size-10x16.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-10x16.webm",
+            "source_checksum": "01c29f4a6a60e17788403790e6d2cd19",
+            "input_file": "vp90-2-02-size-10x16.webm",
+            "output_format": "yuv420p",
+            "result": "2c27a7de97a0ebfc9421848b47037d84"
+        },
+        {
+            "name": "vp90-2-02-size-10x18.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-10x18.webm",
+            "source_checksum": "7f6703dcb0c3ec27a9ac5d803e671047",
+            "input_file": "vp90-2-02-size-10x18.webm",
+            "output_format": "yuv420p",
+            "result": "9a05dd20c2596481fbda1f07ae81fe95"
+        },
+        {
+            "name": "vp90-2-02-size-10x32.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-10x32.webm",
+            "source_checksum": "65cd472d16edeee57c8501206f58c627",
+            "input_file": "vp90-2-02-size-10x32.webm",
+            "output_format": "yuv420p",
+            "result": "fd0b75849e6a96f7fba376bd7c2d06a0"
+        },
+        {
+            "name": "vp90-2-02-size-10x34.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-10x34.webm",
+            "source_checksum": "f75244c72e64d02ea19a533a260dd400",
+            "input_file": "vp90-2-02-size-10x34.webm",
+            "output_format": "yuv420p",
+            "result": "9741af8ee27f8a28a6b1a45c92fc858a"
+        },
+        {
+            "name": "vp90-2-02-size-10x64.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-10x64.webm",
+            "source_checksum": "db73ff2db27c5d7fcc49f4a457bad024",
+            "input_file": "vp90-2-02-size-10x64.webm",
+            "output_format": "yuv420p",
+            "result": "055db170914aa465dadc0f4705367ca7"
+        },
+        {
+            "name": "vp90-2-02-size-10x66.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-10x66.webm",
+            "source_checksum": "9f0ae4977e089d33e15f1722c3f5a0f9",
+            "input_file": "vp90-2-02-size-10x66.webm",
+            "output_format": "yuv420p",
+            "result": "ca7a4821898eb1f68bde75ad5030e4eb"
+        },
+        {
+            "name": "vp90-2-02-size-130x132.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-130x132.webm",
+            "source_checksum": "300de4418f38191496b45da85858ccfd",
+            "input_file": "vp90-2-02-size-130x132.webm",
+            "output_format": "yuv420p",
+            "result": "89e38724490f77c3a4439846b08c2e27"
+        },
+        {
+            "name": "vp90-2-02-size-132x130.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-132x130.webm",
+            "source_checksum": "ab792786fc2888332521aab75da4c536",
+            "input_file": "vp90-2-02-size-132x130.webm",
+            "output_format": "yuv420p",
+            "result": "7781b5585ae38277d5e72fbd5a807f15"
+        },
+        {
+            "name": "vp90-2-02-size-132x132.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-132x132.webm",
+            "source_checksum": "652a43dbbb69e96c5eaf45ad951879d6",
+            "input_file": "vp90-2-02-size-132x132.webm",
+            "output_format": "yuv420p",
+            "result": "d00f763f3dfb25da942cee096655f96d"
+        },
+        {
+            "name": "vp90-2-02-size-16x08.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-16x08.webm",
+            "source_checksum": "0ed7467d88b0f79897ac0d1d4d3b3cd1",
+            "input_file": "vp90-2-02-size-16x08.webm",
+            "output_format": "yuv420p",
+            "result": "c75a408eda94502e33815e11dd8c2900"
+        },
+        {
+            "name": "vp90-2-02-size-16x10.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-16x10.webm",
+            "source_checksum": "62c0730ad4ce71236eb4feed741167f4",
+            "input_file": "vp90-2-02-size-16x10.webm",
+            "output_format": "yuv420p",
+            "result": "6c666f419af8d7a453e337eec956322c"
+        },
+        {
+            "name": "vp90-2-02-size-16x16.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-16x16.webm",
+            "source_checksum": "faa1b7ef623e7cd48de69a329c4409b6",
+            "input_file": "vp90-2-02-size-16x16.webm",
+            "output_format": "yuv420p",
+            "result": "bd01c7edfb4a3c0f02d6c22b87d0ca8a"
+        },
+        {
+            "name": "vp90-2-02-size-16x18.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-16x18.webm",
+            "source_checksum": "473747180ac3d7b26d4819434e6f85dd",
+            "input_file": "vp90-2-02-size-16x18.webm",
+            "output_format": "yuv420p",
+            "result": "a7a35ad8312fa64d7d6a0ca26030d4d1"
+        },
+        {
+            "name": "vp90-2-02-size-16x32.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-16x32.webm",
+            "source_checksum": "c5509a6d58dc5120071f5cd80c6a6a4f",
+            "input_file": "vp90-2-02-size-16x32.webm",
+            "output_format": "yuv420p",
+            "result": "7b1ecea0cc945b5c26192bfe4a33cbf1"
+        },
+        {
+            "name": "vp90-2-02-size-16x34.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-16x34.webm",
+            "source_checksum": "a8fa8881ef3034fcd2db65a1a4b593f5",
+            "input_file": "vp90-2-02-size-16x34.webm",
+            "output_format": "yuv420p",
+            "result": "df047abdd425b71c9de19b13dea0ff87"
+        },
+        {
+            "name": "vp90-2-02-size-16x64.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-16x64.webm",
+            "source_checksum": "28361468cfd7917270c5476e7aef313f",
+            "input_file": "vp90-2-02-size-16x64.webm",
+            "output_format": "yuv420p",
+            "result": "af894f06a92b3ea283d59b28052f050a"
+        },
+        {
+            "name": "vp90-2-02-size-16x66.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-16x66.webm",
+            "source_checksum": "af8dc3144da2608b33b71eb7adf595a4",
+            "input_file": "vp90-2-02-size-16x66.webm",
+            "output_format": "yuv420p",
+            "result": "ccfc8ac4733454b317a0f9b22b7db697"
+        },
+        {
+            "name": "vp90-2-02-size-178x180.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-178x180.webm",
+            "source_checksum": "b68d7f500b882e0408afd28abe29248f",
+            "input_file": "vp90-2-02-size-178x180.webm",
+            "output_format": "yuv420p",
+            "result": "23317c73277190fa81aaa2ce461a0d44"
+        },
+        {
+            "name": "vp90-2-02-size-180x178.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-180x178.webm",
+            "source_checksum": "2579e65d718d3de8f7513ef418be5aad",
+            "input_file": "vp90-2-02-size-180x178.webm",
+            "output_format": "yuv420p",
+            "result": "cb7315cbdaa5da61b57b91167d7b20bb"
+        },
+        {
+            "name": "vp90-2-02-size-180x180.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-180x180.webm",
+            "source_checksum": "7978994ae57b267939f9b9f4132767e8",
+            "input_file": "vp90-2-02-size-180x180.webm",
+            "output_format": "yuv420p",
+            "result": "9204bde5179c758d32e12032f819f392"
+        },
+        {
+            "name": "vp90-2-02-size-18x08.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-18x08.webm",
+            "source_checksum": "fc4dd652fd8383a4c7d720ca9c4d8947",
+            "input_file": "vp90-2-02-size-18x08.webm",
+            "output_format": "yuv420p",
+            "result": "bd547843018f3e5fed47e50520d4f6c9"
+        },
+        {
+            "name": "vp90-2-02-size-18x10.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-18x10.webm",
+            "source_checksum": "12c3502325717232555448949b4fa1eb",
+            "input_file": "vp90-2-02-size-18x10.webm",
+            "output_format": "yuv420p",
+            "result": "5a2dbc33c467941606fa1e1f25f68f08"
+        },
+        {
+            "name": "vp90-2-02-size-18x16.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-18x16.webm",
+            "source_checksum": "730a92cc42601a8d252db42ba7dd89f8",
+            "input_file": "vp90-2-02-size-18x16.webm",
+            "output_format": "yuv420p",
+            "result": "b508fa0f3032a553d399a63d4b4450fe"
+        },
+        {
+            "name": "vp90-2-02-size-18x18.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-18x18.webm",
+            "source_checksum": "f69260fab9901d77bc6bf79d053714ba",
+            "input_file": "vp90-2-02-size-18x18.webm",
+            "output_format": "yuv420p",
+            "result": "2bf4aaa9699b7d9ed10af6affa57be26"
+        },
+        {
+            "name": "vp90-2-02-size-18x32.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-18x32.webm",
+            "source_checksum": "f7a5d52cc8958e3232e553d8495395ed",
+            "input_file": "vp90-2-02-size-18x32.webm",
+            "output_format": "yuv420p",
+            "result": "50268bb59723a7a0469061827f0f3b94"
+        },
+        {
+            "name": "vp90-2-02-size-18x34.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-18x34.webm",
+            "source_checksum": "63f7ac05c666fbf2801b2cffc307690a",
+            "input_file": "vp90-2-02-size-18x34.webm",
+            "output_format": "yuv420p",
+            "result": "bffda9bc1d5181f79c204105baac77fd"
+        },
+        {
+            "name": "vp90-2-02-size-18x64.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-18x64.webm",
+            "source_checksum": "29144fe7ca5eb93c2a7d47f1298a7a77",
+            "input_file": "vp90-2-02-size-18x64.webm",
+            "output_format": "yuv420p",
+            "result": "127873f28d27ef74e045e6595c9363df"
+        },
+        {
+            "name": "vp90-2-02-size-18x66.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-18x66.webm",
+            "source_checksum": "83139bbe18f71e0db1ac90bf243f8e68",
+            "input_file": "vp90-2-02-size-18x66.webm",
+            "output_format": "yuv420p",
+            "result": "bb6608e5c93a6146815b5f4956a3c4bb"
+        },
+        {
+            "name": "vp90-2-02-size-32x08.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-32x08.webm",
+            "source_checksum": "7c6fadc4ce8df0e6debb45e4a9cbd461",
+            "input_file": "vp90-2-02-size-32x08.webm",
+            "output_format": "yuv420p",
+            "result": "3667135a26dac36507fd1f946fa6d7ba"
+        },
+        {
+            "name": "vp90-2-02-size-32x10.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-32x10.webm",
+            "source_checksum": "1ad1152c1df419452a5689d265b2c45c",
+            "input_file": "vp90-2-02-size-32x10.webm",
+            "output_format": "yuv420p",
+            "result": "5e15d0403d5daf8532c8b1b03f751aa8"
+        },
+        {
+            "name": "vp90-2-02-size-32x16.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-32x16.webm",
+            "source_checksum": "42d07fba660aefe7804e45947d5aa192",
+            "input_file": "vp90-2-02-size-32x16.webm",
+            "output_format": "yuv420p",
+            "result": "13fb81ca553eec6ddfbe2a1838b7231a"
+        },
+        {
+            "name": "vp90-2-02-size-32x18.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-32x18.webm",
+            "source_checksum": "d28d1cc5aeff13a8f74156f6065b0891",
+            "input_file": "vp90-2-02-size-32x18.webm",
+            "output_format": "yuv420p",
+            "result": "0a6a10cd56b53b5ae67004fcd293376d"
+        },
+        {
+            "name": "vp90-2-02-size-32x32.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-32x32.webm",
+            "source_checksum": "98477971ab9fe9b92cba28a8ae3dc813",
+            "input_file": "vp90-2-02-size-32x32.webm",
+            "output_format": "yuv420p",
+            "result": "964062bb690ba101e0ea69f9097fb215"
+        },
+        {
+            "name": "vp90-2-02-size-32x34.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-32x34.webm",
+            "source_checksum": "0bd0ba612f9603aeb1e8ea3bedd94ba8",
+            "input_file": "vp90-2-02-size-32x34.webm",
+            "output_format": "yuv420p",
+            "result": "9b24137431aaa6ea3cfe9cb2c30352e1"
+        },
+        {
+            "name": "vp90-2-02-size-32x64.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-32x64.webm",
+            "source_checksum": "4953f81077d4be3b6f8dfdd103840f0b",
+            "input_file": "vp90-2-02-size-32x64.webm",
+            "output_format": "yuv420p",
+            "result": "ea0274cada7ab205ed44203a854b533f"
+        },
+        {
+            "name": "vp90-2-02-size-32x66.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-32x66.webm",
+            "source_checksum": "2e120eabdecb1237aed8487c13c56491",
+            "input_file": "vp90-2-02-size-32x66.webm",
+            "output_format": "yuv420p",
+            "result": "28d3f8bfbf5548d3f710b243581dcb7b"
+        },
+        {
+            "name": "vp90-2-02-size-34x08.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-34x08.webm",
+            "source_checksum": "2a1d14e989e98acdcb8cbbf85af5516b",
+            "input_file": "vp90-2-02-size-34x08.webm",
+            "output_format": "yuv420p",
+            "result": "d06f2cb06b7df6955744dfd15e9ba3d2"
+        },
+        {
+            "name": "vp90-2-02-size-34x10.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-34x10.webm",
+            "source_checksum": "491a2ad936addeca0dd83d5307431a19",
+            "input_file": "vp90-2-02-size-34x10.webm",
+            "output_format": "yuv420p",
+            "result": "0ed772fca98e675215ae55e118c6ac6f"
+        },
+        {
+            "name": "vp90-2-02-size-34x16.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-34x16.webm",
+            "source_checksum": "7edea7b4dd7ae4320578be35219175a9",
+            "input_file": "vp90-2-02-size-34x16.webm",
+            "output_format": "yuv420p",
+            "result": "cfa5cd989ce85b9615ee6a3caeda43ac"
+        },
+        {
+            "name": "vp90-2-02-size-34x18.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-34x18.webm",
+            "source_checksum": "1cddd64c15aa6363ebae967ad98f51b2",
+            "input_file": "vp90-2-02-size-34x18.webm",
+            "output_format": "yuv420p",
+            "result": "011882e9f5ca263dccbb56570e9eb6da"
+        },
+        {
+            "name": "vp90-2-02-size-34x32.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-34x32.webm",
+            "source_checksum": "517beedde9e4d1938ab727e89499ec77",
+            "input_file": "vp90-2-02-size-34x32.webm",
+            "output_format": "yuv420p",
+            "result": "58557a7a0e9ee9785c6f04299614aa08"
+        },
+        {
+            "name": "vp90-2-02-size-34x34.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-34x34.webm",
+            "source_checksum": "cf9c57bc946855553e73e3ad204b58fb",
+            "input_file": "vp90-2-02-size-34x34.webm",
+            "output_format": "yuv420p",
+            "result": "6f32c9f3dc27072051bcc8456cba8850"
+        },
+        {
+            "name": "vp90-2-02-size-34x64.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-34x64.webm",
+            "source_checksum": "9c8b72c79f7401a05fa5e638aeed53f7",
+            "input_file": "vp90-2-02-size-34x64.webm",
+            "output_format": "yuv420p",
+            "result": "c297799957b297412db76588b16bd841"
+        },
+        {
+            "name": "vp90-2-02-size-34x66.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-34x66.webm",
+            "source_checksum": "09f8c3daaa3c40827095ce71797bff35",
+            "input_file": "vp90-2-02-size-34x66.webm",
+            "output_format": "yuv420p",
+            "result": "b3507a41ec6d35f608c3397d532944ac"
+        },
+        {
+            "name": "vp90-2-02-size-64x08.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-64x08.webm",
+            "source_checksum": "ff6f254142656b7cb8f05dddaf57ccdf",
+            "input_file": "vp90-2-02-size-64x08.webm",
+            "output_format": "yuv420p",
+            "result": "1a0efb3a767118b67b86605d0ed2b927"
+        },
+        {
+            "name": "vp90-2-02-size-64x10.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-64x10.webm",
+            "source_checksum": "35e8ded4788eb84836b1866c0205700a",
+            "input_file": "vp90-2-02-size-64x10.webm",
+            "output_format": "yuv420p",
+            "result": "d16f89e46846170108e5a6f64ade1615"
+        },
+        {
+            "name": "vp90-2-02-size-64x16.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-64x16.webm",
+            "source_checksum": "f5a5f8192118702e47e1c724b630c8cb",
+            "input_file": "vp90-2-02-size-64x16.webm",
+            "output_format": "yuv420p",
+            "result": "94a3bc9e9eae9221e076e43098bc3689"
+        },
+        {
+            "name": "vp90-2-02-size-64x18.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-64x18.webm",
+            "source_checksum": "559c38fcc4078f3c9364afaad47b87b1",
+            "input_file": "vp90-2-02-size-64x18.webm",
+            "output_format": "yuv420p",
+            "result": "33fc5659fb728d7815945cc30159088c"
+        },
+        {
+            "name": "vp90-2-02-size-64x32.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-64x32.webm",
+            "source_checksum": "8a193bb752d5811a67b003753f9e7c81",
+            "input_file": "vp90-2-02-size-64x32.webm",
+            "output_format": "yuv420p",
+            "result": "238695392697e1bf883cb08abf084e74"
+        },
+        {
+            "name": "vp90-2-02-size-64x34.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-64x34.webm",
+            "source_checksum": "208df43c645c88408888eae47a2a7637",
+            "input_file": "vp90-2-02-size-64x34.webm",
+            "output_format": "yuv420p",
+            "result": "a9252d8d594f13602b49469fec1e7560"
+        },
+        {
+            "name": "vp90-2-02-size-64x64.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-64x64.webm",
+            "source_checksum": "2f29ffbccc51ec60f3d3fbdf0f0b0cf5",
+            "input_file": "vp90-2-02-size-64x64.webm",
+            "output_format": "yuv420p",
+            "result": "8b745f635cdc6dc2c5eb3f92f64c7b5a"
+        },
+        {
+            "name": "vp90-2-02-size-64x66.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-64x66.webm",
+            "source_checksum": "74a7d94333ca1c3d47536e9420df9964",
+            "input_file": "vp90-2-02-size-64x66.webm",
+            "output_format": "yuv420p",
+            "result": "7a98b8b22b0c10273b263c564eb1c370"
+        },
+        {
+            "name": "vp90-2-02-size-66x08.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-66x08.webm",
+            "source_checksum": "0fc33bb5d00fe5d933390c7459c91c01",
+            "input_file": "vp90-2-02-size-66x08.webm",
+            "output_format": "yuv420p",
+            "result": "58042c5c61ede3c61597c09899d62e38"
+        },
+        {
+            "name": "vp90-2-02-size-66x10.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-66x10.webm",
+            "source_checksum": "54f1bcf5dae9a31cc2b1a016b835d658",
+            "input_file": "vp90-2-02-size-66x10.webm",
+            "output_format": "yuv420p",
+            "result": "584ac4ffd26331b23d747b403755ee86"
+        },
+        {
+            "name": "vp90-2-02-size-66x16.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-66x16.webm",
+            "source_checksum": "7552fa3198eaef114a64e6d5cc26bee5",
+            "input_file": "vp90-2-02-size-66x16.webm",
+            "output_format": "yuv420p",
+            "result": "84ac0da0ba3b0f8685c76e1bd2fa8456"
+        },
+        {
+            "name": "vp90-2-02-size-66x18.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-66x18.webm",
+            "source_checksum": "f6ccc67798b35c0b538227adb1f4d941",
+            "input_file": "vp90-2-02-size-66x18.webm",
+            "output_format": "yuv420p",
+            "result": "2a6d9c3ab1ec4f805fa1377f9724d380"
+        },
+        {
+            "name": "vp90-2-02-size-66x32.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-66x32.webm",
+            "source_checksum": "c7424d401ae9858d170d6c1e3ada6ca9",
+            "input_file": "vp90-2-02-size-66x32.webm",
+            "output_format": "yuv420p",
+            "result": "78793e363c981448f5aadd14d7f01de2"
+        },
+        {
+            "name": "vp90-2-02-size-66x34.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-66x34.webm",
+            "source_checksum": "5b930aa7ac3bba8a88be1235ad5ad18d",
+            "input_file": "vp90-2-02-size-66x34.webm",
+            "output_format": "yuv420p",
+            "result": "8d4f71b9389e09d857a64f1434c47f7e"
+        },
+        {
+            "name": "vp90-2-02-size-66x64.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-66x64.webm",
+            "source_checksum": "51031d25758d12d9077147c52f395b52",
+            "input_file": "vp90-2-02-size-66x64.webm",
+            "output_format": "yuv420p",
+            "result": "e251cdfcf2730d04025e7ca1f8a3107a"
+        },
+        {
+            "name": "vp90-2-02-size-66x66.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-66x66.webm",
+            "source_checksum": "5952743aeac165181f4a74a4da9e7096",
+            "input_file": "vp90-2-02-size-66x66.webm",
+            "output_format": "yuv420p",
+            "result": "ef0e92006732ccfefca70a3dab33dc31"
+        },
+        {
+            "name": "vp90-2-02-size-lf-1920x1080.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-02-size-lf-1920x1080.webm",
+            "source_checksum": "f066e8ba76a74b33842faa65d3e5bb31",
+            "input_file": "vp90-2-02-size-lf-1920x1080.webm",
+            "output_format": "yuv420p",
+            "result": "41b1c1d30e4310b76d4e7847742b804c"
+        },
+        {
+            "name": "vp90-2-03-deltaq.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-deltaq.webm",
+            "source_checksum": "dbbba47417eb4e108058715fb550b1f2",
+            "input_file": "vp90-2-03-deltaq.webm",
+            "output_format": "yuv420p",
+            "result": "9d3dff8ec14e97eeb685581b22eb3035"
+        },
+        {
+            "name": "vp90-2-03-size-196x196.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-196x196.webm",
+            "source_checksum": "6dea4ef2aebd5c26c58a4613ec1de9af",
+            "input_file": "vp90-2-03-size-196x196.webm",
+            "output_format": "yuv420p",
+            "result": "e603d0d5aa4b78baf68f163a4b229b5c"
+        },
+        {
+            "name": "vp90-2-03-size-196x198.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-196x198.webm",
+            "source_checksum": "971f99f68dd6cd8f1eadcccef02627a5",
+            "input_file": "vp90-2-03-size-196x198.webm",
+            "output_format": "yuv420p",
+            "result": "fb6daa50641425268641e4ab5018017d"
+        },
+        {
+            "name": "vp90-2-03-size-196x200.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-196x200.webm",
+            "source_checksum": "1e1ae63665d53c57f63885c829d36500",
+            "input_file": "vp90-2-03-size-196x200.webm",
+            "output_format": "yuv420p",
+            "result": "25e4c65df33df838ffeb643d12613c16"
+        },
+        {
+            "name": "vp90-2-03-size-196x202.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-196x202.webm",
+            "source_checksum": "891184b2c5affdc851e51f609b9d458b",
+            "input_file": "vp90-2-03-size-196x202.webm",
+            "output_format": "yuv420p",
+            "result": "edf74671f25036d65fb38a1f1fbe2e08"
+        },
+        {
+            "name": "vp90-2-03-size-196x208.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-196x208.webm",
+            "source_checksum": "04fcb09af5757887651839fb402532b4",
+            "input_file": "vp90-2-03-size-196x208.webm",
+            "output_format": "yuv420p",
+            "result": "e0692f0f9812c0349b168283e0abe37d"
+        },
+        {
+            "name": "vp90-2-03-size-196x210.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-196x210.webm",
+            "source_checksum": "525e812ccc238ecf9165b48d5bc88038",
+            "input_file": "vp90-2-03-size-196x210.webm",
+            "output_format": "yuv420p",
+            "result": "05aaf57268d84b9d0a76ac99080bd82a"
+        },
+        {
+            "name": "vp90-2-03-size-196x224.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-196x224.webm",
+            "source_checksum": "65f0fdaf0a3d6e34a50bbc83e9616048",
+            "input_file": "vp90-2-03-size-196x224.webm",
+            "output_format": "yuv420p",
+            "result": "d495a54be415bb5a508f20c3263f78bc"
+        },
+        {
+            "name": "vp90-2-03-size-196x226.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-196x226.webm",
+            "source_checksum": "4c1ff866ae25f225043966b6ecd7abc5",
+            "input_file": "vp90-2-03-size-196x226.webm",
+            "output_format": "yuv420p",
+            "result": "b9eab541a1855f0093f46ee4718dd80b"
+        },
+        {
+            "name": "vp90-2-03-size-198x196.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-198x196.webm",
+            "source_checksum": "b07288b2054b95f5d471634cefeec42d",
+            "input_file": "vp90-2-03-size-198x196.webm",
+            "output_format": "yuv420p",
+            "result": "efb774bdb7a520dc20bfce369c9ae66c"
+        },
+        {
+            "name": "vp90-2-03-size-198x198.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-198x198.webm",
+            "source_checksum": "7d46d8af355e886fba040a161b7f81fa",
+            "input_file": "vp90-2-03-size-198x198.webm",
+            "output_format": "yuv420p",
+            "result": "a909b9693ec189cb4ae49b75952a0776"
+        },
+        {
+            "name": "vp90-2-03-size-198x200.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-198x200.webm",
+            "source_checksum": "29a1ff40ad9e5b868fd1ba46876ddd2e",
+            "input_file": "vp90-2-03-size-198x200.webm",
+            "output_format": "yuv420p",
+            "result": "81b4a214a547aad2be36396f64826707"
+        },
+        {
+            "name": "vp90-2-03-size-198x202.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-198x202.webm",
+            "source_checksum": "a530286354456e98d92d2d4510db7a90",
+            "input_file": "vp90-2-03-size-198x202.webm",
+            "output_format": "yuv420p",
+            "result": "edb3180bd7126ee18519f244e283ae5e"
+        },
+        {
+            "name": "vp90-2-03-size-198x208.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-198x208.webm",
+            "source_checksum": "a9189355f57bd58b42bba3cbae776691",
+            "input_file": "vp90-2-03-size-198x208.webm",
+            "output_format": "yuv420p",
+            "result": "7aab93cb31d98724b6e988403d416639"
+        },
+        {
+            "name": "vp90-2-03-size-198x210.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-198x210.webm",
+            "source_checksum": "a196cad2c18fcaf7cd67888faf2e1822",
+            "input_file": "vp90-2-03-size-198x210.webm",
+            "output_format": "yuv420p",
+            "result": "75844dc2bf0efa1d44e162c4c4d4e3d2"
+        },
+        {
+            "name": "vp90-2-03-size-198x224.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-198x224.webm",
+            "source_checksum": "c1ecdf76dcd54230f099bc4f7239a9a6",
+            "input_file": "vp90-2-03-size-198x224.webm",
+            "output_format": "yuv420p",
+            "result": "1d8313f63c31c9c2c87d5092e0a28087"
+        },
+        {
+            "name": "vp90-2-03-size-198x226.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-198x226.webm",
+            "source_checksum": "eafa1a06c77c86d4e31444320abbaa46",
+            "input_file": "vp90-2-03-size-198x226.webm",
+            "output_format": "yuv420p",
+            "result": "f8e6578651d14a56f9a673042af86cc4"
+        },
+        {
+            "name": "vp90-2-03-size-200x196.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-200x196.webm",
+            "source_checksum": "392b66745cc8a4850316cb9a6edf46d5",
+            "input_file": "vp90-2-03-size-200x196.webm",
+            "output_format": "yuv420p",
+            "result": "165f30ddd55bcefd9bcc69a642f2c823"
+        },
+        {
+            "name": "vp90-2-03-size-200x198.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-200x198.webm",
+            "source_checksum": "260e71d7399c64983e8fb202fd3f6a60",
+            "input_file": "vp90-2-03-size-200x198.webm",
+            "output_format": "yuv420p",
+            "result": "0460dcd38e33cbdff10c404e1b5ec021"
+        },
+        {
+            "name": "vp90-2-03-size-200x200.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-200x200.webm",
+            "source_checksum": "9d7f5732a69737eb0a4e96c06826c3cd",
+            "input_file": "vp90-2-03-size-200x200.webm",
+            "output_format": "yuv420p",
+            "result": "09b5dcdc81aeab86758ecd1d8ea57bea"
+        },
+        {
+            "name": "vp90-2-03-size-200x202.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-200x202.webm",
+            "source_checksum": "b5e599d45261d91d6af1e93ebfcc11d5",
+            "input_file": "vp90-2-03-size-200x202.webm",
+            "output_format": "yuv420p",
+            "result": "de661c3eaebbda3656382134e792087f"
+        },
+        {
+            "name": "vp90-2-03-size-200x208.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-200x208.webm",
+            "source_checksum": "0b14037e5a3975a5a0c4cc64768d3988",
+            "input_file": "vp90-2-03-size-200x208.webm",
+            "output_format": "yuv420p",
+            "result": "167879ff7bf868b5242a10d634e50154"
+        },
+        {
+            "name": "vp90-2-03-size-200x210.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-200x210.webm",
+            "source_checksum": "1faf7e04718d237e1cb8d6f097f30086",
+            "input_file": "vp90-2-03-size-200x210.webm",
+            "output_format": "yuv420p",
+            "result": "3c3f98afffb363913dcffb33a570023f"
+        },
+        {
+            "name": "vp90-2-03-size-200x224.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-200x224.webm",
+            "source_checksum": "0e0cf999219a0ee93052133a21321832",
+            "input_file": "vp90-2-03-size-200x224.webm",
+            "output_format": "yuv420p",
+            "result": "f222aa2e6f265f51488172ee95aa03b6"
+        },
+        {
+            "name": "vp90-2-03-size-200x226.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-200x226.webm",
+            "source_checksum": "b323845425b9a1cdf2b2c170b7a5e17e",
+            "input_file": "vp90-2-03-size-200x226.webm",
+            "output_format": "yuv420p",
+            "result": "39298a38e0c71243710421e58946cc9a"
+        },
+        {
+            "name": "vp90-2-03-size-202x196.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-202x196.webm",
+            "source_checksum": "159883a30b9ee8e806ea76b75179fb5f",
+            "input_file": "vp90-2-03-size-202x196.webm",
+            "output_format": "yuv420p",
+            "result": "d8c57b91245bc2db96bd594b0e2ab3ef"
+        },
+        {
+            "name": "vp90-2-03-size-202x198.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-202x198.webm",
+            "source_checksum": "0b9dc115cdf4dd26de7fe287e14b800e",
+            "input_file": "vp90-2-03-size-202x198.webm",
+            "output_format": "yuv420p",
+            "result": "00bcb81e1524eece49f37afbff87071d"
+        },
+        {
+            "name": "vp90-2-03-size-202x200.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-202x200.webm",
+            "source_checksum": "1a901f743d122aec3848388cda4d5a8f",
+            "input_file": "vp90-2-03-size-202x200.webm",
+            "output_format": "yuv420p",
+            "result": "848c1bf35901493639fbed07d03f69c7"
+        },
+        {
+            "name": "vp90-2-03-size-202x202.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-202x202.webm",
+            "source_checksum": "f5eb93532a07cceda29cc5492a3b9e16",
+            "input_file": "vp90-2-03-size-202x202.webm",
+            "output_format": "yuv420p",
+            "result": "438ab414f9e2620e4ae318dd4b459d19"
+        },
+        {
+            "name": "vp90-2-03-size-202x208.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-202x208.webm",
+            "source_checksum": "ed9f3e5e82bd95c3f04e5dc2c0938554",
+            "input_file": "vp90-2-03-size-202x208.webm",
+            "output_format": "yuv420p",
+            "result": "30fba3979b2be4092a9c62d6c49189d0"
+        },
+        {
+            "name": "vp90-2-03-size-202x210.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-202x210.webm",
+            "source_checksum": "15c0fb3c0e46c745b998f07155e8f120",
+            "input_file": "vp90-2-03-size-202x210.webm",
+            "output_format": "yuv420p",
+            "result": "493781aaac018cedb7dd45fd101526ec"
+        },
+        {
+            "name": "vp90-2-03-size-202x224.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-202x224.webm",
+            "source_checksum": "be8cdfd4aefced2416942db13e95ecd5",
+            "input_file": "vp90-2-03-size-202x224.webm",
+            "output_format": "yuv420p",
+            "result": "feb741fa4015920013414c5b348e446d"
+        },
+        {
+            "name": "vp90-2-03-size-202x226.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-202x226.webm",
+            "source_checksum": "4286324b9ef595e5d967b6c83928cca5",
+            "input_file": "vp90-2-03-size-202x226.webm",
+            "output_format": "yuv420p",
+            "result": "767f7bb90a3b544f14665766b3882bef"
+        },
+        {
+            "name": "vp90-2-03-size-208x196.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-208x196.webm",
+            "source_checksum": "151f55c3597f64dc9aea6768f2f57b9d",
+            "input_file": "vp90-2-03-size-208x196.webm",
+            "output_format": "yuv420p",
+            "result": "cd433d55b30cedc1c5b89cfff067b474"
+        },
+        {
+            "name": "vp90-2-03-size-208x198.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-208x198.webm",
+            "source_checksum": "9763ba8dd6b75df5a450b4942f3b3b86",
+            "input_file": "vp90-2-03-size-208x198.webm",
+            "output_format": "yuv420p",
+            "result": "2805165b3d01043f56281acbd77a2fa0"
+        },
+        {
+            "name": "vp90-2-03-size-208x200.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-208x200.webm",
+            "source_checksum": "e2b645b691623dda744662d0e24f85f5",
+            "input_file": "vp90-2-03-size-208x200.webm",
+            "output_format": "yuv420p",
+            "result": "f332487f73fc4e97288be858939aea70"
+        },
+        {
+            "name": "vp90-2-03-size-208x202.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-208x202.webm",
+            "source_checksum": "6b055be62fb2624382c6f8964f53c1a0",
+            "input_file": "vp90-2-03-size-208x202.webm",
+            "output_format": "yuv420p",
+            "result": "06c7d396d1a2062b15d052eed18df4e2"
+        },
+        {
+            "name": "vp90-2-03-size-208x208.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-208x208.webm",
+            "source_checksum": "6e17aca21eb16b70b789104cc4595f1a",
+            "input_file": "vp90-2-03-size-208x208.webm",
+            "output_format": "yuv420p",
+            "result": "79cef9ed91d18d1edbfdfe23394cb542"
+        },
+        {
+            "name": "vp90-2-03-size-208x210.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-208x210.webm",
+            "source_checksum": "0e5bb133887bb9c97cf174be30584d85",
+            "input_file": "vp90-2-03-size-208x210.webm",
+            "output_format": "yuv420p",
+            "result": "da923ee5d5de79bc727f7ec66bf71f28"
+        },
+        {
+            "name": "vp90-2-03-size-208x224.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-208x224.webm",
+            "source_checksum": "a51f79dc6cc67883d27cf1ed72b235ba",
+            "input_file": "vp90-2-03-size-208x224.webm",
+            "output_format": "yuv420p",
+            "result": "78001972567f6d511defc54a2b7818b8"
+        },
+        {
+            "name": "vp90-2-03-size-208x226.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-208x226.webm",
+            "source_checksum": "5dbe98a51307fa2b046f09eb6b60b417",
+            "input_file": "vp90-2-03-size-208x226.webm",
+            "output_format": "yuv420p",
+            "result": "f156ce98802e6055fbca7f9dbebd793a"
+        },
+        {
+            "name": "vp90-2-03-size-210x196.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-210x196.webm",
+            "source_checksum": "2c6b0f492b00165360aa289dd2173682",
+            "input_file": "vp90-2-03-size-210x196.webm",
+            "output_format": "yuv420p",
+            "result": "30ba6826764ed05d94ac296825dd2deb"
+        },
+        {
+            "name": "vp90-2-03-size-210x198.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-210x198.webm",
+            "source_checksum": "4aa9875868ba5a9946e8e9a486b78419",
+            "input_file": "vp90-2-03-size-210x198.webm",
+            "output_format": "yuv420p",
+            "result": "dc1731f175c1885a507b1f463e41b9c3"
+        },
+        {
+            "name": "vp90-2-03-size-210x200.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-210x200.webm",
+            "source_checksum": "cb6b5020fe7d7c739c6de21f1c76840b",
+            "input_file": "vp90-2-03-size-210x200.webm",
+            "output_format": "yuv420p",
+            "result": "cbc5df97fac193648477bee47385adce"
+        },
+        {
+            "name": "vp90-2-03-size-210x202.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-210x202.webm",
+            "source_checksum": "e364a2de0cfce13fed6ece65752a310b",
+            "input_file": "vp90-2-03-size-210x202.webm",
+            "output_format": "yuv420p",
+            "result": "7b528de599cd2ccfdebe51df8d6fc644"
+        },
+        {
+            "name": "vp90-2-03-size-210x208.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-210x208.webm",
+            "source_checksum": "6b5992998ce06c6a2124b9d324631c36",
+            "input_file": "vp90-2-03-size-210x208.webm",
+            "output_format": "yuv420p",
+            "result": "4cd22a416c527524ebed13e2d4999ad5"
+        },
+        {
+            "name": "vp90-2-03-size-210x210.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-210x210.webm",
+            "source_checksum": "df355ddb0691e70070d0eb5484d4dca2",
+            "input_file": "vp90-2-03-size-210x210.webm",
+            "output_format": "yuv420p",
+            "result": "9a80c30350bd6ad6258a666ab0f1e2c8"
+        },
+        {
+            "name": "vp90-2-03-size-210x224.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-210x224.webm",
+            "source_checksum": "5e8767ee53cb3df3ee6529f60df69d82",
+            "input_file": "vp90-2-03-size-210x224.webm",
+            "output_format": "yuv420p",
+            "result": "aec1599537730046cc338cafc4f13c5c"
+        },
+        {
+            "name": "vp90-2-03-size-210x226.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-210x226.webm",
+            "source_checksum": "014c88b4572e323a59ccff528d643d7d",
+            "input_file": "vp90-2-03-size-210x226.webm",
+            "output_format": "yuv420p",
+            "result": "a44565883047487a04f1efce80975616"
+        },
+        {
+            "name": "vp90-2-03-size-224x196.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-224x196.webm",
+            "source_checksum": "3e53a9779725aa9121872c948de662fc",
+            "input_file": "vp90-2-03-size-224x196.webm",
+            "output_format": "yuv420p",
+            "result": "243e1f296e459668fce9c9db0fc47b9b"
+        },
+        {
+            "name": "vp90-2-03-size-224x198.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-224x198.webm",
+            "source_checksum": "dc1b5a6d93da2f67ecb5a4985b33b3ee",
+            "input_file": "vp90-2-03-size-224x198.webm",
+            "output_format": "yuv420p",
+            "result": "8b013a05214aad792fda2bb97d60301f"
+        },
+        {
+            "name": "vp90-2-03-size-224x200.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-224x200.webm",
+            "source_checksum": "3392bade410f600b6f6fadd553c880de",
+            "input_file": "vp90-2-03-size-224x200.webm",
+            "output_format": "yuv420p",
+            "result": "8ff880294d075a6fc4af56db39da92e8"
+        },
+        {
+            "name": "vp90-2-03-size-224x202.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-224x202.webm",
+            "source_checksum": "e7f7fa40dff6c9bef27e1056fbbc6fef",
+            "input_file": "vp90-2-03-size-224x202.webm",
+            "output_format": "yuv420p",
+            "result": "eab622f21328cccce6aa4ab38f4858b9"
+        },
+        {
+            "name": "vp90-2-03-size-224x208.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-224x208.webm",
+            "source_checksum": "e1d1dab0d5323c6e0ddbb708a83b275c",
+            "input_file": "vp90-2-03-size-224x208.webm",
+            "output_format": "yuv420p",
+            "result": "f18c5e3feedd57422e07f94133b5e5cc"
+        },
+        {
+            "name": "vp90-2-03-size-224x210.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-224x210.webm",
+            "source_checksum": "288c9d0ad4309a45699aca2d5d6e84f3",
+            "input_file": "vp90-2-03-size-224x210.webm",
+            "output_format": "yuv420p",
+            "result": "057d188547e7134e8461cc3716c6b551"
+        },
+        {
+            "name": "vp90-2-03-size-224x224.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-224x224.webm",
+            "source_checksum": "d54cab09df7a8a951cfc29a28086316d",
+            "input_file": "vp90-2-03-size-224x224.webm",
+            "output_format": "yuv420p",
+            "result": "894ab8824591ddee18ba1eacfe265a9a"
+        },
+        {
+            "name": "vp90-2-03-size-224x226.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-224x226.webm",
+            "source_checksum": "6bf98d62d8ab47c897fb8709950bcb94",
+            "input_file": "vp90-2-03-size-224x226.webm",
+            "output_format": "yuv420p",
+            "result": "064f21e06434073f20f74e09d1f5b191"
+        },
+        {
+            "name": "vp90-2-03-size-226x196.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-226x196.webm",
+            "source_checksum": "f438b8bab4a783a22a6af5d7c1ef3b86",
+            "input_file": "vp90-2-03-size-226x196.webm",
+            "output_format": "yuv420p",
+            "result": "3f1578b7421112161907b0c3cf68d36c"
+        },
+        {
+            "name": "vp90-2-03-size-226x198.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-226x198.webm",
+            "source_checksum": "e62174886a4d89737f487d1585ba7cd2",
+            "input_file": "vp90-2-03-size-226x198.webm",
+            "output_format": "yuv420p",
+            "result": "a7f0cbaec547c9f80db06c8244d82c67"
+        },
+        {
+            "name": "vp90-2-03-size-226x200.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-226x200.webm",
+            "source_checksum": "c55410f9b4d6ad301209e6efd212cb7c",
+            "input_file": "vp90-2-03-size-226x200.webm",
+            "output_format": "yuv420p",
+            "result": "80890c0ff46f6b3749b1a1f3a452d6a3"
+        },
+        {
+            "name": "vp90-2-03-size-226x202.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-226x202.webm",
+            "source_checksum": "5844f9eb91edcb581b6f261f951ff071",
+            "input_file": "vp90-2-03-size-226x202.webm",
+            "output_format": "yuv420p",
+            "result": "14dc25a1100dd34a36580e8a99c47913"
+        },
+        {
+            "name": "vp90-2-03-size-226x208.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-226x208.webm",
+            "source_checksum": "72b5c27f8a37131042c7696e496f64fd",
+            "input_file": "vp90-2-03-size-226x208.webm",
+            "output_format": "yuv420p",
+            "result": "c869cb1225e4b9614a2b091058e8be5e"
+        },
+        {
+            "name": "vp90-2-03-size-226x210.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-226x210.webm",
+            "source_checksum": "de6c4a06df1cb9a76f676616f57dac33",
+            "input_file": "vp90-2-03-size-226x210.webm",
+            "output_format": "yuv420p",
+            "result": "683efd9610c64fffc72a8d034df7c774"
+        },
+        {
+            "name": "vp90-2-03-size-226x224.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-226x224.webm",
+            "source_checksum": "fa6d04c22e947818bd510826da07df6a",
+            "input_file": "vp90-2-03-size-226x224.webm",
+            "output_format": "yuv420p",
+            "result": "0d68089e75a9a7c857bc7bf799a58b2d"
+        },
+        {
+            "name": "vp90-2-03-size-226x226.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-226x226.webm",
+            "source_checksum": "d042e6a58da175ac2bb63e5e3a713820",
+            "input_file": "vp90-2-03-size-226x226.webm",
+            "output_format": "yuv420p",
+            "result": "b35a1b707b28e82be025d960aba039bc"
+        },
+        {
+            "name": "vp90-2-03-size-352x288.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-03-size-352x288.webm",
+            "source_checksum": "e9eb916f1f51701d46623f6d2944675e",
+            "input_file": "vp90-2-03-size-352x288.webm",
+            "output_format": "yuv420p",
+            "result": "013064484be3dd09435439a8f7950849"
+        },
+        {
+            "name": "vp90-2-05-resize.ivf",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-05-resize.ivf",
+            "source_checksum": "1c39300b93fe110e1db30974e5d3479d",
+            "input_file": "vp90-2-05-resize.ivf",
+            "output_format": "yuv420p",
+            "result": "d1c46d62ef713cb7f6fd5024c510f2da"
+        },
+        {
+            "name": "vp90-2-06-bilinear.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-06-bilinear.webm",
+            "source_checksum": "c70ebb94618b981aa92db85d1f9c7295",
+            "input_file": "vp90-2-06-bilinear.webm",
+            "output_format": "yuv420p",
+            "result": "299923c8093e734f42b89594923c807f"
+        },
+        {
+            "name": "vp90-2-07-frame_parallel-1.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-07-frame_parallel-1.webm",
+            "source_checksum": "12fca93f31cc644f55170008481bd7cb",
+            "input_file": "vp90-2-07-frame_parallel-1.webm",
+            "output_format": "yuv420p",
+            "result": "8c9e048e5b60b379ab5a377c5ecfc97d"
+        },
+        {
+            "name": "vp90-2-07-frame_parallel.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-07-frame_parallel.webm",
+            "source_checksum": "c25e477965b7fa68783cef57fdf45e77",
+            "input_file": "vp90-2-07-frame_parallel.webm",
+            "output_format": "yuv420p",
+            "result": "6a48450207785d0be2922457f77a4bc4"
+        },
+        {
+            "name": "vp90-2-08-tile_1x2_frame_parallel.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-08-tile_1x2_frame_parallel.webm",
+            "source_checksum": "4ad1e554438d40c3002bdcea6def2dc7",
+            "input_file": "vp90-2-08-tile_1x2_frame_parallel.webm",
+            "output_format": "yuv420p",
+            "result": "68ede6abd66bae0a2edf2eb9232241b6"
+        },
+        {
+            "name": "vp90-2-08-tile_1x2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-08-tile_1x2.webm",
+            "source_checksum": "6ab0bccf00579152e979581bb8a5585f",
+            "input_file": "vp90-2-08-tile_1x2.webm",
+            "output_format": "yuv420p",
+            "result": "570b4a5d5a70d58b5359671668328a16"
+        },
+        {
+            "name": "vp90-2-08-tile_1x4_frame_parallel.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-08-tile_1x4_frame_parallel.webm",
+            "source_checksum": "ec52e1e5dd0272d691fc566349232cdb",
+            "input_file": "vp90-2-08-tile_1x4_frame_parallel.webm",
+            "output_format": "yuv420p",
+            "result": "368ebc6ebf3a5e478d85b2c3149b2848"
+        },
+        {
+            "name": "vp90-2-08-tile_1x4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-08-tile_1x4.webm",
+            "source_checksum": "79e38f0d64c50260b618a57f367bffe4",
+            "input_file": "vp90-2-08-tile_1x4.webm",
+            "output_format": "yuv420p",
+            "result": "988d86049e884c66909d2d163a09841a"
+        },
+        {
+            "name": "vp90-2-08-tile_1x8_frame_parallel.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-08-tile_1x8_frame_parallel.webm",
+            "source_checksum": "05b5b275582c7028bdf8e4d320c832b8",
+            "input_file": "vp90-2-08-tile_1x8_frame_parallel.webm",
+            "output_format": "yuv420p",
+            "result": "17e439da2388aff3a0f69cb22579c6c1"
+        },
+        {
+            "name": "vp90-2-08-tile_1x8.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-08-tile_1x8.webm",
+            "source_checksum": "852b69dc79b270a2f595334f4fd6218a",
+            "input_file": "vp90-2-08-tile_1x8.webm",
+            "output_format": "yuv420p",
+            "result": "0941902a52e9092cb010905eab16364c"
+        },
+        {
+            "name": "vp90-2-08-tile-4x1.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-08-tile-4x1.webm",
+            "source_checksum": "3f25d83e6981f26cbabd724ffb7f6d19",
+            "input_file": "vp90-2-08-tile-4x1.webm",
+            "output_format": "yuv420p",
+            "result": "06505aade6647c583c8e00a2f582266f"
+        },
+        {
+            "name": "vp90-2-08-tile-4x4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-08-tile-4x4.webm",
+            "source_checksum": "fb320a29342cc70128d63050d1c00957",
+            "input_file": "vp90-2-08-tile-4x4.webm",
+            "output_format": "yuv420p",
+            "result": "85c2299892460d76e2c600502d52bfe2"
+        },
+        {
+            "name": "vp90-2-09-aq2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-09-aq2.webm",
+            "source_checksum": "edf17a37a4ce0dde7159a437f7b2e380",
+            "input_file": "vp90-2-09-aq2.webm",
+            "output_format": "yuv420p",
+            "result": "daf228b24642c39c0519ec5fe66b06d4"
+        },
+        {
+            "name": "vp90-2-09-lf_deltas.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-09-lf_deltas.webm",
+            "source_checksum": "dd6c928cd311787a3c8061464536c4af",
+            "input_file": "vp90-2-09-lf_deltas.webm",
+            "output_format": "yuv420p",
+            "result": "dacb7e056abb35d5fe5e7dfef1f207c1"
+        },
+        {
+            "name": "vp90-2-09-subpixel-00.ivf",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-09-subpixel-00.ivf",
+            "source_checksum": "b04b0bc0b4212b15b6f5c853710b1342",
+            "input_file": "vp90-2-09-subpixel-00.ivf",
+            "output_format": "yuv420p",
+            "result": "1ee498c11e48be15772cc3047ff5558c"
+        },
+        {
+            "name": "vp90-2-10-show-existing-frame2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-10-show-existing-frame2.webm",
+            "source_checksum": "85d3926792fd8aa5fff8c15c9dd0592c",
+            "input_file": "vp90-2-10-show-existing-frame2.webm",
+            "output_format": "yuv420p",
+            "result": "e843c34cccb947ca10f9a9f305700178"
+        },
+        {
+            "name": "vp90-2-10-show-existing-frame.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-10-show-existing-frame.webm",
+            "source_checksum": "7a190afb359b5645925b786fed5af487",
+            "input_file": "vp90-2-10-show-existing-frame.webm",
+            "output_format": "yuv420p",
+            "result": "a4be22bc691c58bc48bd83d7ba37730c"
+        },
+        {
+            "name": "vp90-2-11-size-351x287.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-11-size-351x287.webm",
+            "source_checksum": "28766c97cec7d2cbf053ba2104ae5760",
+            "input_file": "vp90-2-11-size-351x287.webm",
+            "output_format": "yuv420p",
+            "result": "042a6a229a1020cafbe330622a7e4875"
+        },
+        {
+            "name": "vp90-2-11-size-351x288.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-11-size-351x288.webm",
+            "source_checksum": "cb8f8b43595d92457d647defd09da71e",
+            "input_file": "vp90-2-11-size-351x288.webm",
+            "output_format": "yuv420p",
+            "result": "ea267efd59fa75cd453e5a2a2afbdb22"
+        },
+        {
+            "name": "vp90-2-11-size-352x287.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-11-size-352x287.webm",
+            "source_checksum": "6c9670e6fbebb3d5412377960d634eda",
+            "input_file": "vp90-2-11-size-352x287.webm",
+            "output_format": "yuv420p",
+            "result": "38e34f0ce2bb8e45471759eb1617d710"
+        },
+        {
+            "name": "vp90-2-12-droppable_1.ivf",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-12-droppable_1.ivf",
+            "source_checksum": "0e671fac0f9704eccca7917dcde710e2",
+            "input_file": "vp90-2-12-droppable_1.ivf",
+            "output_format": "yuv420p",
+            "result": "5fb71b03206131e267f4efcf3a8f12db"
+        },
+        {
+            "name": "vp90-2-12-droppable_2.ivf",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-12-droppable_2.ivf",
+            "source_checksum": "0e671fac0f9704eccca7917dcde710e2",
+            "input_file": "vp90-2-12-droppable_2.ivf",
+            "output_format": "yuv420p",
+            "result": "5fb71b03206131e267f4efcf3a8f12db"
+        },
+        {
+            "name": "vp90-2-12-droppable_3.ivf",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-12-droppable_3.ivf",
+            "source_checksum": "9022440bd8eaa37892b235bcf836a2cf",
+            "input_file": "vp90-2-12-droppable_3.ivf",
+            "output_format": "yuv420p",
+            "result": "1ed79ee6cb442e93090cd8941c27c1e3"
+        },
+        {
+            "name": "vp90-2-14-resize-10frames-fp-tiles-1-2-4-8.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-10frames-fp-tiles-1-2-4-8.webm",
+            "source_checksum": "ec91c5524bdbed54f266c6edd4e005fe",
+            "input_file": "vp90-2-14-resize-10frames-fp-tiles-1-2-4-8.webm",
+            "output_format": "yuv420p",
+            "result": "0de8cb39172ee3693da869b4dd19c6bc"
+        },
+        {
+            "name": "vp90-2-14-resize-10frames-fp-tiles-1-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-10frames-fp-tiles-1-2.webm",
+            "source_checksum": "576ac73c28fb965632cf71ea7d163fcc",
+            "input_file": "vp90-2-14-resize-10frames-fp-tiles-1-2.webm",
+            "output_format": "yuv420p",
+            "result": "6c1d273248b5a41f05269fb38f428333"
+        },
+        {
+            "name": "vp90-2-14-resize-10frames-fp-tiles-1-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-10frames-fp-tiles-1-4.webm",
+            "source_checksum": "dc8c55e032448c9bd515159831fedff7",
+            "input_file": "vp90-2-14-resize-10frames-fp-tiles-1-4.webm",
+            "output_format": "yuv420p",
+            "result": "eaf03337a67dc919dde0262fb570cf2e"
+        },
+        {
+            "name": "vp90-2-14-resize-10frames-fp-tiles-1-8.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-10frames-fp-tiles-1-8.webm",
+            "source_checksum": "fd3b9436f3c3af049514f3fd60bcd416",
+            "input_file": "vp90-2-14-resize-10frames-fp-tiles-1-8.webm",
+            "output_format": "yuv420p",
+            "result": "d7f860ac5decf80fb806087a4992a86b"
+        },
+        {
+            "name": "vp90-2-14-resize-10frames-fp-tiles-2-1.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-10frames-fp-tiles-2-1.webm",
+            "source_checksum": "7b284e2e61131ab7cb2dd4210af8241b",
+            "input_file": "vp90-2-14-resize-10frames-fp-tiles-2-1.webm",
+            "output_format": "yuv420p",
+            "result": "ea04fcd003da1df4823d4384928fe50b"
+        },
+        {
+            "name": "vp90-2-14-resize-10frames-fp-tiles-2-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-10frames-fp-tiles-2-4.webm",
+            "source_checksum": "fcf627ae38e1c0b8a2785499dd46ac2b",
+            "input_file": "vp90-2-14-resize-10frames-fp-tiles-2-4.webm",
+            "output_format": "yuv420p",
+            "result": "b3aa88c4014ba4a6b72a45600d869795"
+        },
+        {
+            "name": "vp90-2-14-resize-10frames-fp-tiles-2-8.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-10frames-fp-tiles-2-8.webm",
+            "source_checksum": "f65f33429eba1382622a46ce5aea4a0c",
+            "input_file": "vp90-2-14-resize-10frames-fp-tiles-2-8.webm",
+            "output_format": "yuv420p",
+            "result": "a2dfe8c1f7b76e79fb65b4333c6030cd"
+        },
+        {
+            "name": "vp90-2-14-resize-10frames-fp-tiles-4-1.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-10frames-fp-tiles-4-1.webm",
+            "source_checksum": "0a23402ccc86de2e63c3ddf48edffed2",
+            "input_file": "vp90-2-14-resize-10frames-fp-tiles-4-1.webm",
+            "output_format": "yuv420p",
+            "result": "1836054b769fcff490018d45f296e9b5"
+        },
+        {
+            "name": "vp90-2-14-resize-10frames-fp-tiles-4-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-10frames-fp-tiles-4-2.webm",
+            "source_checksum": "ef3393f5907f5627bcf539ce7e0c73b4",
+            "input_file": "vp90-2-14-resize-10frames-fp-tiles-4-2.webm",
+            "output_format": "yuv420p",
+            "result": "158d2265a17612b02c81cd0eeda47bde"
+        },
+        {
+            "name": "vp90-2-14-resize-10frames-fp-tiles-4-8.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-10frames-fp-tiles-4-8.webm",
+            "source_checksum": "7cb2bf140ed03100bebbbede2e30848f",
+            "input_file": "vp90-2-14-resize-10frames-fp-tiles-4-8.webm",
+            "output_format": "yuv420p",
+            "result": "f4131e1e3f3492dabde06147169b2da2"
+        },
+        {
+            "name": "vp90-2-14-resize-10frames-fp-tiles-8-1.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-10frames-fp-tiles-8-1.webm",
+            "source_checksum": "3e813a8e956b668d0d2dcb026e3e1213",
+            "input_file": "vp90-2-14-resize-10frames-fp-tiles-8-1.webm",
+            "output_format": "yuv420p",
+            "result": "c89058349351fc27d01d46c00d89d1ef"
+        },
+        {
+            "name": "vp90-2-14-resize-10frames-fp-tiles-8-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-10frames-fp-tiles-8-2.webm",
+            "source_checksum": "e20fe0943adbf80a1fc77a473966ef38",
+            "input_file": "vp90-2-14-resize-10frames-fp-tiles-8-2.webm",
+            "output_format": "yuv420p",
+            "result": "6f6a2d3d1dc0f42bf025cc9c916c1679"
+        },
+        {
+            "name": "vp90-2-14-resize-10frames-fp-tiles-8-4-2-1.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-10frames-fp-tiles-8-4-2-1.webm",
+            "source_checksum": "36ac98334b2c7d30d2dc03d82b6e28fe",
+            "input_file": "vp90-2-14-resize-10frames-fp-tiles-8-4-2-1.webm",
+            "output_format": "yuv420p",
+            "result": "b443c299fa4b9d4321960038033b2e7b"
+        },
+        {
+            "name": "vp90-2-14-resize-10frames-fp-tiles-8-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-10frames-fp-tiles-8-4.webm",
+            "source_checksum": "26a45bccf0961c613fa275538f1d58b8",
+            "input_file": "vp90-2-14-resize-10frames-fp-tiles-8-4.webm",
+            "output_format": "yuv420p",
+            "result": "f4b171127f2d63f292d387365ba35df8"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-1-16.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-1-16.webm",
+            "source_checksum": "66af9de4754cf502fbfa9dbd975a13f1",
+            "input_file": "vp90-2-14-resize-fp-tiles-1-16.webm",
+            "output_format": "yuv420p",
+            "result": "0cd5e632c326297e975f38949c31ea94"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-1-2-4-8-16.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-1-2-4-8-16.webm",
+            "source_checksum": "738954723d22ed85415f0c685afb8ef3",
+            "input_file": "vp90-2-14-resize-fp-tiles-1-2-4-8-16.webm",
+            "output_format": "yuv420p",
+            "result": "5c78a96a42e7f4a4f6b2edcdb791e44c"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-1-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-1-2.webm",
+            "source_checksum": "fee4151e627939a8169ef557b7564182",
+            "input_file": "vp90-2-14-resize-fp-tiles-1-2.webm",
+            "output_format": "yuv420p",
+            "result": "e030450ae85c3277be2a418769df98e2"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-1-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-1-4.webm",
+            "source_checksum": "f8abfcfc6cfb5ba33654685f8c5f9c3d",
+            "input_file": "vp90-2-14-resize-fp-tiles-1-4.webm",
+            "output_format": "yuv420p",
+            "result": "312eed4e2b64eb7a4e7f18916606a430"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-16-1.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-16-1.webm",
+            "source_checksum": "87687db30cfa2e923ae4a696ad8f9de3",
+            "input_file": "vp90-2-14-resize-fp-tiles-16-1.webm",
+            "output_format": "yuv420p",
+            "result": "1755c16d8af16a9cb3fe7338d90abe52"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-16-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-16-2.webm",
+            "source_checksum": "bcc44024ab26dc907c488341f12b3171",
+            "input_file": "vp90-2-14-resize-fp-tiles-16-2.webm",
+            "output_format": "yuv420p",
+            "result": "500300592d3fcb6f12fab25e48aaf4df"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-16-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-16-4.webm",
+            "source_checksum": "40a4ac598626a3839d5f6f4ce68303d3",
+            "input_file": "vp90-2-14-resize-fp-tiles-16-4.webm",
+            "output_format": "yuv420p",
+            "result": "47c48379fa6331215d91c67648e1af6e"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-16-8-4-2-1.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-16-8-4-2-1.webm",
+            "source_checksum": "b3b743df404ba8dc71aeb9f5eb02bca4",
+            "input_file": "vp90-2-14-resize-fp-tiles-16-8-4-2-1.webm",
+            "output_format": "yuv420p",
+            "result": "eecf17290739bc708506fa4827665989"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-16-8.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-16-8.webm",
+            "source_checksum": "ff4cb1efd1b61405f0784253986c0f1d",
+            "input_file": "vp90-2-14-resize-fp-tiles-16-8.webm",
+            "output_format": "yuv420p",
+            "result": "29b6bb54e4c26b5ca85d5de5fed94e76"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-1-8.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-1-8.webm",
+            "source_checksum": "02a2eec4263c64f8cffc92ae877224e0",
+            "input_file": "vp90-2-14-resize-fp-tiles-1-8.webm",
+            "output_format": "yuv420p",
+            "result": "1b6f175e08cd82cf84bb800ac6d1caa3"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-2-16.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-2-16.webm",
+            "source_checksum": "6b5db300ae5785596b6932cabfbc31ac",
+            "input_file": "vp90-2-14-resize-fp-tiles-2-16.webm",
+            "output_format": "yuv420p",
+            "result": "ca3b03e4197995d8d5444ede7a6c0804"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-2-1.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-2-1.webm",
+            "source_checksum": "f746610eb0192aafd15f9c59ab57e381",
+            "input_file": "vp90-2-14-resize-fp-tiles-2-1.webm",
+            "output_format": "yuv420p",
+            "result": "99aec065369d70bbb78ccdff65afed3f"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-2-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-2-4.webm",
+            "source_checksum": "f73ff6904e40583c424ef72b8a259995",
+            "input_file": "vp90-2-14-resize-fp-tiles-2-4.webm",
+            "output_format": "yuv420p",
+            "result": "22d0ebdb49b87d2920a85aea32e1afd5"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-2-8.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-2-8.webm",
+            "source_checksum": "d92422e68a697dea48db05ab787311fb",
+            "input_file": "vp90-2-14-resize-fp-tiles-2-8.webm",
+            "output_format": "yuv420p",
+            "result": "c2115cf051c62e0f7db1d4a783831541"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-4-16.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-4-16.webm",
+            "source_checksum": "dfab3eb451daf6f8f52f424345fcc807",
+            "input_file": "vp90-2-14-resize-fp-tiles-4-16.webm",
+            "output_format": "yuv420p",
+            "result": "c690d7e1719b31367564cac0af0939cb"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-4-1.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-4-1.webm",
+            "source_checksum": "fea9ab855a9e5b31a1dcc06cfd38097a",
+            "input_file": "vp90-2-14-resize-fp-tiles-4-1.webm",
+            "output_format": "yuv420p",
+            "result": "a926020b2cc3e15ad4cc271853a0ff26"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-4-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-4-2.webm",
+            "source_checksum": "ef53aa97fe309058151dad6663171f64",
+            "input_file": "vp90-2-14-resize-fp-tiles-4-2.webm",
+            "output_format": "yuv420p",
+            "result": "42699063d9e581f1993d0cf890c2be78"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-4-8.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-4-8.webm",
+            "source_checksum": "e3d5ac5ab009c1bf07ede23c5f50e659",
+            "input_file": "vp90-2-14-resize-fp-tiles-4-8.webm",
+            "output_format": "yuv420p",
+            "result": "7f76d96036382f45121e3d5aa6f8ec52"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-8-16.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-8-16.webm",
+            "source_checksum": "fdbf9325fdbcc0e7f549c72ade6f08c1",
+            "input_file": "vp90-2-14-resize-fp-tiles-8-16.webm",
+            "output_format": "yuv420p",
+            "result": "76a43fcdd7e658542913ea43216ec55d"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-8-1.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-8-1.webm",
+            "source_checksum": "190a23a49dbe245b5750b08d29a3c320",
+            "input_file": "vp90-2-14-resize-fp-tiles-8-1.webm",
+            "output_format": "yuv420p",
+            "result": "8e3fbe89486ca60a59299dea9da91378"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-8-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-8-2.webm",
+            "source_checksum": "662c655668d24afe5072e87beac03bec",
+            "input_file": "vp90-2-14-resize-fp-tiles-8-2.webm",
+            "output_format": "yuv420p",
+            "result": "ae96f21f21b6370cc0125621b441fc52"
+        },
+        {
+            "name": "vp90-2-14-resize-fp-tiles-8-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-14-resize-fp-tiles-8-4.webm",
+            "source_checksum": "8c56b9f980d0652e4a563a446835fb59",
+            "input_file": "vp90-2-14-resize-fp-tiles-8-4.webm",
+            "output_format": "yuv420p",
+            "result": "3eb4f24f10640d42218f7fd7b9fd30d4"
+        },
+        {
+            "name": "vp90-2-15-segkey_adpq.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-15-segkey_adpq.webm",
+            "source_checksum": "3ee2215a0bd910b6215938573a73d8e0",
+            "input_file": "vp90-2-15-segkey_adpq.webm",
+            "output_format": "yuv420p",
+            "result": "56723549fb468a0031e1c9ee4ab63e9d"
+        },
+        {
+            "name": "vp90-2-15-segkey.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-15-segkey.webm",
+            "source_checksum": "4c64ea0cf650b62166ce9c1a91f8a9d1",
+            "input_file": "vp90-2-15-segkey.webm",
+            "output_format": "yuv420p",
+            "result": "d3805a0d832b9bdd69ad99d68490be7b"
+        },
+        {
+            "name": "vp90-2-16-intra-only.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-16-intra-only.webm",
+            "source_checksum": "70d4afd231a41dd0f0364fec8121fa09",
+            "input_file": "vp90-2-16-intra-only.webm",
+            "output_format": "yuv420p",
+            "result": "61554865e7ad3e3ef3e8bc35c6a1c6eb"
+        },
+        {
+            "name": "vp90-2-17-show-existing-frame.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-17-show-existing-frame.webm",
+            "source_checksum": "68aa5f0f3a6cfe916b48caf2f48e7167",
+            "input_file": "vp90-2-17-show-existing-frame.webm",
+            "output_format": "yuv420p",
+            "result": "5f613ed2ff8fdb1351b23b0076ab2063"
+        },
+        {
+            "name": "vp90-2-18-resize.ivf",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-18-resize.ivf",
+            "source_checksum": "84048208fa4ac98ca459733c43f08d9d",
+            "input_file": "vp90-2-18-resize.ivf",
+            "output_format": "yuv420p",
+            "result": "f132f13e9c4cc6d3e1965292341bb590"
+        },
+        {
+            "name": "vp90-2-19-skip-01.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-19-skip-01.webm",
+            "source_checksum": "bea4461714b68a39200016fbac29a9d9",
+            "input_file": "vp90-2-19-skip-01.webm",
+            "output_format": "yuv420p",
+            "result": "02df67098851988b9a0023c8237a0857"
+        },
+        {
+            "name": "vp90-2-19-skip-02.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-19-skip-02.webm",
+            "source_checksum": "2e167a08cfe9d9b383cdd3bc4bd38b57",
+            "input_file": "vp90-2-19-skip-02.webm",
+            "output_format": "yuv420p",
+            "result": "50ed22bf9e109b891c5d8505a4126baa"
+        },
+        {
+            "name": "vp90-2-19-skip.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-19-skip.webm",
+            "source_checksum": "d82269246a139c11cb2e6a9eeaba62b7",
+            "input_file": "vp90-2-19-skip.webm",
+            "output_format": "yuv420p",
+            "result": "c2d6e7e425d883f2c2cce7c80711c566"
+        },
+        {
+            "name": "vp90-2-20-big_superframe-01.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-20-big_superframe-01.webm",
+            "source_checksum": "59f8035de0783b6abfa7f05c72c1abf2",
+            "input_file": "vp90-2-20-big_superframe-01.webm",
+            "output_format": "yuv420p",
+            "result": "046c079a2b05c0ce951817c1b5fde3ef"
+        },
+        {
+            "name": "vp90-2-20-big_superframe-02.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-20-big_superframe-02.webm",
+            "source_checksum": "ee722f1df67cce5fd6434f915fe3a625",
+            "input_file": "vp90-2-20-big_superframe-02.webm",
+            "output_format": "yuv420p",
+            "result": "49c72adf5f991344051275e232fa79ca"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_1280x720_5_1-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_1280x720_5_1-2.webm",
+            "source_checksum": "3c50cd59ae4a27a3b75dc2e932c851f6",
+            "input_file": "vp90-2-21-resize_inter_1280x720_5_1-2.webm",
+            "output_format": "yuv420p",
+            "result": "dac2d22fc158e751de72918b8755ac1d"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_1280x720_5_3-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_1280x720_5_3-4.webm",
+            "source_checksum": "a96ee2689ebd7c00aa65b84a3d376e46",
+            "input_file": "vp90-2-21-resize_inter_1280x720_5_3-4.webm",
+            "output_format": "yuv420p",
+            "result": "8b72cac7011753c55632b1b323dd5f0c"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_1280x720_7_1-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_1280x720_7_1-2.webm",
+            "source_checksum": "92facba467ed0c818790e668446b2cff",
+            "input_file": "vp90-2-21-resize_inter_1280x720_7_1-2.webm",
+            "output_format": "yuv420p",
+            "result": "dbe6f8ece272167da484fa400ee0ee4d"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_1280x720_7_3-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_1280x720_7_3-4.webm",
+            "source_checksum": "2486c36e1228f0433e8f9aaad19c1867",
+            "input_file": "vp90-2-21-resize_inter_1280x720_7_3-4.webm",
+            "output_format": "yuv420p",
+            "result": "0fede2b7ecd17320f1bc0ea023d5e685"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_1920x1080_5_1-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_1920x1080_5_1-2.webm",
+            "source_checksum": "24756f71899e84982c5be9b1d99d55c1",
+            "input_file": "vp90-2-21-resize_inter_1920x1080_5_1-2.webm",
+            "output_format": "yuv420p",
+            "result": "56f7814ee1734e1917f1267ebedff702"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_1920x1080_5_3-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_1920x1080_5_3-4.webm",
+            "source_checksum": "0771c3e10f60dcf33c023e7e41a7e683",
+            "input_file": "vp90-2-21-resize_inter_1920x1080_5_3-4.webm",
+            "output_format": "yuv420p",
+            "result": "681053375073b5a1a87c5cb68cb51a2b"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_1920x1080_7_1-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_1920x1080_7_1-2.webm",
+            "source_checksum": "5d9336d1885fff3c635aed569540d4af",
+            "input_file": "vp90-2-21-resize_inter_1920x1080_7_1-2.webm",
+            "output_format": "yuv420p",
+            "result": "f771b2d11ab08fe6905f2babe3773045"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_1920x1080_7_3-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_1920x1080_7_3-4.webm",
+            "source_checksum": "acc8e738093e48cbd54645b0b9836bd2",
+            "input_file": "vp90-2-21-resize_inter_1920x1080_7_3-4.webm",
+            "output_format": "yuv420p",
+            "result": "1479508cc8e91ae6bff7f37865ff04fd"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_320x180_5_1-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_320x180_5_1-2.webm",
+            "source_checksum": "286acadf49feda043203aa5cee6ab784",
+            "input_file": "vp90-2-21-resize_inter_320x180_5_1-2.webm",
+            "output_format": "yuv420p",
+            "result": "06d406449692ab53dfae5b6d2245d193"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_320x180_5_3-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_320x180_5_3-4.webm",
+            "source_checksum": "0f6395f1de042908b4682e15235920bf",
+            "input_file": "vp90-2-21-resize_inter_320x180_5_3-4.webm",
+            "output_format": "yuv420p",
+            "result": "ae5905ef96d39ce78df7f4ee725b54c2"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_320x180_7_1-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_320x180_7_1-2.webm",
+            "source_checksum": "21681f8d85fda6be01464472a932907a",
+            "input_file": "vp90-2-21-resize_inter_320x180_7_1-2.webm",
+            "output_format": "yuv420p",
+            "result": "a8a4f82b5fe33ee11850ee7b68b0bc82"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_320x180_7_3-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_320x180_7_3-4.webm",
+            "source_checksum": "5673a1177f4ebe07ca6397412b70b216",
+            "input_file": "vp90-2-21-resize_inter_320x180_7_3-4.webm",
+            "output_format": "yuv420p",
+            "result": "bfdc9bcc548e4196a2020703fdd31743"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_320x240_5_1-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_320x240_5_1-2.webm",
+            "source_checksum": "e6077f263b5d68fbc06cfd37f6f6e6c9",
+            "input_file": "vp90-2-21-resize_inter_320x240_5_1-2.webm",
+            "output_format": "yuv420p",
+            "result": "90c58a41ca53b00e9c4543283761a655"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_320x240_5_3-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_320x240_5_3-4.webm",
+            "source_checksum": "3d1eff2667957dd150a768273402e39a",
+            "input_file": "vp90-2-21-resize_inter_320x240_5_3-4.webm",
+            "output_format": "yuv420p",
+            "result": "be3129f24b887f224682a11a7e6692e7"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_320x240_7_1-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_320x240_7_1-2.webm",
+            "source_checksum": "c56baced3899c585a98f5cb210951473",
+            "input_file": "vp90-2-21-resize_inter_320x240_7_1-2.webm",
+            "output_format": "yuv420p",
+            "result": "1a8e782d98c2a6640153421384a70b4e"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_320x240_7_3-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_320x240_7_3-4.webm",
+            "source_checksum": "91dfe6f1ef9f799c49579df5dbc906a1",
+            "input_file": "vp90-2-21-resize_inter_320x240_7_3-4.webm",
+            "output_format": "yuv420p",
+            "result": "e8a8eadb43c5e5f4c790f61c6f573b4c"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_640x360_5_1-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_640x360_5_1-2.webm",
+            "source_checksum": "956e2d2cc057d63d5801a9a36da3a844",
+            "input_file": "vp90-2-21-resize_inter_640x360_5_1-2.webm",
+            "output_format": "yuv420p",
+            "result": "2b6659868bd6ee40a5731e4d2aa04031"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_640x360_5_3-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_640x360_5_3-4.webm",
+            "source_checksum": "2bbba21644aa50d97ec5dfb4090f9bb3",
+            "input_file": "vp90-2-21-resize_inter_640x360_5_3-4.webm",
+            "output_format": "yuv420p",
+            "result": "614cb4ac200504fe5f6d62f96d66b06a"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_640x360_7_1-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_640x360_7_1-2.webm",
+            "source_checksum": "714018dda6123433c62d641719536a77",
+            "input_file": "vp90-2-21-resize_inter_640x360_7_1-2.webm",
+            "output_format": "yuv420p",
+            "result": "d08ebb63bba3c604cf4edc41f7cd5345"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_640x360_7_3-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_640x360_7_3-4.webm",
+            "source_checksum": "7b647cea07d329642a1c4710ffc6a1fa",
+            "input_file": "vp90-2-21-resize_inter_640x360_7_3-4.webm",
+            "output_format": "yuv420p",
+            "result": "717adaaaecb781f635337de891c03312"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_640x480_5_1-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_640x480_5_1-2.webm",
+            "source_checksum": "ef43f10a6b0d853ba144d21d47c278b0",
+            "input_file": "vp90-2-21-resize_inter_640x480_5_1-2.webm",
+            "output_format": "yuv420p",
+            "result": "1e8b7efa80a0986bc357f20b1ce5da3c"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_640x480_5_3-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_640x480_5_3-4.webm",
+            "source_checksum": "7f9de3678fcd7bdbb49efe254e368be5",
+            "input_file": "vp90-2-21-resize_inter_640x480_5_3-4.webm",
+            "output_format": "yuv420p",
+            "result": "c3d55529b37a3839e8b3c738ff566d7b"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_640x480_7_1-2.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_640x480_7_1-2.webm",
+            "source_checksum": "b845a7ed31dc0fd443bce1b50c5524b2",
+            "input_file": "vp90-2-21-resize_inter_640x480_7_1-2.webm",
+            "output_format": "yuv420p",
+            "result": "91dd0807518ac3a0c35ef4e27bb828c0"
+        },
+        {
+            "name": "vp90-2-21-resize_inter_640x480_7_3-4.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-21-resize_inter_640x480_7_3-4.webm",
+            "source_checksum": "6727bd490140cf1b7d9e50025f9de23a",
+            "input_file": "vp90-2-21-resize_inter_640x480_7_3-4.webm",
+            "output_format": "yuv420p",
+            "result": "1474a79fffdbc3faef27a28d41538a7a"
+        },
+        {
+            "name": "vp90-2-22-svc_1280x720_1.webm",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-22-svc_1280x720_1.webm",
+            "source_checksum": "1c22ff57d05a6c610aa73694887e1ef3",
+            "input_file": "vp90-2-22-svc_1280x720_1.webm",
+            "output_format": "yuv420p",
+            "result": "b6d457471ee2f7407674d874bc4d2a9d"
+        },
+        {
+            "name": "vp90-2-22-svc_1280x720_3.ivf",
+            "source": "https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/vp90-2-22-svc_1280x720_3.ivf",
+            "source_checksum": "d681cfa4245e7b1db596a97dd7963991",
+            "input_file": "vp90-2-22-svc_1280x720_3.ivf",
+            "output_format": "yuv420p",
+            "result": "fbdd9f9bb30c27434d50c1258fe80491"
+        }
+    ]
+}


### PR DESCRIPTION
Hi All,

I would like to add a VP9 test suite. For that being possible VP9 fluster decoders should start existing in the first place. I have created a branch which contains a proposal of how this can be done (both the decoders and the test suite). If you consider my changes fit for merging, kindly do so, If you see other approaches to landing VP9 support that's absolutely fine, too.

I have factored out a base class from vp8 reference decoder and then subclassed it for VP9, adding VP9 test vectors, which come from https://storage.googleapis.com/downloads.webmproject.org/test_data/libvpx/. Please see the corresponding commit message to know how I generated the json. In the last patch I added a VP9 ffmpeg software decoder next to its VP8 counterpart.