### PR TITLE
Bring back support for Python 3.6+ in Fluster

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.6
     - name: Install dependencies
       run: |
         make install_deps
@@ -32,10 +32,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.6
     - name: Install dependencies
       run: |
         make install_deps

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ easily extended to add more decoders and test suites.
 
 ## Description
 
-Fluster requires **Python 3.7+** to work. It has zero dependencies apart from
+Fluster requires **Python 3.6+** to work. It has zero dependencies apart from
 that. The [requirements.txt](requirements.txt) file includes Python's modules
 used only for development.
 

--- a/fluster/decoder.py
+++ b/fluster/decoder.py
@@ -17,7 +17,6 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-from __future__ import annotations
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from shutil import which

--- a/fluster/test_suite.py
+++ b/fluster/test_suite.py
@@ -17,7 +17,6 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-from __future__ import annotations
 from functools import lru_cache
 import os.path
 import json
@@ -113,14 +112,14 @@ class TestSuite:
         self.test_vectors_success = 0
         self.time_taken = 0.0
 
-    def clone(self) -> TestSuite:
+    def clone(self) -> "TestSuite":
         """Create a deep copy of the object"""
         return copy.deepcopy(self)
 
     @classmethod
     def from_json_file(
-        cls: Type[TestSuite], filename: str, resources_dir: str
-    ) -> TestSuite:
+        cls: Type["TestSuite"], filename: str, resources_dir: str
+    ) -> "TestSuite":
         """Create a TestSuite instance from a file"""
         with open(filename) as json_file:
             data = json.load(json_file)
@@ -326,7 +325,7 @@ class TestSuite:
               in {self.time_taken:.3f} secs"
         )
 
-    def run(self, ctx: Context) -> Optional[TestSuite]:
+    def run(self, ctx: Context) -> Optional["TestSuite"]:
         """
         Run the test suite.
         Returns a new copy of the test suite with the result of the test

--- a/fluster/test_vector.py
+++ b/fluster/test_vector.py
@@ -17,7 +17,6 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-from __future__ import annotations
 from enum import Enum
 from typing import List, Dict, Type, Any
 from fluster.codec import PixelFormat
@@ -60,7 +59,7 @@ class TestVector:
         self.errors: List[List[str]] = []
 
     @classmethod
-    def from_json(cls: Type[TestVector], data: Any) -> Any:
+    def from_json(cls: Type["TestVector"], data: Any) -> Any:
         """Deserialize an instance of TestVector from a json file"""
         if "output_format" in data:
             data["output_format"] = PixelFormat(data["output_format"])


### PR DESCRIPTION
Postponed Evaluation of Annotations (PEP 563) was added in python 3.7 importing annotations from `__future__`.

This commit will have to be reverted when the end of python 3.6 support.