### PR TITLE
OCP-2433 Add time spent running a test suite to the summary

### DIFF
--- a/fluster/fluster.py
+++ b/fluster/fluster.py
@@ -320,6 +320,21 @@ class Fluster:
                 output += (
                     f"{test_suite.test_vectors_success}/{len(test_suite.test_vectors)}|"
                 )
+            output += "\n|TOTAL TIME|"
+            for test_suite in test_suites:
+                # Substract from the total time that took running a test suite on a decoder
+                # the timeouts. This is not ideal since we won't be comparing decoding the
+                # same number of test vectors, but at least it is much better than comparing
+                # total times when timeouts are such a huge part of the global time taken.
+                timeouts = sum(
+                    [
+                        ctx.timeout
+                        for tv in test_suite.test_vectors.values()
+                        if tv.test_result == TestVectorResult.TIMEOUT
+                    ]
+                )
+                total_time = test_suite.time_taken - timeouts
+                output += f"{total_time:.3f}s|"
             output += separator if first else ""
             return output
 


### PR DESCRIPTION
Add a new row to the summary including the total time taken to execute the test suite for each decoder.
The only catch here is what to do with timeouts. I decided to substract the time spent in test vectors that end up in timeout. This way, we are not always comparing the same amount of test vectors decoded, but at least we're not poisoning the results if 1 or more test vectors give timeout.

e.g.
```
./fluster.py run -d FFmpeg-H.264 FFmpeg-H.264-VAAPI GStreamer-H.264-VAAPI-Gst1.0 -j1 -s
```


