### PR TITLE
Developer experience improvement to facilitate copy/paste.

### DIFF
--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -56,8 +56,13 @@ def run_command(command: list, verbose: bool = False, check: bool = True, timeou
     serr = subprocess.DEVNULL if not verbose else None
     if verbose:
         print(f'\nRunning command \"{" ".join(command)}\"')
-    subprocess.run(command, stdout=sout, stderr=serr,
-                   check=check, timeout=timeout)
+    try:
+        subprocess.run(command, stdout=sout, stderr=serr,
+                       check=check, timeout=timeout)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
+        # Developer experience improvement (facilitates copy/paste)
+        ex.cmd = " ".join(ex.cmd)
+        raise ex
 
 
 def is_extractable(filepath: str) -> bool:


### PR DESCRIPTION
Before:
```
subprocess.TimeoutExpired: Command '['gst-launch-1.0', 'filesrc', 'location=resources/JVT-AVC_V1/MR3_TANDBERG_B/MR3_TANDBERG_B.264', '!', 'h264parse', '!', 'fluvadec', '!', 'video/x-raw', '!', 'videoconvert', 'dither=none', '!', 'video/x-raw,format=I420', '!', 'filesink', 'location=results/JVT-AVC_V1/MR3_TANDBERG_B.yuv']' timed out after 30 seconds
```

After:
```
subprocess.CalledProcessError: Command 'gst-launch-1.0 filesrc location=resources/JVT-AVC_V1/sp2_bt_b/H26L/BitstreamExchange/sp2_bt_b.h264 ! h264parse ! fluvadec ! video/x-raw ! videoconvert dither=none ! video/x-raw,format=I420 ! filesink location=results/JVT-AVC_V1/sp2_bt_b.yuv' returned non-zero exit status 1.
```