### PR TITLE
codec: Fix pixel format gst mapping

### DIFF
--- a/fluster/codec.py
+++ b/fluster/codec.py
@@ -39,6 +39,6 @@ class PixelFormat(Enum):
 
     def to_gst(self) -> str:
         """Return GStreamer pixel format"""
-        mapping = {self.YUV420P: "I420", self.YUV420P10LE: "I420_10LE"}
+        mapping = {str(self.YUV420P): "I420", str(self.YUV420P10LE): "I420_10LE"}
 
         return mapping[str(self)]


### PR DESCRIPTION
The map is using enum objects are key, but the to_gst() function was
using string as key. This was causing all GStreamer test to fail with a
backtrace.