### PR TITLE
OCP-2301 Add logic in Fluster to compare a reference raw video frame against another one

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,6 +23,9 @@ jobs:
       run: |
         make install_deps
         sudo apt update && sudo apt install gstreamer1.0-tools gstreamer1.0-libav gstreamer1.0-plugins-bad ffmpeg vpx-tools
+    - name: Unit test
+      run: |
+        make unit-test
     - name: Check
       run: |
         make check
@@ -39,6 +42,9 @@ jobs:
     - name: Install dependencies
       run: |
         make install_deps
+    - name: Unit test
+      run: |
+        make unit-test
     - name: Check
       run: |
         make check

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .vscode
+.idea
+venv
 __pycache__
 __MACOSX
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PY_FILES=fluster
+PY_FILES=fluster unit_test
 CONTRIB_DIR=contrib
 DECODERS_DIR=decoders
 PYTHONPATH=.
@@ -119,4 +119,8 @@ aac_reference_decoder: ## build AAC reference decoder
 dbg-%:
 	echo "Value of $* = $($*)"
 
-.PHONY: help all_reference_decoders h264_reference_decoder h265_reference_decoder aac_reference_decoder lint check format install_deps
+unit-test: ## Run unit tests
+	@echo "Run unit test"
+	@python3 -m unittest discover -s unit_test -p "*_test.py" -v
+
+.PHONY: help all_reference_decoders h264_reference_decoder h265_reference_decoder aac_reference_decoder lint check format install_deps unit-test

--- a/fluster/image/__init__.py
+++ b/fluster/image/__init__.py
@@ -1,0 +1,27 @@
+# Fluster - testing framework for decoders conformance
+# Copyright (C) 2021, Fluendo, S.A.
+#  Author: Manuel Jimeno Martínez <mjimeno@fluendo.com>, Fluendo, S.A.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+import glob
+import os.path
+
+modules = glob.glob(os.path.join(os.path.dirname(__file__), "*.py"))
+__all__ = [
+    os.path.basename(os.path.splitext(f)[0])
+    for f in modules
+    if os.path.isfile(f) and not f.endswith("__init__.py")
+]

