### PR TITLE
OCP-2399 - Replaced Fraunhofer AAC ref decoder with ISO reference decoder

### DIFF
--- a/fluster/decoders/iso_mpeg4_aac.py
+++ b/fluster/decoders/iso_mpeg4_aac.py
@@ -25,16 +25,19 @@ from fluster.utils import file_checksum, run_command
 
 
 @register_decoder
-class FDKAACDecoder(Decoder):
-    '''FDK AAC reference decoder implementation'''
-    name = "FDK-AAC"
-    description = "FDK AAC reference decoder"
+class ISOAACDecoder(Decoder):
+    '''ISO MPEG4 AAC reference decoder implementation'''
+    name = "ISO-MPEG4-AAC"
+    description = "ISO MPEG4 AAC reference decoder"
     codec = Codec.AAC
-    binary = 'aac-dec'
+    binary = 'mp4audec_mc'
 
     def decode(self, input_filepath: str, output_filepath: str, output_format: OutputFormat, timeout: int,
                verbose: bool) -> str:
         '''Decodes input_filepath in output_filepath'''
+        # Addition of .pcm as extension is a must. If it is something else, e.g. ".out" the decoder will output a
+        # ".wav", which is undesirable.
+        output_filepath += ".pcm"
         run_command([self.binary, input_filepath, output_filepath],
                     timeout=timeout, verbose=verbose)
         return file_checksum(output_filepath)

--- a/test_suites/aac/ISO_IEC_13818-4_2004.json
+++ b/test_suites/aac/ISO_IEC_13818-4_2004.json
@@ -9,7 +9,7 @@
             "source_checksum": "2843464c7d9b40adac27c075ef100705",
             "input_file": "al09_08.adts",
             "output_format": "None",