|Test|FFmpeg-H.264|FFmpeg-H.264-VAAPI|GStreamer-H.264-VAAPI-Gst1.0|
|-|-|-|-|
|TOTAL|120/135|120/135|121/135|
|TOTAL TIME|17.801s|26.751s|36.319s|
|-|-|-|-|
|AUD_MW_E|✔️|✔️|✔️|
|BA1_FT_C|✔️|✔️|✔️|
|BA1_Sony_D|✔️|✔️|✔️|
|BA2_Sony_F|✔️|✔️|✔️|
|BA3_SVA_C|✔️|✔️|✔️|
|BA_MW_D|✔️|✔️|✔️|
|BAMQ1_JVC_C|✔️|✔️|✔️|
|BAMQ2_JVC_C|✔️|✔️|✔️|
|BANM_MW_D|✔️|✔️|✔️|
|BASQP1_Sony_C|✔️|✔️|✔️|
|CABA1_Sony_D|✔️|✔️|✔️|
|CABA1_SVA_B|✔️|✔️|✔️|
|CABA2_Sony_E|✔️|✔️|✔️|
|CABA2_SVA_B|✔️|✔️|✔️|
|CABA3_Sony_C|✔️|✔️|✔️|
|CABA3_SVA_B|✔️|✔️|✔️|
|CABA3_TOSHIBA_E|✔️|✔️|✔️|
|cabac_mot_fld0_full|✔️|✔️|✔️|
|cabac_mot_frm0_full|✔️|✔️|✔️|
|cabac_mot_mbaff0_full|✔️|✔️|✔️|
|cabac_mot_picaff0_full|✔️|✔️|✔️|
|CABACI3_Sony_B|✔️|✔️|✔️|
|CABAST3_Sony_E|✔️|✔️|✔️|
|CABASTBR3_Sony_B|✔️|✔️|✔️|
|CABREF3_Sand_D|✔️|✔️|✔️|
|CACQP3_Sony_D|✔️|✔️|✔️|
|CAFI1_SVA_C|✔️|✔️|✔️|
|CAMA1_Sony_C|✔️|✔️|✔️|
|CAMA1_TOSHIBA_B|✔️|✔️|✔️|
|cama1_vtc_c|✔️|✔️|✔️|
|cama2_vtc_b|✔️|✔️|✔️|
|CAMA3_Sand_E|✔️|✔️|✔️|
|cama3_vtc_b|✔️|✔️|✔️|
|CAMACI3_Sony_C|✔️|✔️|✔️|
|CAMANL1_TOSHIBA_B|✔️|✔️|✔️|
|CAMANL2_TOSHIBA_B|✔️|✔️|✔️|
|CAMANL3_Sand_E|✔️|✔️|✔️|
|CAMASL3_Sony_B|✔️|✔️|✔️|
|CAMP_MOT_MBAFF_L30|✔️|✔️|✔️|
|CAMP_MOT_MBAFF_L31|✔️|✔️|✔️|
|CANL1_Sony_E|✔️|✔️|✔️|
|CANL1_SVA_B|✔️|✔️|✔️|
|CANL1_TOSHIBA_G|✔️|✔️|✔️|
|CANL2_Sony_E|✔️|✔️|✔️|
|CANL2_SVA_B|✔️|✔️|✔️|
|CANL3_Sony_C|✔️|✔️|✔️|
|CANL3_SVA_B|✔️|✔️|✔️|
|CANL4_SVA_B|✔️|✔️|✔️|
|CANLMA2_Sony_C|✔️|✔️|✔️|
|CANLMA3_Sony_C|✔️|✔️|✔️|
|CAPA1_TOSHIBA_B|✔️|✔️|✔️|
|CAPAMA3_Sand_F|✔️|✔️|✔️|
|CAPCM1_Sand_E|✔️|✔️|✔️|
|CAPCMNL1_Sand_E|✔️|✔️|✔️|
|CAPM3_Sony_D|✔️|✔️|✔️|
|CAQP1_Sony_B|✔️|✔️|✔️|
|cavlc_mot_fld0_full_B|✔️|✔️|✔️|
|cavlc_mot_frm0_full_B|✔️|✔️|✔️|
|cavlc_mot_mbaff0_full_B|✔️|✔️|✔️|
|cavlc_mot_picaff0_full_B|✔️|✔️|✔️|
|CAWP1_TOSHIBA_E|✔️|✔️|✔️|
|CAWP5_TOSHIBA_E|✔️|✔️|✔️|
|CI1_FT_B|✔️|✔️|✔️|
|CI_MW_D|✔️|✔️|✔️|
|CVBS3_Sony_C|✔️|✔️|✔️|
|CVCANLMA2_Sony_C|✔️|✔️|✔️|
|CVFC1_Sony_C|❌|❌|❌|
|CVFI1_Sony_D|✔️|✔️|✔️|
|CVFI1_SVA_C|✔️|✔️|✔️|
|CVFI2_Sony_H|✔️|✔️|✔️|
|CVFI2_SVA_C|✔️|✔️|✔️|
|CVMA1_Sony_D|✔️|✔️|✔️|
|CVMA1_TOSHIBA_B|✔️|✔️|✔️|
|CVMANL1_TOSHIBA_B|✔️|✔️|✔️|
|CVMANL2_TOSHIBA_B|✔️|✔️|✔️|
|CVMAPAQP3_Sony_E|❌|❌|✔️|
|CVMAQP2_Sony_G|✔️|✔️|✔️|
|CVMAQP3_Sony_D|✔️|✔️|✔️|
|CVMP_MOT_FLD_L30_B|✔️|✔️|✔️|
|CVMP_MOT_FRM_L31_B|✔️|✔️|✔️|
|CVNLFI1_Sony_C|✔️|✔️|✔️|
|CVNLFI2_Sony_H|✔️|✔️|✔️|
|CVPA1_TOSHIBA_B|✔️|✔️|✔️|
|CVPCMNL1_SVA_C|✔️|✔️|✔️|
|CVPCMNL2_SVA_C|✔️|✔️|❌|
|CVSE2_Sony_B|❌|❌|✔️|
|CVSE3_Sony_H|❌|❌|✔️|
|CVSEFDFT3_Sony_E|❌|❌|✔️|
|CVWP1_TOSHIBA_E|✔️|✔️|✔️|
|CVWP2_TOSHIBA_E|✔️|✔️|✔️|
|CVWP3_TOSHIBA_E|✔️|✔️|✔️|
|CVWP5_TOSHIBA_E|✔️|✔️|✔️|
|FI1_Sony_E|✔️|✔️|✔️|
|FM1_BT_B|☠|☠|☠|
|FM1_FT_E|❌|❌|☠|
|FM2_SVA_C|☠|☠|☠|
|HCBP1_HHI_A|✔️|✔️|✔️|
|HCBP2_HHI_A|✔️|✔️|✔️|
|HCMP1_HHI_A|✔️|✔️|✔️|
|LS_SVA_D|✔️|✔️|✔️|
|MIDR_MW_D|✔️|✔️|✔️|
|MPS_MW_A|✔️|✔️|✔️|
|MR1_BT_A|✔️|✔️|✔️|
|MR1_MW_A|✔️|✔️|✔️|
|MR2_MW_A|✔️|✔️|✔️|
|MR2_TANDBERG_E|✔️|✔️|☠|
|MR3_TANDBERG_B|❌|❌|☠|
|MR4_TANDBERG_C|✔️|✔️|☠|
|MR5_TANDBERG_C|✔️|✔️|☠|
|MR6_BT_B|✔️|✔️|❌|
|MR7_BT_B|❌|❌|❌|
|MR8_BT_B|✔️|✔️|⌛|
|MR9_BT_B|❌|❌|✔️|
|MV1_BRCM_D|✔️|✔️|✔️|
|NL1_Sony_D|✔️|✔️|✔️|
|NL2_Sony_H|✔️|✔️|✔️|
|NL3_SVA_E|✔️|✔️|✔️|
|NLMQ1_JVC_C|✔️|✔️|✔️|
|NLMQ2_JVC_C|✔️|✔️|✔️|
|NRF_MW_E|✔️|✔️|✔️|
|Sharp_MP_Field_1_B|✔️|✔️|✔️|
|Sharp_MP_Field_2_B|✔️|✔️|✔️|
|Sharp_MP_Field_3_B|✔️|✔️|✔️|
|Sharp_MP_PAFF_1r2|❌|❌|✔️|
|Sharp_MP_PAFF_2r|❌|❌|✔️|
|SL1_SVA_B|✔️|✔️|✔️|
|SP1_BT_A|❌|❌|☠|
|sp2_bt_b|❌|❌|☠|
|SVA_BA1_B|✔️|✔️|✔️|
|SVA_BA2_D|✔️|✔️|✔️|
|SVA_Base_B|✔️|✔️|✔️|
|SVA_CL1_E|✔️|✔️|✔️|
|SVA_FM1_E|✔️|✔️|✔️|
|SVA_NL1_B|✔️|✔️|✔️|
|SVA_NL2_E|✔️|✔️|✔️|
|-|-|-|-|
|Test|FFmpeg-H.264|FFmpeg-H.264-VAAPI|GStreamer-H.264-VAAPI-Gst1.0|
|TOTAL|120/135|120/135|121/135|
|TOTAL TIME|17.801s|26.751s|36.319s|
