### PR TITLE
OCP-2317 : Add AAC reference decoder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,27 +58,60 @@ lint: format-check ## run static analysis using pylint, flake8 and mypy
 	@echo "Checking with mypy..."
 	mypy --strict $(PY_FILES)
 
-$(CONTRIB_DIR):
-	mkdir -p $@
+create_dirs=mkdir -p $(CONTRIB_DIR) $(DECODERS_DIR)
 
-$(DECODERS_DIR):
-	mkdir -p $@
+all_reference_decoders: h265_reference_decoder h264_reference_decoder aac_reference_decoder ## build all reference decoders
 
-decoders: h265_reference_decoder h264_reference_decoder ## build all reference decoders
-
-h265_reference_decoder: $(CONTRIB_DIR) $(DECODERS_DIR) ## build H.265 reference decoder
+h265_reference_decoder: ## build H.265 reference decoder
+	$(create_dirs)
 	cd $(CONTRIB_DIR) && git clone https://vcgit.hhi.fraunhofer.de/jct-vc/HM.git --depth=1 | true
 	cd $(CONTRIB_DIR)/HM && git stash && git pull && git stash apply | true
 	cd $(CONTRIB_DIR)/HM && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release && $(MAKE) -C build TAppDecoder
-	find $(CONTRIB_DIR)/HM/bin/umake -name "TAppDecoder" -type f -exec cp "{}" $(DECODERS_DIR) \;
+	find $(CONTRIB_DIR)/HM/bin/umake -name "TAppDecoder" -type f -exec cp {} $(DECODERS_DIR)/ \;
 
-h264_reference_decoder: $(CONTRIB_DIR) ## build H.264 reference decoder
+h264_reference_decoder: ## build H.264 reference decoder
+	$(create_dirs)
 	cd $(CONTRIB_DIR) && git clone https://vcgit.hhi.fraunhofer.de/jct-vc/JM.git --depth=1 | true
 	cd $(CONTRIB_DIR)/JM && git stash && git pull && git stash apply | true
 	cd $(CONTRIB_DIR)/JM && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wno-stringop-truncation -Wno-stringop-overflow" && $(MAKE) -C build ldecod
-	find $(CONTRIB_DIR)/JM/bin/umake -name "ldecod" -type f -exec cp "{}" $(DECODERS_DIR) \;
+	find $(CONTRIB_DIR)/JM/bin/umake -name "ldecod" -type f -exec cp {} $(DECODERS_DIR)/ \;
+
+aac_reference_decoder: ## build AAC reference decoder
+	if ! test -d $(CONTRIB_DIR)/fdk-aac; \
+	then \
+		$(create_dirs) && \
+		cd $(CONTRIB_DIR) && git clone https://github.com/mstorsjo/fdk-aac.git | true && \
+		cd fdk-aac && git checkout -B decoder origin/decoder-example && git merge-base master decoder | true && \
+		git rebase master || git checkout --ours .gitignore && git add .gitignore && \
+		git rebase --continue || git checkout --ours .gitignore && git add .gitignore && \
+		git rebase --continue && git checkout master && git merge decoder | true && \
+		sed -i '586a\
+		\
+		## Program sources \
+		\
+		set(aac_dec_SOURCES \
+			aac-dec.c \
+			wavwriter.c \
+			wavwriter.h) \
+		\
+		## Program target \
+		add_executable(aac-dec $${aac_dec_SOURCES}) \
+		\ \
+		## Program target configuration \
+		target_link_libraries(aac-dec PRIVATE fdk-aac) \
+		target_compile_definitions(aac-dec PRIVATE $$<$$<BOOL:$${MSVC}>:_CRT_SECURE_NO_WARNINGS>) \
+		if(WIN32) \
+			target_sources(aac-dec PRIVATE win32/getopt.h) \
+			target_include_directories(aac-dec PRIVATE win32) \
+		endif() \
+		\
+		## Program target installation \
+		install(TARGETS aac-dec RUNTIME DESTINATION $${CMAKE_INSTALL_BINDIR})' CMakeLists.txt; \
+	fi
+	cd $(CONTRIB_DIR)/fdk-aac && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DBUILD_PROGRAMS=1 && $(MAKE) -C build aac-dec
+	find $(CONTRIB_DIR)/fdk-aac/build -name "aac-dec" -type f -exec cp {} $(DECODERS_DIR) \;
 
 dbg-%:
 	echo "Value of $* = $($*)"
 
-.PHONY: help decoders h264_reference_decoder h265_reference_decoder lint check format install_deps
+.PHONY: help all_reference_decoders h264_reference_decoder h265_reference_decoder aac_reference_decoder lint check format install_deps

--- a/fluster/codec.py
+++ b/fluster/codec.py
@@ -29,6 +29,7 @@ class Codec(Enum):
     H265 = "H.265"
     VP8 = "VP8"
     VP9 = "VP9"
+    AAC = "AAC"
 
 
 class PixelFormat(Enum):

--- a/fluster/decoders/fdk_aac.py
+++ b/fluster/decoders/fdk_aac.py
@@ -1,0 +1,40 @@
+# Fluster - testing framework for decoders conformance
+# Copyright (C) 2021, Fluendo, S.A.
+#  Author: Michalis Dimopoulos <mdimopoulos@fluendo.com>, Fluendo, S.A.
+#  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
+#  Author: Andoni Morales Alastruey <amorales@fluendo.com>, Fluendo, S.A.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+from fluster.codec import Codec, PixelFormat
+from fluster.decoder import Decoder, register_decoder
+from fluster.utils import file_checksum, run_command
+
+
+@register_decoder
+class FDKAACDecoder(Decoder):
+    '''FDK AAC reference decoder implementation'''
+    name = "FDK-AAC"
+    description = "FDK AAC reference decoder"
+    codec = Codec.AAC
+    binary = 'aac-dec'
+
+    def decode(self, input_filepath: str, output_filepath: str, output_format: PixelFormat, timeout: int,
+               verbose: bool) -> str:
+        '''Decodes input_filepath in output_filepath'''
+        run_command([self.binary, input_filepath, output_filepath],
+                    timeout=timeout, verbose=verbose)
+        return file_checksum(output_filepath)


### PR DESCRIPTION
+decoder.py: modified decoder() function argument sequence

+aac_dec.py: added a wrapper for the reference aac decoder

+Makefile: changed target names to be more precise and
replaced 2 targets which were not building executables/files
with variables that can be executed at runtime.