-            "result": "88a0bbed55df7e505d5529e369e598d5"
+            "result": "385198f06cb664a13c535ff49c04b88c"
         },
         {
             "name": "al09_11",
@@ -17,7 +17,7 @@
             "source_checksum": "d9c69bdd4677c4998591272e6de378e7",
             "input_file": "al09_11.adts",
             "output_format": "None",
-            "result": "a9e96f962a0f7ec82aba4d4b25600ee4"
+            "result": "ada779fe594fdcab99af4fc47e23559f"
         },
         {
             "name": "al09_12",
@@ -25,7 +25,7 @@
             "source_checksum": "cd8ae7d9c7a06f1af755a33683594a98",
             "input_file": "al09_12.adts",
             "output_format": "None",
-            "result": "db6897e43d54eec9617ccbf3f8824be8"
+            "result": "51b5beac5200b2794a7c7e9286314632"
         },
         {
             "name": "al09_16",
@@ -33,7 +33,7 @@
             "source_checksum": "8c91b5fc725fdba3c44c8f2390f89381",
             "input_file": "al09_16.adts",
             "output_format": "None",
-            "result": "c1ffffad1aafbb718422ddeb5ae2e871"
+            "result": "fbc7c9af31c8cdb561f92cb61aaff61c"
         },
         {
             "name": "al09_22",
@@ -41,7 +41,7 @@
             "source_checksum": "683f11281b7830def34ee1f778c7130b",
             "input_file": "al09_22.adts",
             "output_format": "None",
-            "result": "0e6497475f0e0441cb83a7c204fe476d"
+            "result": "42cd6fddbc3e3425c350ee38a01a20c8"
         },
         {
             "name": "al09_24",
@@ -49,7 +49,7 @@
             "source_checksum": "3e5a52c0c73cc9bb46d98d4c28378374",
             "input_file": "al09_24.adts",
             "output_format": "None",
-            "result": "226b880db82dcac840918b459a2a73b0"
+            "result": "b7c13b112a6dde20f831f325bb694aa6"
         },
         {
             "name": "al09_32",
@@ -57,7 +57,7 @@
             "source_checksum": "56e57d9b3c98efaf74c2e75e46b94707",
             "input_file": "al09_32.adts",
             "output_format": "None",
-            "result": "7426aedb64bd0e92bab9d9fa238695bb"
+            "result": "30d1b4ea7670a46a5bd7d19491e753c3"
         },
         {
             "name": "al09_44",
@@ -65,7 +65,7 @@
             "source_checksum": "8d67429688392ceaf915ae92dc0eb14e",
             "input_file": "al09_44.adts",
             "output_format": "None",
-            "result": "1b52ed7f35ece8e67a3b8f5458c94f24"
+            "result": "f94ac68ef4dc6c9bce35a7fd51000ac6"
         },
         {
             "name": "al09_48",
@@ -73,7 +73,7 @@
             "source_checksum": "5be05f18cfcf9340c9967a0d0007e4ad",
             "input_file": "al09_48.adts",
             "output_format": "None",
-            "result": "2638f55d2232727bf942c765e77d9964"
+            "result": "a4af5705b86bec13462ea6483c27802a"
         },
         {
             "name": "al09_64",
@@ -81,7 +81,7 @@
             "source_checksum": "154b9a2a184284d5f27aa9109324578a",
             "input_file": "al09_64.adts",
             "output_format": "None",
-            "result": "dfb9200512a6bfbd9682901b7791e304"
+            "result": "5f92fd7fada10e5dbd08b9587f19e8e1"
         },
         {
             "name": "al09_88",
@@ -89,7 +89,7 @@
             "source_checksum": "a4d5e526f7c0fc8fb048aad54e4d71c2",
             "input_file": "al09_88.adts",
             "output_format": "None",
-            "result": "a63a2bf8dd983630e0b5f266a25901d2"
+            "result": "ad8bb96b3ac329ba4b290233f22401f8"
         },
         {
             "name": "al09_96",
@@ -97,7 +97,15 @@
             "source_checksum": "5ccaa6962dbbe8a7988990834b588b61",
             "input_file": "al09_96.adts",
             "output_format": "None",
-            "result": "3b2617321d971d30784f0e0a7381f916"
+            "result": "74b3d242c6ac44779826115cfc15c46d"
+        },
+        {
+            "name": "al12_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_13818-4_2004_Conformance_Testing/AAC/compressedAdts/al12_48.adts",
+            "source_checksum": "27929bfbce9d06fb61274cb013d04e9a",
+            "input_file": "al12_48.adts",
+            "output_format": "None",
+            "result": "d4497dd09304c27484a4461b2f568b60"
         },
         {
             "name": "al13_48",
@@ -105,17 +113,7 @@
             "source_checksum": "92e966b0c730d9dcde6373636d869534",
             "input_file": "al13_48.adts",
             "output_format": "None",
-            "result": "c501b080cb6f35cd5e7f1383be63be0f"
-        }
-    ],
-    "failing_test_vectors": [
-        {
-            "name": "al12_48",
-            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_13818-4_2004_Conformance_Testing/AAC/compressedAdts/al12_48.adts",
-            "source_checksum": "27929bfbce9d06fb61274cb013d04e9a",
-            "input_file": "al12_48.adts",
-            "output_format": "None",
-            "result": ""
+            "result": "dbbebf84893807b7180eb7c9cc36099a"
         },
         {
             "name": "as18_08",
@@ -123,7 +121,7 @@
             "source_checksum": "a64588993a1bb52acfedb21df39e9b78",
             "input_file": "as18_08.adts",
             "output_format": "None",
-            "result": ""
+            "result": "1f6f96bd1d3b052e95286c93ebd24160"
         },
         {
             "name": "as18_11",
@@ -131,7 +129,7 @@
             "source_checksum": "f5ffb91d23d125853afcb8297d925404",
             "input_file": "as18_11.adts",
             "output_format": "None",
-            "result": ""
+            "result": "c6ce39ac9f3a19c727c9f1a6df0a3b24"
         },
         {
             "name": "as18_12",
@@ -139,7 +137,7 @@
             "source_checksum": "b745ffe579e4832c214c6de012485f1f",
             "input_file": "as18_12.adts",
             "output_format": "None",
-            "result": ""
+            "result": "6c33d452b9f9e9c11be869296a706c60"
         },
         {
             "name": "as18_16",
@@ -147,7 +145,7 @@
             "source_checksum": "a5bb06ebb5238ebd2539f481515aec11",
             "input_file": "as18_16.adts",
             "output_format": "None",
-            "result": ""
+            "result": "6a12f289a1f5a4f51b5b32364cb9dd01"
         },
         {
             "name": "as18_22",
@@ -155,7 +153,7 @@
             "source_checksum": "5369c26e819fa6ea569007ad629ac0ec",
             "input_file": "as18_22.adts",
             "output_format": "None",
-            "result": ""
+            "result": "7bdf3d0d5f144e49024717fd9a8a269b"
         },
         {
             "name": "as18_24",
@@ -163,7 +161,7 @@
             "source_checksum": "192ab015b67c34d36d22aa0675ca5560",
             "input_file": "as18_24.adts",
             "output_format": "None",
-            "result": ""
+            "result": "e683ef621ad09675f21632b06f89b894"
         },
         {
             "name": "as18_32",
@@ -171,7 +169,7 @@
             "source_checksum": "e12fc78483b5c2a5bf4cab5aca1cd921",
             "input_file": "as18_32.adts",
             "output_format": "None",
-            "result": ""
+            "result": "9cc0ae49da101bd127a800aad247abf3"
         },
         {
             "name": "as18_44",
@@ -179,7 +177,7 @@
             "source_checksum": "b4b616b26ab554ed57ea7014de845cc0",
             "input_file": "as18_44.adts",
             "output_format": "None",
-            "result": ""
+            "result": "81ea5c9925e1537495ac8698793d761d"
         },
         {
             "name": "as18_48",
@@ -187,7 +185,7 @@
             "source_checksum": "e5fd7fb3db6bea960171e155ffcd81f2",
             "input_file": "as18_48.adts",
             "output_format": "None",
-            "result": ""
+            "result": "cd4d8fa4ce36a8b2d727f31b9d467f3b"
         },
         {
             "name": "as18_64",
@@ -195,7 +193,7 @@
             "source_checksum": "8b9d9f7969f20284dcb670c51b425d93",
             "input_file": "as18_64.adts",
             "output_format": "None",
-            "result": ""
+            "result": "de4eada5809199644d621d62c4d2b306"
         },
         {
             "name": "as18_88",
@@ -203,7 +201,7 @@
             "source_checksum": "c565798d39dbbc3a0c3dcb07d7210df8",
             "input_file": "as18_88.adts",
             "output_format": "None",
-            "result": ""
+            "result": "201a8ee48bfa77a78679dd26646382ac"
         },
         {
             "name": "as18_96",
@@ -211,7 +209,7 @@
             "source_checksum": "5fca7fa515d86d5910147cc909bfc9fb",
             "input_file": "as18_96.adts",
             "output_format": "None",
-            "result": ""
+            "result": "24f35893403e126343fa56bdb3c6f9d7"
         },
         {
             "name": "as19_08",
@@ -219,7 +217,7 @@
             "source_checksum": "035f0a74173468a7940e901da1599d55",
             "input_file": "as19_08.adts",
             "output_format": "None",
-            "result": ""
+            "result": "bce7bf321502962190947a6b504801e7"
         },
         {
             "name": "as19_11",
@@ -227,7 +225,7 @@
             "source_checksum": "f6415137c41dd5ce5572659abbd61333",
             "input_file": "as19_11.adts",
             "output_format": "None",
-            "result": ""
+            "result": "5dda30abdc4fa3399c8fa1a7c602bca8"
         },
         {
             "name": "as19_12",
@@ -235,7 +233,7 @@
             "source_checksum": "1e22b357bef8f7a32fb5a0655a03cc65",
             "input_file": "as19_12.adts",
             "output_format": "None",
-            "result": ""
+            "result": "33d07752b3f3d2beb45a705754be6584"
         },
         {
             "name": "as19_16",
@@ -243,7 +241,7 @@
             "source_checksum": "4a7dda41b06c18a35b9f9d7dbad42bc7",
             "input_file": "as19_16.adts",
             "output_format": "None",
-            "result": ""
+            "result": "17af6ae5dbd337a059710648c9ff996d"
         },
         {
             "name": "as19_22",
@@ -251,7 +249,7 @@
             "source_checksum": "21a24c98f9c0c871422050e31ff5a27a",
             "input_file": "as19_22.adts",
             "output_format": "None",
-            "result": ""
+            "result": "e4152a4e3bce0c8ce8665a1615f9e8f5"
         },
         {
             "name": "as19_24",
@@ -259,7 +257,7 @@
             "source_checksum": "d95b1df14e768ae90fecebab57219b58",
             "input_file": "as19_24.adts",
             "output_format": "None",
-            "result": ""
+            "result": "d622aee91247ec1273194aa6de5c9745"
         },
         {
             "name": "as19_32",
@@ -267,7 +265,7 @@
             "source_checksum": "9e4044870f052175df24acdd6d04cd39",
             "input_file": "as19_32.adts",
             "output_format": "None",
-            "result": ""
+            "result": "eb269af031d50a8b3bed859d6bd25a4a"
         },
         {
             "name": "as19_44",
@@ -275,7 +273,7 @@
             "source_checksum": "5622d850cdae2178bf8cca590fdfa011",
             "input_file": "as19_44.adts",
             "output_format": "None",
-            "result": ""
+            "result": "06180286f29acf2b250cc6e29bd3a0a3"
         },
         {
             "name": "as19_48",
@@ -283,7 +281,7 @@
             "source_checksum": "a7a3032f2d9abb74ba53c59f8edaefec",
             "input_file": "as19_48.adts",
             "output_format": "None",
-            "result": ""
+            "result": "ba89239240bc73639dfb558223bc6fc2"
         },
         {
             "name": "as19_64",
@@ -291,7 +289,7 @@
             "source_checksum": "e45128742ebd2432e82c007f18a631b9",
             "input_file": "as19_64.adts",
             "output_format": "None",
-            "result": ""
+            "result": "a5b63ad2134366d0b149854439dd87be"
         },
         {
             "name": "as19_88",
@@ -299,7 +297,7 @@
             "source_checksum": "5843d8d610d372283455b48f74cbe0d3",
             "input_file": "as19_88.adts",
             "output_format": "None",
-            "result": ""
+            "result": "71511bbda2ff1142753fb067b8248d99"
         },
         {
             "name": "as19_96",
@@ -307,7 +305,7 @@
             "source_checksum": "78ecb299d42f2aa4aa07d15240013e78",
             "input_file": "as19_96.adts",
             "output_format": "None",
-            "result": ""
+            "result": "0f7b79ceebf35154b63adf2d3ddd4ca5"
         },
         {
             "name": "as20_08",
@@ -315,7 +313,7 @@
             "source_checksum": "ad7d08193b166cf1c46ff84a3f3ebb7d",
             "input_file": "as20_08.adts",
             "output_format": "None",
-            "result": ""
+            "result": "88514de302080fc199c2c5426fbbb256"
         },
         {
             "name": "as20_11",
@@ -323,7 +321,7 @@
             "source_checksum": "6d3260070f0e55a02e41272edce11d23",
             "input_file": "as20_11.adts",
             "output_format": "None",
-            "result": ""
+            "result": "c3f2298751f0b3c9b2d50ff8b4fd9d4e"
         },
         {
             "name": "as20_12",
@@ -331,7 +329,7 @@
             "source_checksum": "f694118f7ff688c2915d6fe4060bef33",
             "input_file": "as20_12.adts",
             "output_format": "None",
-            "result": ""
+            "result": "15e83d3892a9532d46c4be01cd78cbe8"
         },
         {
             "name": "as20_16",
@@ -339,7 +337,7 @@
             "source_checksum": "a8ec01e8aa200ed65dbae8459b438df6",
             "input_file": "as20_16.adts",
             "output_format": "None",
-            "result": ""
+            "result": "84a7aa3b4b6cd9fc132916c32b7141f1"
         },
         {
             "name": "as20_22",
@@ -347,7 +345,7 @@
             "source_checksum": "3cefa90c24155f261826bebb95065fe0",
             "input_file": "as20_22.adts",
             "output_format": "None",
-            "result": ""
+            "result": "0238c48dee49b5c46d17c87889ad9d7d"
         },
         {
             "name": "as20_24",
@@ -355,7 +353,7 @@
             "source_checksum": "711515116cd73b67d1f76862edc9cb10",
             "input_file": "as20_24.adts",
             "output_format": "None",
-            "result": ""
+            "result": "d5e46ba493f520194429846c1b377589"
         },
         {
             "name": "as20_32",
@@ -363,7 +361,7 @@
             "source_checksum": "f9de9178603479f2575db585cc944622",
             "input_file": "as20_32.adts",
             "output_format": "None",
-            "result": ""
+            "result": "33fef2e3a0d96972297b51ff0662abd4"
         },
         {
             "name": "as20_44",
@@ -371,7 +369,7 @@
             "source_checksum": "c6c903ccd30accc90b44dbe556bf3701",
             "input_file": "as20_44.adts",
             "output_format": "None",
-            "result": ""
+            "result": "279af7b736395078a76289d9983e149d"
         },
         {
             "name": "as20_48",
@@ -379,7 +377,7 @@
             "source_checksum": "569bb98829b5a308c3bb9c7afc83cdc6",
             "input_file": "as20_48.adts",
             "output_format": "None",
-            "result": ""
+            "result": "fa1e9486032f1dd20d3a4c5d760553d2"
         },
         {
             "name": "as20_64",
@@ -387,7 +385,7 @@
             "source_checksum": "da230df29e16888934ef7a64ca544243",
             "input_file": "as20_64.adts",
             "output_format": "None",
-            "result": ""
+            "result": "a49b9fdaac7c3bc18d7ea3254fc994b7"
         },
         {
             "name": "as20_88",
@@ -395,7 +393,7 @@
             "source_checksum": "d9a81756fa3880d19821de84ca37dd9a",
             "input_file": "as20_88.adts",
             "output_format": "None",
-            "result": ""
+            "result": "babc22cc098d8e7d797fbaa41e6663e4"
         },
         {
             "name": "as20_96",
@@ -403,7 +401,7 @@
             "source_checksum": "0ffe6dc8a1a8817bc9f4f95bb0a272cf",
             "input_file": "as20_96.adts",
             "output_format": "None",
-            "result": ""
+            "result": "6f8594ae06969889a84608bf6ffd5e63"
         },
         {
             "name": "as21_08",
@@ -411,7 +409,7 @@
             "source_checksum": "a8ba0949a1e983cb076dafa6726082d4",
             "input_file": "as21_08.adts",
             "output_format": "None",
-            "result": ""
+            "result": "04c3c5d0994244b9a0abb57f0a20a211"
         },
         {
             "name": "as21_11",
@@ -419,7 +417,7 @@
             "source_checksum": "09b1c407c41e2370417abb5dedffce9c",
             "input_file": "as21_11.adts",
             "output_format": "None",
-            "result": ""
+            "result": "cdfca8758bec798142cf6d5337aa5f5b"
         },
         {
             "name": "as21_12",
@@ -427,7 +425,7 @@
             "source_checksum": "939556a3ce7d04dc581db45317147d08",
             "input_file": "as21_12.adts",
             "output_format": "None",
-            "result": ""
+            "result": "db64f9c3f19a8136737977be740bfdff"
         },
         {
             "name": "as21_16",
@@ -435,7 +433,7 @@
             "source_checksum": "29c98dae5c26f6739fa449607dc6adf9",
             "input_file": "as21_16.adts",
             "output_format": "None",
-            "result": ""
+            "result": "b44abf44783aebd3abc2478522c5889c"
         },
         {
             "name": "as21_22",
@@ -443,7 +441,7 @@
             "source_checksum": "316b53896aff83108f32d2db8aa39fcf",
             "input_file": "as21_22.adts",
             "output_format": "None",
-            "result": ""
+            "result": "04d847223c86171e00fe677929ee3186"
         },
         {
             "name": "as21_24",
@@ -451,7 +449,7 @@
             "source_checksum": "7d54f1ca0dea1a42491252e61e0b0ade",
             "input_file": "as21_24.adts",
             "output_format": "None",
-            "result": ""
+            "result": "d619feee354716ce44a7c2966b9ab000"
         },
         {
             "name": "as21_32",
@@ -459,7 +457,7 @@
             "source_checksum": "af841a1ebdefb2a40cd819c174fc1be6",
             "input_file": "as21_32.adts",
             "output_format": "None",
-            "result": ""
+            "result": "e3c9a074b3d1d32d8c38d6bc3bd25492"
         },
         {
             "name": "as21_44",
@@ -467,7 +465,7 @@
             "source_checksum": "8318287c05fcdde7031de892a154dc7a",
             "input_file": "as21_44.adts",
             "output_format": "None",
-            "result": ""
+            "result": "d862ac356292d4b0822cdf6aa76b9c16"
         },
         {
             "name": "as21_48",
@@ -475,7 +473,7 @@
             "source_checksum": "1c98f957869644bbc3f1095d0ee90ec4",
             "input_file": "as21_48.adts",
             "output_format": "None",
-            "result": ""
+            "result": "d9c561723a11e490b82c34f8405c9e79"
         },
         {
             "name": "as21_64",
@@ -483,7 +481,7 @@
             "source_checksum": "6c595906c5e563a765ed97c825719cc6",
             "input_file": "as21_64.adts",
             "output_format": "None",
-            "result": ""
+            "result": "ad991bc9a517fb82965911570146a624"
         },
         {
             "name": "as21_88",
@@ -491,7 +489,7 @@
             "source_checksum": "d1675729e2333effc6fcc50ab0b5e94b",
             "input_file": "as21_88.adts",
             "output_format": "None",
-            "result": ""
+            "result": "54c1a5c135243bf076dfcaef2672cfb5"
         },
         {
             "name": "as21_96",
@@ -499,7 +497,7 @@
             "source_checksum": "5f31709d01b272dd9434e5800dd948dd",
             "input_file": "as21_96.adts",
             "output_format": "None",
-            "result": ""
+            "result": "0ec45e077a46af9ed983f847701abb0e"
         }
     ]
 }