--- a/fluster/image/raw_buffer.py
+++ b/fluster/image/raw_buffer.py
@@ -1,0 +1,361 @@
+# Fluster - testing framework for decoders conformance
+# Copyright (C) 2021, Fluendo, S.A.
+#  Author: Manuel Jimeno Martínez <mjimeno@fluendo.com>, Fluendo, S.A.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+# pylint: disable=too-many-instance-attributes, protected-access
+from typing import Tuple, Optional, Dict, Any
+from enum import Enum
+
+PixelToIgnore = Dict[int, Any]
+
+
+class RawBuffer:
+    """Class to handle the raw image buffer"""
+
+    _RGBA_TOLERANCE = 0
+    _YUV_TOLERANCE = 0
+
+    class Type(Enum):
+        """Allows raw buffer types"""
+
+        YUV420 = "yuv420"
+        RGBA = "rgba"
+
+    def __init__(
+        self,
+        buffer: bytes,
+        width: int,
+        height: int,
+        buffer_type: Type = Type.YUV420,
+        pixels_to_ignore: Optional[PixelToIgnore] = None,
+        create_diff_buffer: bool = False,
+        color_diff: Optional[Tuple[int, int, int]] = None,
+        buffer_diff: Optional[bytearray] = None,
+    ):
+        if buffer_type == RawBuffer.Type.YUV420:
+            if (width % 4) or (height % 4):
+                raise Exception("Width and height must be multiples of 4")
+            len_buffer = (width * height * 3) // 2
+        elif buffer_type == RawBuffer.Type.RGBA:
+            len_buffer = width * height * 4
+        else:
+            raise RuntimeError(f"The type buffer {buffer_type} is not supported")
+
+        if len(buffer) != len_buffer:
+            raise RuntimeError(
+                f"The size of the frame and the len of the buffer do not match {len(buffer)} {len_buffer}"
+            )
+
+        self._width = width
+        self._height = height
+        self._buffer_type = buffer_type
+        self._buffer = buffer
+        if pixels_to_ignore is None:
+            self._pixels_to_ignore: PixelToIgnore = {}
+        else:
+            self._pixels_to_ignore = pixels_to_ignore
+        self._create_diff_buffer = create_diff_buffer
+
+        if color_diff is None:
+            self._color_diff: Tuple[int, int, int] = (0xFF, 0, 0)
+        else:
+            self._color_diff = color_diff
+
+        if buffer_diff is None:
+            self._buffer_diff: bytearray = bytearray()
+        else:
+            self._buffer_diff = buffer_diff
+
+    def from_format(self, buffer_type: Type) -> "RawBuffer":
+        """Returns an instance of RawBuffer in the requested format"""
+        if (
+            self.buffer_type == RawBuffer.Type.RGBA
+            and buffer_type == RawBuffer.Type.YUV420
+        ):
+            new_buffer = self.rgba_to_yuv420()
+        elif (
+            self.buffer_type == RawBuffer.Type.YUV420
+            and buffer_type == RawBuffer.Type.RGBA
+        ):
+            new_buffer = self.yuv420_to_rgba()
+        elif self.buffer_type == buffer_type:
+            new_buffer = self.buffer
+        else:
+            raise RuntimeError(f"The {buffer_type} is not supported")
+
+        return RawBuffer(
+            new_buffer,
+            self._width,
+            self._height,
+            buffer_type,
+            self._pixels_to_ignore,
+            self._create_diff_buffer,
+            self._color_diff,
+            self._buffer_diff,
+        )
+
+    @property
+    def buffer_diff(self) -> Optional[bytearray]:
+        """Return the buffer with comparison differences"""
+        return self._buffer_diff
+
+    @property
+    def create_diff_buffer(self) -> bool:
+        """Returns a value that indicates it should be generated a new buffer with the differences between buffers"""
+        return self._create_diff_buffer
+
+    @create_diff_buffer.setter
+    def create_diff_buffer(self, value: bool) -> None:
+        """Set create_diff_buffer value"""
+        self._create_diff_buffer = value
+        if value:
+            self._color_diff = (0xFF, 0, 0)
+
+    @property
+    def color_diff(self) -> Optional[Tuple[int, int, int]]:
+        """Returns a value that indicates the color of the different points in a three-position tuple in RGB format"""
+        return self._color_diff
+
+    @color_diff.setter
+    def color_diff(self, value: Tuple[int, int, int]) -> None:
+        """Set color_diff value"""
+        if len(value) != 3:
+            raise RuntimeError("A format other than RGB is not allowed")
+        self._color_diff = value
+        self._create_diff_buffer = True
+
+    @property
+    def buffer(self) -> bytes:
+        """Returns the raw data"""
+        return self._buffer
+
+    @property
+    def pixels_to_ignore(self) -> PixelToIgnore:
+        """Returns the list of pixels to ignore in comparison"""
+        return self._pixels_to_ignore
+
+    @property
+    def buffer_type(self) -> Type:
+        """Returns the buffer type of the class"""
+        return self._buffer_type
+
+    @property
+    def width(self) -> int:
+        """Returns the width of the image stored in the buffer"""
+        return self._width
+
+    @property
+    def height(self) -> int:
+        """Returns the height of the image stored in the buffer"""
+        return self._height
+
+    @property
+    def frame_size(self) -> int:
+        """Returns the size of the frame stored in the buffer"""
+        return self._height * self._width
+
+    def _rgba(self, index: int) -> Tuple[int, int, int, int]:
+        """Returns the RGBA tuple from the indicated position"""
+        return (
+            self._buffer[index] & 0xFF,
+            self._buffer[index + 1] & 0xFF,
+            self._buffer[index + 2] & 0xFF,
+            self._buffer[index + 3] & 0xFF,
+        )
+
+    @staticmethod
+    def _rgba_to_yuv(rgba_value: Tuple[int, int, int, int]) -> Tuple[int, int, int]:
+        """It converts an RGBA tuple to another YUV420 tuple"""
+
+        def y_from_rgba(_r: int, _g: int, _b: int, _a: int) -> int:
+            return RawBuffer.clamp(((66 * _r + 129 * _g + 25 * _b + 128) >> 8) + 16)
+
+        def u_from_rgba(_r: int, _g: int, _b: int, _a: int) -> int:
+            return RawBuffer.clamp(((-38 * _r - 74 * _g + 112 * _b + 128) >> 8) + 128)
+
+        def v_from_rgba(_r: int, _g: int, _b: int, _a: int) -> int:
+            return RawBuffer.clamp(((112 * _r - 94 * _g - 18 * _b + 128) >> 8) + 128)
+
+        return (
+            y_from_rgba(*rgba_value),
+            u_from_rgba(*rgba_value),
+            v_from_rgba(*rgba_value),
+        )
+
+    def _yuv420_comparison(
+        self, target: "RawBuffer", deviations: Dict[int, int]
+    ) -> int:
+        """Comparison of two buffers of type YUV420"""
+        source_buffer: bytes = self.buffer
+        target_buffer: bytes = target.buffer
+        size_chroma: int = self.frame_size // 4
+        start_u: int = self.frame_size
+        start_v: int = self.frame_size + size_chroma
+        total_errors = 0
+
+        def check_deviation(source_pixel: int, target_pixel: int) -> int:
+            deviation = int(abs(source_pixel - target_pixel))
+            if deviation > self._YUV_TOLERANCE:
+                if i not in self._pixels_to_ignore:
+                    deviations[deviation] = (
+                        1 if deviation not in deviations else deviations[deviation] + 1
+                    )
+                    return 1
+            return 0
+
+        # First compare the y buffer
+        for i in range(self.frame_size):
+            total_errors += check_deviation(source_buffer[i], target_buffer[i])
+            if i < size_chroma:
+                total_errors += check_deviation(
+                    source_buffer[i + start_u], target_buffer[i + start_u]
+                )
+                total_errors += check_deviation(
+                    source_buffer[i + start_v], target_buffer[i + start_v]
+                )
+
+        return total_errors
+
+    def _rgba_comparison(self, target: "RawBuffer", deviations: Dict[int, int]) -> int:
+        """Comparison of two buffers of type RGBA"""
+        if self._create_diff_buffer:
+            self._buffer_diff = bytearray(self._buffer)
+        total_errors = 0
+
+        for i in range((self.frame_size * 4)):
+            deviation = abs(self._buffer[i] - target.buffer[i])
+            if deviation:
+                total_errors += 1
+                if self._create_diff_buffer and i % 4 == 0:
+                    self._buffer_diff[i] = self._color_diff[0]
+                    self._buffer_diff[i + 1] = self._color_diff[1]
+                    self._buffer_diff[i + 2] = self._color_diff[2]
+                deviations[deviation] = (
+                    1 if deviation not in deviations else deviations[deviation] + 1
+                )
+
+        return total_errors
+
+    @staticmethod
+    def clamp(value: int) -> int:
+        """Clip between 0 and 255"""
+        return max(0, min(255, value))
+
+    def save(self, filename: str) -> None:
+        """Save the content of the buffer to file"""
+        with open(filename, "wb") as file:
+            file.write(self._buffer)
+
+    def save_diff(self, filename: str) -> None:
+        """Save the content of the buffer to file"""
+        with open(filename, "wb") as file:
+            file.write(self._buffer_diff)
+
+    def save_as_python(self, filename: str) -> None:
+        """Save the content of the buffer to file"""
+        with open(filename, "w") as file:
+            counter = 0
+            sentence = "image_content = ["
+            for item in self._buffer:
+                sentence += f"{item},"
+                if counter % 20 == 0:
+                    sentence += "\n"
+                counter += 1
+            sentence += "]"
+            file.write(sentence)
+
+    def rgba_to_yuv420(self) -> bytes:
+        """Converts rgba to yuv420p"""
+        yuv_buffer = bytearray((self.frame_size * 3) // 2)
+        u_index = self.frame_size
+        v_index = u_index + (self.frame_size // 4)
+
+        def is_pixel_to_ignore(_r: int, _g: int, _b: int, _a: int) -> bool:
+            return _r in (0, 255) or _g in (0, 255) or _b in (0, 255)
+
+        for row in range(self._height):
+            for column in range(self._width):
+                y_index = row * self._width + column
+                rgba = self._rgba(y_index * 4)
+                yuv = RawBuffer._rgba_to_yuv(rgba)
+                yuv_buffer[y_index] = yuv[0]
+
+                if is_pixel_to_ignore(*rgba):
+                    self._pixels_to_ignore[y_index] = [rgba, yuv]
+
+                if row % 2 == 0 and y_index % 2 == 0:
+                    yuv_buffer[u_index] = yuv[1]
+                    u_index += 1
+                    yuv_buffer[v_index] = yuv[2]
+                    v_index += 1
+
+        return bytes(yuv_buffer)
+
+    def yuv420_to_rgba(self) -> bytes:
+        """Converts yuv420p to rgba"""
+        rgba_buffer = bytearray(self._width * self._height * 4)
+        rgba_index = 0
+        y_index = 0
+
+        def r_from_yuv(_y: int, _u: int, _v: int) -> int:
+            return RawBuffer.clamp((_y + 409 * _v + 128) // 256)
+
+        def g_from_yuv(_y: int, _u: int, _v: int) -> int:
+            return RawBuffer.clamp((_y - 100 * _u - 208 * _v + 128) // 256)
+
+        def b_from_yuv(_y: int, _u: int, _v: int) -> int:
+            return RawBuffer.clamp((_y + 516 * _u + 128) // 256)
+
+        for row in range(0, self._height):
+            u_index = self.frame_size + (row // 2) * (self._width // 2)
+            v_index = u_index + self.frame_size // 4
+
+            for column in range(0, self._width):
+                yuv = (
+                    ((self._buffer[y_index] - 16) * 298),
+                    (self._buffer[u_index] - 128),
+                    (self._buffer[v_index] - 128),
+                )
+
+                rgba_buffer[rgba_index] = r_from_yuv(*yuv)
+                rgba_buffer[rgba_index + 1] = g_from_yuv(*yuv)
+                rgba_buffer[rgba_index + 2] = b_from_yuv(*yuv)
+                rgba_buffer[rgba_index + 3] = 0xFF
+
+                u_index += column % 2
+                v_index += column % 2
+                y_index += 1
+                rgba_index += 4
+
+        return bytes(rgba_buffer)
+
+    def is_equal(
+        self,
+        target: "RawBuffer",
+        buffer_type: Type,
+    ) -> int:
+        """Comparison of two RawBuffers"""
+        deviations: Dict[int, int] = {}
+        if buffer_type == RawBuffer.Type.YUV420:
+            different_pixels = self._yuv420_comparison(target, deviations)
+        elif buffer_type == RawBuffer.Type.RGBA:
+            different_pixels = self._rgba_comparison(target, deviations)
+        else:
+            raise RuntimeError(f"The {buffer_type} is not supported")
+
+        return different_pixels

--- a/fluster/image/raw_image.py
+++ b/fluster/image/raw_image.py
@@ -1,0 +1,152 @@
+# Fluster - testing framework for decoders conformance
+# Copyright (C) 2021, Fluendo, S.A.
+#  Author: Manuel Jimeno Martínez <mjimeno@fluendo.com>, Fluendo, S.A.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+# pylint: disable=too-many-instance-attributes, protected-access
+
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+from fluster.image.raw_buffer import RawBuffer
+
+
+def get_full_meta_from_name(
+    filename: str, buffer_type: Optional[RawBuffer.Type] = None
+) -> Tuple[str, str, int, int, RawBuffer.Type, int]:
+    """Retrieves the metadata stored in the file name"""
+    filename_split = filename.split(".")
+    info = str(filename_split[0]).split("_")
+    video_name = info[0]
+    decode_type = info[1]
+    if buffer_type is None:
+        buffer_type = RawBuffer.Type(filename_split[1].lower())
+    width = int(info[2])
+    height = int(info[3])
+    num_frame = int(info[4])
+    return video_name, decode_type, width, height, buffer_type, num_frame
+
+
+def get_meta_from_name(
+    filename: str, buffer_type: Optional[RawBuffer.Type]
+) -> Tuple[str, int, int, RawBuffer.Type]:
+    """Retrieves part of the metadata stored in the file name"""
+    video_name, _, width, height, buffer_type, _ = get_full_meta_from_name(
+        filename, buffer_type
+    )
+    return video_name, width, height, buffer_type
+
+
+class RawImage:
+    """Class to handle the raw image"""
+
+    def __init__(
+        self,
+        buffer: bytes,
+        video_name: str,
+        width: int,
+        height: int,
+        buffer_type: RawBuffer.Type,
+        create_diff_buffer: bool = False,
+    ) -> None:
+
+        self._buffer_type: RawBuffer.Type = buffer_type
+        self._width: int = width
+        self._height: int = height
+        self._video_name: str = video_name
+        self._create_diff_buffer: bool = create_diff_buffer
+        self._data: Dict[RawBuffer.Type, RawBuffer] = {
+            buffer_type: RawBuffer(
+                buffer,
+                width,
+                height,
+                buffer_type,
+                create_diff_buffer=create_diff_buffer,
+            )
+        }
+
+    @staticmethod
+    def from_file(
+        filename: str, buffer_type: Optional[RawBuffer.Type] = None
+    ) -> "RawImage":
+        """Create a RawImage from a file using the content and the metadata stored in the file name"""
+        file_path = Path(filename)
+        if not file_path.exists():
+            raise RuntimeError(f"The file {filename} does not exists")
+        buffer = bytes(file_path.read_bytes())
+        return RawImage(buffer, *get_meta_from_name(filename, buffer_type))
+
+    @staticmethod
+    def from_buffer(
+        filename: str,
+        buffer: bytes,
+        buffer_type: RawBuffer.Type,
+    ) -> "RawImage":
+        """Create a RawImage from a buffer using the content and the metadata stored in the file name"""
+        return RawImage(buffer, *get_meta_from_name(filename, buffer_type))
+
+    def __str__(self) -> str:
+        message = f"{self._video_name} with \n"
+        for key in self._data:
+            raw_image = self._data[key]
+            message += f"buffer type {raw_image.buffer_type} ({raw_image.width},{raw_image.height})\n"
+        return message
+
+    def _convert(self, buffer_type: RawBuffer.Type) -> None:
+        if buffer_type not in self._data:
+            self._data[buffer_type] = self.default_raw_buffer.from_format(buffer_type)
+
+    @property
+    def default_raw_buffer(self) -> RawBuffer:
+        """Return the first buffer created"""
+        return self._data[self._buffer_type]
+
+    @property
+    def video_name(self) -> str:
+        """Return the video name"""
+        return self._video_name
+
+    def is_equal(
+        self,
+        target_image: "RawImage",
+        buffer_type: RawBuffer.Type,
+    ) -> int:
+        """Compares two RawBuffer in the specified pixel format"""
+        self._convert(buffer_type)
+        target_image._convert(buffer_type)
+
+        result: int = self._data[buffer_type].is_equal(
+            target_image._data[buffer_type], buffer_type
+        )
+
+        if result > 0 and self._create_diff_buffer:
+            self.save_diff(f"{self._video_name}_color_diff.rgba")
+
+        return result
+
+    def save_diff(self, filename: str) -> None:
+        """Save buffer_diff stored in the raw image"""
+        self.default_raw_buffer.save_diff(filename)
+
+    def save(self, filename: str, buffer_type: RawBuffer.Type) -> None:
+        """Save RawBuffer stored in the specified pixel format"""
+        self._convert(buffer_type)
+        self._data[buffer_type].save(filename)
+
+    def save_as_python(self, filename: str, buffer_type: RawBuffer.Type) -> None:
+        """Save RawBuffer stored in the specified pixel format as a python bytes array"""
+        self._convert(buffer_type)
+        self._data[self._buffer_type].save_as_python(filename)

--- a/fluster/image/raw_video.py
+++ b/fluster/image/raw_video.py
@@ -1,0 +1,104 @@
+# Fluster - testing framework for decoders conformance
+# Copyright (C) 2021, Fluendo, S.A.
+#  Author: Manuel Jimeno Martínez <mjimeno@fluendo.com>, Fluendo, S.A.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+from pathlib import Path
+from typing import Optional, List
+
+from fluster.image.raw_buffer import RawBuffer
+from fluster.image.raw_image import RawImage, get_meta_from_name
+
+
+class RawVideo:
+    """Class to handle the raw video"""
+
+    def __init__(
+        self,
+        buffer: bytes,
+        video_name: str,
+        width: int,
+        height: int,
+        buffer_type: RawBuffer.Type,
+    ):
+        self._buffer: bytes = buffer
+        self._video_name: str = video_name
+        self._width: int = width
+        self._height: int = height
+        self._buffer_type: RawBuffer.Type = buffer_type
+        self._frames = []
+
+        if buffer_type == RawBuffer.Type.YUV420:
+            if width % 4 != 0 or height % 4 != 0:
+                raise Exception("Width and height must be multiples of 4")
+            len_buffer = (width * height * 3) // 2
+        elif buffer_type == RawBuffer.Type.RGBA:
+            len_buffer = width * height * 4
+        else:
+            raise RuntimeError(f"The type buffer {buffer_type} is not supported")
+
+        # Slice the buffer using len_buffer
+        last_frame_start: int = 0
+        for next_frame_start in range(len_buffer, len(buffer) + 1, len_buffer):
+            self._frames.append(
+                RawImage(
+                    buffer[last_frame_start:next_frame_start],
+                    video_name,
+                    width,
+                    height,
+                    buffer_type,
+                )
+            )
+            last_frame_start = next_frame_start
+
+    @property
+    def frames(self) -> List[RawImage]:
+        """Return the frames of the video"""
+        return self._frames
+
+    @property
+    def width(self) -> int:
+        """Return the width of the video"""
+        return self._width
+
+    @property
+    def height(self) -> int:
+        """Return the height of the video"""
+        return self._height
+
+    @staticmethod
+    def from_file(
+        filename: str,
+        buffer_type: Optional[RawBuffer.Type] = None,
+    ) -> "RawVideo":
+        """Create a RawVideo from a file using the content and the metadata stored in the file name"""
+        file_path = Path(filename)
+
+        if not file_path.exists():
+            raise RuntimeError(f"The file {filename} does not exist")
+
+        buffer = bytes(file_path.read_bytes())
+
+        return RawVideo(buffer, *get_meta_from_name(filename, buffer_type))
+
+    @staticmethod
+    def from_buffer(
+        filename: str,
+        buffer: bytes,
+        buffer_type: RawBuffer.Type,
+    ) -> "RawVideo":
+        """Create a RawVideo from a buffer using the content and the metadata stored in the file name"""
+        return RawVideo(buffer, *get_meta_from_name(filename, buffer_type))

--- a/unit_test/__init__.py
+++ b/unit_test/__init__.py
@@ -1,0 +1,18 @@
+# Fluster - testing framework for decoders conformance
+# Copyright (C) 2021, Fluendo, S.A.
+#  Author: Manuel Jimeno Martínez <mjimeno@fluendo.com>, Fluendo, S.A.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.

--- a/unit_test/raw_image_test.py
+++ b/unit_test/raw_image_test.py
@@ -1,0 +1,112 @@
+# Fluster - testing framework for decoders conformance
+# Copyright (C) 2021, Fluendo, S.A.
+#  Author: Manuel Jimeno Martínez <mjimeno@fluendo.com>, Fluendo, S.A.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+import unittest
+from typing import List
+
+from fluster.image.raw_buffer import RawBuffer
+from fluster.image.raw_image import RawImage
+
+
+class SyntheticImage:
+    """Generate a synthetic RGBA image
+    As we do not want to include image files in the repository,
+    this class is in charge of generating an image with three verticals
+    color bands of at least one pixel."""
+
+    RED = [0xFF, 0, 0, 0xFF]
+    GREEN = [0, 0xFF, 0, 0xFF]
+    BLUE = [0, 0, 0xFF, 0xFF]
+
+    def __init__(
+        self,
+        first_band: List[int],
+        second_band: List[int],
+        third_band: List[int],
+        color_band_width: int,
+        num_rows: int,
+    ) -> None:
+        if color_band_width < 3:
+            raise RuntimeError("color_band_width must be greater or equal than 3")
+
+        color_band_width = color_band_width // 3
+        _row = []
+        _row.extend(first_band * color_band_width)
+        _row.extend(second_band * color_band_width)
+        _row.extend(third_band * color_band_width)
+
+        self._image: bytearray = bytearray(_row * num_rows)
+
+    @property
+    def image(self) -> bytearray:
+        """Returns the image buffer"""
+        return self._image
+
+
+class TestRawImage(unittest.TestCase):
+    """Raw Image unit test"""
+
+    def test_frame_comparison_custom_rgba(self) -> None:
+        """Comparison of 2 identical raw images in RGBA pixel format using custom comparison method"""
+        square_1 = SyntheticImage(
+            SyntheticImage.RED, SyntheticImage.GREEN, SyntheticImage.BLUE, 24, 24
+        )
+        square_2 = SyntheticImage(
+            SyntheticImage.RED, SyntheticImage.GREEN, SyntheticImage.BLUE, 24, 24
+        )
+        source = RawImage(square_1.image, "square_1", 24, 24, RawBuffer.Type.RGBA)
+        target = RawImage(square_2.image, "square_2", 24, 24, RawBuffer.Type.RGBA)
+        self.assertEqual(source.is_equal(target, RawBuffer.Type.RGBA), 0)
+
+    def test_frame_comparison_custom_yuv(self) -> None:
+        """Comparison of 2 identical raw images in YUV420 pixel format using custom comparison method"""
+        square_1 = SyntheticImage(
+            SyntheticImage.RED, SyntheticImage.GREEN, SyntheticImage.BLUE, 24, 24
+        )
+        square_2 = SyntheticImage(
+            SyntheticImage.RED, SyntheticImage.GREEN, SyntheticImage.BLUE, 24, 24
+        )
+        source = RawImage(square_1.image, "square_1", 24, 24, RawBuffer.Type.RGBA)
+        target = RawImage(square_2.image, "square_2", 24, 24, RawBuffer.Type.RGBA)
+        self.assertEqual(source.is_equal(target, RawBuffer.Type.YUV420), 0)
+
+    def test_expected_fail_frame_comparison_custom_rgba(self) -> None:
+        """Comparison with expected fail of 2 different raw images in RGBA pixel format
+        using custom comparison method"""
+        square_1 = SyntheticImage(
+            SyntheticImage.RED, SyntheticImage.GREEN, SyntheticImage.BLUE, 24, 24
+        )
+        square_2 = SyntheticImage(
+            SyntheticImage.GREEN, SyntheticImage.GREEN, SyntheticImage.BLUE, 24, 24
+        )
+        source = RawImage(square_1.image, "square_1", 24, 24, RawBuffer.Type.RGBA)
+        target = RawImage(square_2.image, "square_2", 24, 24, RawBuffer.Type.RGBA)
+        self.assertNotEqual(source.is_equal(target, RawBuffer.Type.RGBA), 0)
+
+    def test_expected_fail_frame_comparison_custom_yuv(self) -> None:
+        """Comparison with expected fail of 2 different raw images in YUV420 pixel format
+        using custom comparison method"""
+        square_1 = SyntheticImage(
+            SyntheticImage.RED, SyntheticImage.GREEN, SyntheticImage.BLUE, 24, 24
+        )
+        square_2 = SyntheticImage(
+            SyntheticImage.GREEN, SyntheticImage.GREEN, SyntheticImage.BLUE, 24, 24
+        )
+        source = RawImage(square_1.image, "square_1", 24, 24, RawBuffer.Type.RGBA)
+        target = RawImage(square_2.image, "square_2", 24, 24, RawBuffer.Type.RGBA)
+        self.assertNotEqual(source.is_equal(target, RawBuffer.Type.RGBA), 0)


### PR DESCRIPTION
- It's the class where we start to use unit tests, in this case, to compare synthetic images in RGBA and YUV420p format.
- Now the .gitignore file includes the files used by pyCharm.
- The makefile file has a new option, test, that scans the unit_test folder and launches all the tests contained in it.
- The CI has a new step that launches the unit tests.
- Added numpy module in Python requirements.txt file, it is needed for PSNR comparison