### PR TITLE
Fix dummy_fail test vector

### DIFF
--- a/check/dummy_download_fail.json
+++ b/check/dummy_download_fail.json
@@ -4,7 +4,7 @@
     "description": "Dummy download fail test suite",
     "test_vectors": [
         {
-            "name": "fail",
+            "name": "download_fail",
             "source": "https://www.itu.int//wftp3/av-arch/jctvc-site/bitstream_exchange/draft_conformance/HEVC_v1/ipcm_B_NEC_3.zip",
             "source_checksum": "bad checksum on purpose",
             "input_file": "ipcm_B_NEC_3/ipcm_B_NEC_3.bit",

--- a/check/dummy_fail.json
+++ b/check/dummy_fail.json
@@ -4,7 +4,7 @@
     "description": "Dummy fail test suite",
     "test_vectors": [
         {
-            "name": "fail",
+            "name": "expected_fail",
             "source": "https://www.itu.int//wftp3/av-arch/jctvc-site/bitstream_exchange/draft_conformance/HEVC_v1/ipcm_B_NEC_3.zip",
             "source_checksum": "0efbe6e6a4a7cd259ffa241c4aee473e",
             "input_file": "ipcm_B_NEC_3/ipcm_B_NEC_3.bit",

--- a/fluster/test.py
+++ b/fluster/test.py
@@ -71,6 +71,6 @@ class Test(unittest.TestCase):
             if self.test_vector.result.lower() == result.lower():
                 self.test_suite.test_vectors[self.test_vector.name].test_result = TestVectorResult.SUCCESS
             self.assertEqual(self.test_vector.result.lower(), result.lower(),
-                             f'{self.test_vector.input_file}')
+                             self.test_vector.name)
         else:
             self.test_suite.test_vectors[self.test_vector.name].result = result

--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -38,7 +38,7 @@ def download(url: str, dest_dir: str):
             shutil.copyfileobj(response, dest)
 
 
-def file_checksum(path: str):
+def file_checksum(path: str) -> str:
     '''Calculates the checksum of a file reading chunks of 64KiB'''
     md5 = hashlib.md5()
     with open(path, 'rb') as file:
@@ -60,7 +60,7 @@ def run_command(command: list, verbose: bool = False, check: bool = True, timeou
                    check=check, timeout=timeout)
 
 
-def is_extractable(filepath: str):
+def is_extractable(filepath: str) -> bool:
     '''Checks is a file can be extracted from the its extension'''
     return filepath.endswith(TARBALL_EXTS) or filepath.endswith('.zip')
 
@@ -80,7 +80,7 @@ def extract(filepath: str, output_dir: str, file: str = None):
         raise Exception("Unknown tarball format %s" % filepath)
 
 
-def normalize_binary_cmd(cmd: str):
+def normalize_binary_cmd(cmd: str) -> str:
     '''Return the OS-form binary'''
     if platform.system() == 'Windows':
         return cmd if cmd.endswith('.exe') else cmd + '.exe'
@@ -89,7 +89,7 @@ def normalize_binary_cmd(cmd: str):
     return cmd
 
 
-def normalize_path(path: str):
+def normalize_path(path: str) -> str:
     '''Normalize the path to make it Unix-like'''
     if platform.system() == 'Windows':
         return path.replace('\\', '/')


### PR DESCRIPTION
Apparently, having 'fail' in the test name has the following
result:

Traceback (most recent call last):
  File "/home/pablo/Fluendo/fluster/fluster/test.py", line 73, in _test
    self.assertEqual(self.test_vector.result.lower(), result.lower(),
  File "/usr/lib/python3.8/unittest/case.py", line 912, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/usr/lib/python3.8/unittest/case.py", line 1292, in assertMultiLineEqual
    self.fail(self._formatMessage(msg, standardMsg))
TypeError: _test() takes 1 positional argument but 2 were given

Most likely this is due to some hidden witchcraft thingy done on
Python's unit test framework. We set the test name by doing:

        setattr(self, test_vector.name, self._test)
        super().__init__(test_vector.name)