### PR TITLE
pylint: Set min-similarity-lines to 20

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -363,7 +363,7 @@ ignore-docstrings=yes
 ignore-imports=yes
 
 # Minimum lines number of a similarity.
-min-similarity-lines=8
+min-similarity-lines=20
 
 
 [BASIC]


### PR DESCRIPTION
Increase the line limit for duplicate-code with min-similarity-lines
of 20

Fixes issue with last commit:
```
pylint fluster --fail-under=10
************* Module fluster.decoders.gstreamer
fluster/decoders/gstreamer.py:1:0: R0801: Similar lines in 2 files
==fluster.decoders.av1_aom:33
==fluster.decoders.libvpx:38
    def decode(
        self,
        input_filepath: str,
        output_filepath: str,
        output_format: OutputFormat,
        timeout: int,
        verbose: bool,
    ) -> str:
        """Decodes input_filepath in output_filepath"""
        run_command(
            [self.binary, "--i420", input_filepath, "-o", output_filepath],
            timeout=timeout,
            verbose=verbose,
        )
        return file_checksum(output_filepath) (duplicate-code)

-----------------------------------
Your code has been rated at 9.99/10
```