### PR TITLE
Consolidate test cases and decoders check for matches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,10 @@ check: ## check that very basic tests run
 	$(FLUSTER) run -ts dummy -th 1
 	$(FLUSTER) run -ts dummy -tth 10
 ifneq ($(OS),Windows_NT)
+	$(FLUSTER) run -ts dummy non_existing_test_suite; test $$? -ne 0
 	$(FLUSTER) run -ts dummy -th 2; test $$? -eq 2
 	$(FLUSTER) run -ts dummy -tth 0.000000001; test $$? -eq 3
+	$(FLUSTER) download dummy non_existing_test_suite; test $$? -ne 0
 	$(FLUSTER) download dummy_fail; test $$? -ne 0
 	$(FLUSTER) run -ts dummy_fail -th 1
 	$(FLUSTER) run -ts dummy_fail -th 2; test $$? -eq 2

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ check: ## check that very basic tests run
 	$(FLUSTER) list -c
 	$(FLUSTER) -ne list -c
 	$(FLUSTER) list -ts dummy -tv
-	$(FLUSTER) download dummy
+	$(FLUSTER) download dummy dummy_fail
 	$(FLUSTER) run -ts dummy -tv one
 	$(FLUSTER) reference Dummy dummy
 	$(FLUSTER) run -ts dummy -tv one -j1
@@ -34,12 +34,13 @@ ifneq ($(OS),Windows_NT)
 	$(FLUSTER) run -ts dummy non_existing_test_suite; test $$? -ne 0
 	$(FLUSTER) run -ts dummy -th 2; test $$? -eq 2
 	$(FLUSTER) run -ts dummy -tth 0.000000001; test $$? -eq 3
-	$(FLUSTER) download dummy non_existing_test_suite; test $$? -ne 0
-	$(FLUSTER) download dummy_fail; test $$? -ne 0
 	$(FLUSTER) run -ts dummy_fail -th 1
 	$(FLUSTER) run -ts dummy_fail -th 2; test $$? -eq 2
 	$(FLUSTER) run -ts dummy_fail -j1 -ff -s; test $$? -ne 0
+	$(FLUSTER) download dummy non_existing_test_suite; test $$? -ne 0
+	$(FLUSTER) download dummy dummy_download_fail; test $$? -ne 0
 endif
+	@echo "\nAll test finished succesfully!"
 
 format: ## format Python code using autopep8
 	autopep8 -i -j0 -r $(PY_FILES)

--- a/check/dummy_download_fail.json
+++ b/check/dummy_download_fail.json
@@ -1,0 +1,15 @@
+{
+    "name": "dummy_download_fail",
+    "codec": "Dummy",
+    "description": "Dummy download fail test suite",
+    "test_vectors": [
+        {
+            "name": "fail",
+            "source": "https://www.itu.int//wftp3/av-arch/jctvc-site/bitstream_exchange/draft_conformance/HEVC_v1/ipcm_B_NEC_3.zip",
+            "source_checksum": "bad checksum on purpose",
+            "input_file": "ipcm_B_NEC_3/ipcm_B_NEC_3.bit",
+            "output_format": "yuv420p",
+            "result": "23a3b7024fd9bc64b946b9961ab0f51e"
+        }
+    ]
+}