--- a/test_suites/aac/ISO_IEC_14496-26_2010.json
+++ b/test_suites/aac/ISO_IEC_14496-26_2010.json
@@ -9,7 +9,7 @@
             "source_checksum": "354eeece733c86fc4f22b63c2a6e0dbc",
             "input_file": "al18_08.adts",
             "output_format": "None",
-            "result": "ecdae29ff39024947a4e1c8a4306257e"
+            "result": "b2927751ae7a97613a9d9d0d2748eca7"
         },
         {
             "name": "al18_22",
@@ -17,7 +17,7 @@
             "source_checksum": "9bd1df720da86de0f12a5e13cd9bac3f",
             "input_file": "al18_22.adts",
             "output_format": "None",
-            "result": "5f8292a7e5fb470c89254b35790eaef6"
+            "result": "9c650228dea2c563560dcf3fbc31bff1"
         },
         {
             "name": "al18_32",
@@ -25,7 +25,7 @@
             "source_checksum": "fbfbcc287abaa61bb1d4e6209dc7b351",
             "input_file": "al18_32.adts",
             "output_format": "None",
-            "result": "e4c3e8eeb8da0ae9fe78e3156514c01f"
+            "result": "26c2430033002a138568d17ca3317ade"
         },
         {
             "name": "al18_64",
@@ -33,7 +33,7 @@
             "source_checksum": "908ef86a5c5b546f2707e7abf6a4fcbf",
             "input_file": "al18_64.adts",
             "output_format": "None",
-            "result": "18802e6ef0f2a269334bd979b4cd007e"
+            "result": "756d27e1b1bead05839758072cea9690"
         },
         {
             "name": "al18_96",
@@ -41,17 +41,15 @@
             "source_checksum": "3a2cc79299fb52481170cced3441b5de",
             "input_file": "al18_96.adts",
             "output_format": "None",
-            "result": "1baa05fb8532952e16edf36c0f75025b"
-        }
-    ],
-    "failing_test_vectors": [
+            "result": "02b0f333d4caa37379a8ab513dbc4dbf"
+        },
         {
             "name": "ap01_48",
             "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedAdts/add-opt/ap01_48.adts",
             "source_checksum": "fb59fdf49e4c6ca1b7a766ce2112e36f",
             "input_file": "ap01_48.adts",
             "output_format": "None",
-            "result": ""
+            "result": "cb8a260c08236e342d2122496ae126d9"
         },
         {
             "name": "ap02_48",
@@ -59,7 +57,7 @@
             "source_checksum": "f918c11808e687e6dc5a64154d0685b3",
             "input_file": "ap02_48.adts",
             "output_format": "None",
-            "result": ""
+            "result": "57f4964f065c75fa825bf7c795ae621f"
         },
         {
             "name": "ap04_48",
@@ -67,7 +65,7 @@
             "source_checksum": "07092bd549a107aab9546b4a7e0ececa",
             "input_file": "ap04_48.adts",
             "output_format": "None",
-            "result": ""
+            "result": "6e1767241de43646691c21587ccbab9f"
         },
         {
             "name": "ap05_48",
@@ -75,7 +73,7 @@
             "source_checksum": "9470863a3df3daf3d4a47a8226933501",
             "input_file": "ap05_48.adts",
             "output_format": "None",
-            "result": ""
+            "result": "e5f3db7043119313eb29f6f670989ecd"
         }
     ]
 }


### PR DESCRIPTION
Makefile
~ modified aac_reference_decoder target to correspond to steps needed
to build ISO MPEG4 AAC decoder
+ added new "clean" target to be able to delete all content of ./contrib folder
~ refactored other targets to use logical OR "||" instead of pipe operation "|"
to "true"

renamed fdk-aac.py to iso_mpeg4_aac.py

ISO_IEC_13818-4_2004, ISO_IEC_14496-26_2010
~ moved previously failing test vectors into test vector section because they
pass with ISO decoder
+ replaced and added "result" md5 checksums of all test vectors to correspond to the
ISO decoder