### PR TITLE
OCP-2337 Fix removing non-compressed downloaded files

### DIFF
--- a/fluster/main.py
+++ b/fluster/main.py
@@ -268,7 +268,8 @@ class Main:
         subparser.add_argument(
             "-k",
             "--keep",
-            help="keep downloaded file after extracting",
+            help="keep original downloaded file after extracting. Only applicable to compressed "
+            "files such as .zip, .tar.gz, etc",
             action="store_true",
         )
         subparser.add_argument(

--- a/fluster/test_suite.py
+++ b/fluster/test_suite.py
@@ -154,7 +154,10 @@ class TestSuite:
             and os.path.exists(dest_path)
             and test_vector.source_checksum == utils.file_checksum(dest_path)
         ):
-            if not ctx.keep_file:
+            # Remove file only in case the input file was extractable.
+            # Otherwise, we'd be removing the original file we want to work
+            # with every even time we execute the download subcommand.
+            if utils.is_extractable(dest_path) and not ctx.keep_file:
                 os.remove(dest_path)
             return
         print(f"\tDownloading test vector {test_vector.name} from {dest_dir}")


### PR DESCRIPTION
We were wrongly assuming when this code was created
that only compressed files would be used. After adding
VP8, VP9 and in the near future the AAC tests, this is
not true anymore.

Before. Starting with an empty resources dir:
```bash
$./fluster.py download VP8-TEST-VECTORS
...
All downloads finished

find resources/VP8-TEST-VECTORS -type f | wc -l
61

./fluster.py download VP8-TEST-VECTORS
...
All downloads finished

find resources/VP8-TEST-VECTORS -type f | wc -l
0
```

Now. Starting with an empty resources dir:
```
$./fluster.py download VP8-TEST-VECTORS
...
All downloads finished

find resources/VP8-TEST-VECTORS -type f | wc -l
61

./fluster.py download VP8-TEST-VECTORS
Downloading test suite VP8-TEST-VECTORS using 16 parallel jobs
All downloads finished

find resources/VP8-TEST-VECTORS -type f | wc -l
61

./fluster.py download VP8-TEST-VECTORS
Downloading test suite VP8-TEST-VECTORS using 16 parallel jobs
All downloads finished
find resources/VP8-TEST-VECTORS -type f | wc -l
61
```
 