--- a/check/dummy_fail.json
+++ b/check/dummy_fail.json
@@ -6,7 +6,7 @@
         {
             "name": "fail",
             "source": "https://www.itu.int//wftp3/av-arch/jctvc-site/bitstream_exchange/draft_conformance/HEVC_v1/ipcm_B_NEC_3.zip",
-            "source_checksum": "bad checksum on purpose",
+            "source_checksum": "0efbe6e6a4a7cd259ffa241c4aee473e",
             "input_file": "ipcm_B_NEC_3/ipcm_B_NEC_3.bit",
             "output_format": "yuv420p",
             "result": "bad result on purpose"

--- a/fluster/codec.py
+++ b/fluster/codec.py
@@ -22,7 +22,7 @@ from enum import Enum
 
 class Codec(Enum):
     '''Codec type'''
-    Dummy = 'Dummy'
+    DUMMY = 'Dummy'
     H264 = 'H.264'
     H265 = 'H.265'
     VP8 = 'VP8'
@@ -31,14 +31,14 @@ class Codec(Enum):
 
 class PixelFormat(Enum):
     '''Pixel format'''
-    yuv420p = 'yuv420p'
-    yuv420p10le = 'yuv420p10le'
+    YUV420P = 'yuv420p'
+    YUV420P10LE = 'yuv420p10le'
 
     def to_gst(self):
         '''Return GStreamer pixel format'''
         mapping = {
-            self.yuv420p: 'I420',
-            self.yuv420p10le: 'I420_10LE'
+            self.YUV420P: 'I420',
+            self.YUV420P10LE: 'I420_10LE'
         }
 
         return mapping[self]

--- a/fluster/decoders/dummy.py
+++ b/fluster/decoders/dummy.py
@@ -26,7 +26,7 @@ from fluster.utils import file_checksum
 class Dummy(Decoder):
     '''Dummy decoder implementation'''
     name = "Dummy"
-    codec = Codec.Dummy
+    codec = Codec.DUMMY
     description = "This is a dummy implementation for the dummy codec"
 
     def decode(self, input_filepath: str, output_filepath: str, output_format: PixelFormat, timeout: int,

--- a/fluster/fluster.py
+++ b/fluster/fluster.py
@@ -144,19 +144,18 @@ class Fluster:
                 for test_vector in test_suite.test_vectors.values():
                     print(test_vector)
 
-    def _get_run_param(self, in_list: list, check_list: list, name: str):
+    def _get_matches(self, in_list: list, check_list: list, name: str) -> list:
         if in_list:
-            run = []
-            for name_list in in_list:
-                for entry in check_list:
-                    if entry.name.lower() == name_list:
-                        run.append(entry)
-            if not run:
-                raise Exception(
-                    f'No {name} found matching {in_list}')
+            in_list_names = {x.lower() for x in in_list}
+            check_list_names = {x.name.lower() for x in check_list}
+            matches = in_list_names & check_list_names
+            if len(matches) != len(in_list):
+                sys.exit(
+                    f'No {name} found for: {", ".join(in_list_names - check_list_names)}')
+            matches = [x for x in check_list if x.name.lower() in matches]
         else:
-            run = check_list
-        return run
+            matches = check_list
+        return matches
 
     def _normalize_context(self, ctx: Context):
         # Convert all test suites and decoders to lowercase to make the filter greedy
@@ -166,9 +165,9 @@ class Fluster:
             ctx.decoders = [x.lower() for x in ctx.decoders]
         if ctx.test_vectors:
             ctx.test_vectors = [x.lower() for x in ctx.test_vectors]
-        ctx.test_suites = self._get_run_param(
+        ctx.test_suites = self._get_matches(
             ctx.test_suites, self.test_suites, 'test suite')
-        ctx.decoders = self._get_run_param(
+        ctx.decoders = self._get_matches(
             ctx.decoders, self.decoders, 'decoders')
 
     def run_test_suites(self, ctx: Context):
@@ -277,10 +276,11 @@ class Fluster:
         '''Download a group of test suites'''
         self._load_test_suites()
         if not test_suites:
-            test_suites = self.test_suites
+            download_test_suites = self.test_suites
         else:
-            test_suites = [
-                t for t in self.test_suites if t.name in test_suites]
-        for test_suite in test_suites:
+            download_test_suites = self._get_matches(
+                test_suites, self.test_suites, 'test suites')
+
+        for test_suite in download_test_suites:
             test_suite.download(jobs, self.resources_dir,
                                 verify=True, keep_file=keep_file)

--- a/fluster/fluster.py
+++ b/fluster/fluster.py
@@ -68,19 +68,19 @@ class Context:
 
 
 EMOJI_RESULT = {
-    TestVectorResult.NotRun: '',
-    TestVectorResult.Success: '✔️',
-    TestVectorResult.Failure: '❌',
-    TestVectorResult.Timeout: '⌛',
-    TestVectorResult.Error: '☠'
+    TestVectorResult.NOT_RUN: '',
+    TestVectorResult.SUCCESS: '✔️',
+    TestVectorResult.FAILURE: '❌',
+    TestVectorResult.TIMEOUT: '⌛',
+    TestVectorResult.ERROR: '☠'
 }
 
 TEXT_RESULT = {
-    TestVectorResult.NotRun: '',
-    TestVectorResult.Success: 'OK',
-    TestVectorResult.Failure: 'KO',
-    TestVectorResult.Timeout: 'TO',
-    TestVectorResult.Error: 'ER'
+    TestVectorResult.NOT_RUN: '',
+    TestVectorResult.SUCCESS: 'OK',
+    TestVectorResult.FAILURE: 'KO',
+    TestVectorResult.TIMEOUT: 'TO',
+    TestVectorResult.ERROR: 'ER'
 }
 
 
@@ -125,8 +125,8 @@ class Fluster:
             for decoder in decoders_dict[codec]:
                 string = f'{decoder}'
                 if check:
-                    string += '... ' + (self.emoji[TestVectorResult.Success] if decoder.check(
-                        verbose) else self.emoji[TestVectorResult.Failure])
+                    string += '... ' + (self.emoji[TestVectorResult.SUCCESS] if decoder.check(
+                        verbose) else self.emoji[TestVectorResult.FAILURE])
                 print(string)
 
     def list_test_suites(self, show_test_vectors: bool = False, test_suites: list = None):

--- a/fluster/main.py
+++ b/fluster/main.py
@@ -183,9 +183,8 @@ class Main:
                           )
         try:
             fluster.run_test_suites(context)
-        except Exception as exception:
-            print(exception)
-            sys.exit(1)
+        except SystemExit as exception:
+            sys.exit(exception.code)
 
     def _reference_cmd(self, args, fluster):
         context = Context(jobs=args.jobs,
@@ -197,9 +196,8 @@ class Main:
                           reference=True)
         try:
             fluster.run_test_suites(context)
-        except Exception as exception:
-            print(exception)
-            sys.exit(1)
+        except SystemExit as exception:
+            sys.exit(exception.code)
 
     def _download_cmd(self, args, fluster):
         args.jobs = args.jobs if args.jobs > 0 else multiprocessing.cpu_count()

--- a/fluster/test.py
+++ b/fluster/test.py
@@ -56,10 +56,10 @@ class Test(unittest.TestCase):
             result = self.decoder.decode(
                 input_filepath, output_filepath, self.test_vector.output_format, self.timeout, self.verbose)
         except TimeoutExpired:
-            self.test_suite.test_vectors[self.test_vector.name].test_result = TestVectorResult.Timeout
+            self.test_suite.test_vectors[self.test_vector.name].test_result = TestVectorResult.TIMEOUT
             raise
         except Exception:
-            self.test_suite.test_vectors[self.test_vector.name].test_result = TestVectorResult.Error
+            self.test_suite.test_vectors[self.test_vector.name].test_result = TestVectorResult.ERROR
             raise
 
         if not self.keep_files and os.path.exists(output_filepath) and \
@@ -67,9 +67,9 @@ class Test(unittest.TestCase):
             os.remove(output_filepath)
 
         if not self.reference:
-            self.test_suite.test_vectors[self.test_vector.name].test_result = TestVectorResult.Failure
+            self.test_suite.test_vectors[self.test_vector.name].test_result = TestVectorResult.FAILURE
             if self.test_vector.result.lower() == result.lower():
-                self.test_suite.test_vectors[self.test_vector.name].test_result = TestVectorResult.Success
+                self.test_suite.test_vectors[self.test_vector.name].test_result = TestVectorResult.SUCCESS
             self.assertEqual(self.test_vector.result.lower(), result.lower(),
                              f'{self.test_vector.input_file}')
         else:

--- a/fluster/test_suite.py
+++ b/fluster/test_suite.py
@@ -161,8 +161,7 @@ class TestSuite:
 
         for job in downloads:
             if not job.successful():
-                print('Some download failed')
-                sys.exit(1)
+                sys.exit('Some download failed')
 
         print('All downloads finished')
 

--- a/fluster/test_vector.py
+++ b/fluster/test_vector.py
@@ -23,11 +23,11 @@ from fluster.codec import PixelFormat
 
 class TestVectorResult(Enum):
     '''Test Result'''
-    NotRun = 'NotRun'
-    Success = 'Success'
-    Failure = 'Failure'
-    Timeout = 'Timeout'
-    Error = 'Error'
+    NOT_RUN = 'NotRun'
+    SUCCESS = 'Success'
+    FAILURE = 'Failure'
+    TIMEOUT = 'Timeout'
+    ERROR = 'Error'
 
 
 class TestVector:
@@ -45,7 +45,7 @@ class TestVector:
         self.result = result
 
         # Not included in JSON
-        self.test_result = TestVectorResult.NotRun
+        self.test_result = TestVectorResult.NOT_RUN
         self.errors = []
 
     @classmethod
@@ -54,7 +54,7 @@ class TestVector:
         if 'output_format' in data:
             data['output_format'] = PixelFormat(data['output_format'])
         else:
-            data['output_format'] = PixelFormat.yuv420p
+            data['output_format'] = PixelFormat.YUV420P
         return (data['name'], cls(**data))
 
     def data_to_serialize(self):

--- a/scripts/gen_jct_vc.py
+++ b/scripts/gen_jct_vc.py
@@ -94,7 +94,7 @@ class JCTVTGenerator:
             name = os.path.splitext(file_url)[0]
             file_input = f'{name}.bin'
             test_vector = TestVector(
-                name, url, '', file_input, PixelFormat.yuv420p, '')
+                name, url, '', file_input, PixelFormat.YUV420P, '')
             test_suite.test_vectors[name] = test_vector
 
         if download:
@@ -114,7 +114,7 @@ class JCTVTGenerator:
                 raise Exception(f'Bitstream file not found in {dest_dir}')
             test_vector.source_checksum = utils.file_checksum(dest_path)
             if 'main10' in test_vector.name.lower():
-                test_vector.output_format = PixelFormat.yuv420p10le
+                test_vector.output_format = PixelFormat.YUV420P10LE
 
             if self.codec == Codec.H265:
                 self._fill_checksum_h265(test_vector, dest_dir)


### PR DESCRIPTION
Consolidate test cases and decoders check for matches

./fluster.py -tsd check download dummy non_existing_test_suite

was not failing before while it does now. We'd rather be
explicit reporting to the user both an error and the test
suite that did not match any available.

This fixes https://github.com/fluendo/fluster/issues/63