### PR TITLE
Warning if not test vectors

### DIFF
--- a/fluster/test_suite.py
+++ b/fluster/test_suite.py
@@ -395,6 +395,10 @@ class TestSuite:
         test_suite = self.clone()
         tests = test_suite.generate_tests(ctx)
         if not tests:
+            extra = ""
+            if ctx.test_vectors:
+                extra = "with names: " + ", ".join(ctx.test_vectors)
+            print(f"No test vectors for suite {self.name} {extra}")
             return None
 
         print("*" * 100)


### PR DESCRIPTION
If the user, by mistake, uses -tv instead of -ts fluster doesn't
execute any test but doesn't complain either.

Example
```
$ ./fluster.py run -d FFmpeg-H.264 -tv JVT-AVC_V1
$ echo $?
1
```

After change:

```
$ ./fluster.py run -d FFmpeg-H.264 -tv JVT-AVC_V1
No test vectors for suite JVT-AVC_V1 with names: jvt-avc_v1
$ echo $?
1
```

Note: I don't usually confuse arguments, it's for a friend.