### PR TITLE
Download all the test suites when no argument

### DIFF
--- a/fluster/main.py
+++ b/fluster/main.py
@@ -157,7 +157,7 @@ class Main:
         subparser.add_argument(
             '-k', '--keep', help="keep downloaded file after extracting", action='store_true')
         subparser.add_argument(
-            'testsuites', help='list of testsuites to download', nargs='+')
+            'testsuites', help='list of testsuites to download', nargs='*')
         subparser.set_defaults(func=self._download_cmd)
 
     def _list_cmd(self, args, fluster):


### PR DESCRIPTION
Before the change:
```
./fluster.py download
usage: fluster.py download [-h] [-j JOBS] [-k] testsuites [testsuites ...]
fluster.py download: error: the following arguments are required: testsuites
```

After change all test suites are downloaded.

Bug added in: https://github.com/fluendo/fluster/commit/28abe738f0ee20798d98027a52e590ea87322a1f#diff-32f2af3ad7194c5108dd8d6d7d308e9a3c4d8fa7f2483280a30f545d74e8eefdR152

Fix: Issue #63