### PR TITLE
Warning if repeated test suite's name

### DIFF
--- a/fluster/fluster.py
+++ b/fluster/fluster.py
@@ -107,6 +107,9 @@ class Fluster:
                     try:
                         test_suite = TestSuite.from_json_file(
                             os.path.join(root, file), self.resources_dir)
+                        if test_suite.name in [ts.name for ts in self.test_suites]:
+                            raise Exception(
+                                f'Repeated test suite with name "{test_suite.name}"')
                         self.test_suites.append(test_suite)
                     except Exception as ex:
                         print(f'Error loading test suite {file}: {ex}')

--- a/fluster/main.py
+++ b/fluster/main.py
@@ -37,7 +37,6 @@ class Main:
     # pylint: disable=broad-except
 
     def __init__(self):
-        self.test_suites_dir = TEST_SUITES_DIR
         self.decoders_dir = DECODERS_DIR
         self.parser = self._create_parser()
 


### PR DESCRIPTION
Whenever I created a sub-test suite from another I forget to change the name and realize about the mistake is not easy. This warning can help.