### PR TITLE
gstreamer: Avoid writing back raw image file to disk

### DIFF
--- a/fluster/decoder.py
+++ b/fluster/decoder.py
@@ -49,6 +49,7 @@ class Decoder(ABC):
         output_format: OutputFormat,
         timeout: int,
         verbose: bool,
+        keep_files: bool,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         raise Exception("Not implemented")

--- a/fluster/decoders/av1_aom.py
+++ b/fluster/decoders/av1_aom.py
@@ -38,8 +38,10 @@ class AV1AOMDecoder(Decoder):
         output_format: OutputFormat,
         timeout: int,
         verbose: bool,
+        keep_files: bool,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
+        # pylint: disable=unused-argument
         run_command(
             [self.binary, "--i420", input_filepath, "-o", output_filepath],
             timeout=timeout,

--- a/fluster/decoders/chromium.py
+++ b/fluster/decoders/chromium.py
@@ -48,7 +48,9 @@ class ChromiumH264(Decoder):
             output_format: OutputFormat,
             timeout: int,
             verbose: bool,
+            keep_files: bool,
     ) -> str:
+        # pylint: disable=unused-argument
         return str(main(input_filepath))
 
     @lru_cache(maxsize=None)

--- a/fluster/decoders/dummy.py
+++ b/fluster/decoders/dummy.py
@@ -36,5 +36,7 @@ class Dummy(Decoder):
         output_format: OutputFormat,
         timeout: int,
         verbose: bool,
+        keep_files: bool,
     ) -> str:
+        # pylint: disable=unused-argument
         return file_checksum(input_filepath)

--- a/fluster/decoders/ffmpeg.py
+++ b/fluster/decoders/ffmpeg.py
@@ -52,8 +52,10 @@ class FFmpegDecoder(Decoder):
         output_format: OutputFormat,
         timeout: int,
         verbose: bool,
+        keep_files: bool,
     ) -> str:
         '''Decodes input_filepath in output_filepath'''
+        # pylint: disable=unused-argument
         cmd = shlex.split(FFMPEG_TPL.format(
             self.cmd, input_filepath, str(output_format.value), output_filepath))
         run_command(cmd, timeout=timeout, verbose=verbose)

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -21,12 +21,13 @@
 import shlex
 import subprocess
 from functools import lru_cache
+from typing import Optional, Tuple
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
 from fluster.utils import file_checksum, run_command, normalize_binary_cmd
 
-PIPELINE_TPL = '{} filesrc location={} ! {} ! {} ! {} location={}'
+PIPELINE_TPL = '{} filesrc location={} ! {} ! {} ! {} {}'
 
 
 @lru_cache(maxsize=None)
@@ -71,10 +72,29 @@ class GStreamer(Decoder):
         if not gst_element_exists(self.sink):
             self.sink = 'filesink'
 
-    def gen_pipeline(self, input_filepath: str, output_filepath: str, output_format: OutputFormat) -> str:
+    def gen_pipeline(self, input_filepath: str, output_filepath: Optional[str], output_format: OutputFormat) -> str:
         '''Generate the GStreamer pipeline used to decode the test vector'''
         # pylint: disable=unused-argument
-        return PIPELINE_TPL.format(self.cmd, input_filepath, self.decoder_bin, self.caps, self.sink, output_filepath)
+        output = "location={}".format(output_filepath) if output_filepath else ""
+        return PIPELINE_TPL.format(self.cmd, input_filepath, self.decoder_bin, self.caps, self.sink, output)
+
+    def parse_md5sum(self, data: Tuple[str, str], verbose: bool) -> str:
+        '''Parse the MD5 sum out of commandline output'''
+        md5sum = "error"
+        for line in filter(None, data):
+            if verbose:
+                print(line, end='')
+            pattern = "conformance/checksum, checksum-type=(string)MD5, checksum=(string)"
+            sum_start = line.find(pattern)
+            if sum_start > 0:
+                sum_start += len(pattern)
+                sum_end = line[sum_start:].find(";")
+                if sum_end > 0:
+                    sum_end += sum_start
+                    md5sum = line[sum_start:sum_end]
+                    if not verbose:
+                        return md5sum
+        return md5sum
 
     def decode(
         self,
@@ -86,7 +106,29 @@ class GStreamer(Decoder):
         keep_files: bool,
     ) -> str:
         '''Decode the test vector and do the checksum'''
-	# pylint: disable=unused-argument
+        # When using videocodectestsink we can avoid writing files to disk
+        # completely, or avoid a full raw file read in order to compute the MD5
+        # SUM.
+        if self.sink == 'videocodectestsink':
+            output_param = output_filepath if keep_files else None
+            pipeline = self.gen_pipeline(
+                input_filepath, output_param, output_format)
+            command = shlex.split(pipeline)
+            command.append("-m")
+            serr = subprocess.DEVNULL if not verbose else None
+            if verbose:
+                print(f'\nRunning command "{" ".join(command)}"')
+
+            try:
+                with subprocess.Popen(command, stdout=subprocess.PIPE,
+                                      stderr=serr, universal_newlines=True) as pipe:
+                    data = pipe.communicate(timeout=timeout)
+                    return self.parse_md5sum(data, verbose)
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
+                # Developer experience improvement (facilitates copy/paste)
+                ex.cmd = " ".join(ex.cmd)
+                raise ex
+
         pipeline = self.gen_pipeline(
             input_filepath, output_filepath, output_format)
         run_command(shlex.split(pipeline), timeout=timeout, verbose=verbose)
@@ -117,9 +159,10 @@ class GStreamer10Video(GStreamer):
     sink = 'videocodectestsink'
     provider = 'GStreamer'
 
-    def gen_pipeline(self, input_filepath: str, output_filepath: str, output_format: OutputFormat) -> str:
+    def gen_pipeline(self, input_filepath: str, output_filepath: Optional[str], output_format: OutputFormat) -> str:
         caps = f'{self.caps} ! videoconvert dither=none ! video/x-raw,format={output_format_to_gst(output_format)}'
-        return PIPELINE_TPL.format(self.cmd, input_filepath, self.decoder_bin, caps, self.sink, output_filepath)
+        output = "location={}".format(output_filepath) if output_filepath else ""
+        return PIPELINE_TPL.format(self.cmd, input_filepath, self.decoder_bin, caps, self.sink, output)
 
 
 class GStreamer10Audio(GStreamer):
@@ -164,7 +207,6 @@ class GStreamerLibavVP8(GStreamer10Video):
     codec = Codec.VP8
     decoder_bin = ' ivfparse ! avdec_vp8 '
     api = 'Libav'
-    sink = 'filesink'
     hw_acceleration = False
 
 
@@ -346,7 +388,6 @@ class GStreamerLibvpxVP8(GStreamer10Video):
     codec = Codec.VP8
     decoder_bin = ' ivfparse ! vp8dec '
     api = 'libvpx'
-    sink = 'filesink'
     hw_acceleration = False
 
 

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -83,8 +83,10 @@ class GStreamer(Decoder):
         output_format: OutputFormat,
         timeout: int,
         verbose: bool,
+        keep_files: bool,
     ) -> str:
         '''Decode the test vector and do the checksum'''
+	# pylint: disable=unused-argument
         pipeline = self.gen_pipeline(
             input_filepath, output_filepath, output_format)
         run_command(shlex.split(pipeline), timeout=timeout, verbose=verbose)

--- a/fluster/decoders/h264_jct_vt.py
+++ b/fluster/decoders/h264_jct_vt.py
@@ -38,8 +38,10 @@ class H264JCTVTDecoder(Decoder):
         output_format: OutputFormat,
         timeout: int,
         verbose: bool,
+        keep_files: bool,
     ) -> str:
         '''Decodes input_filepath in output_filepath'''
+        # pylint: disable=unused-argument
         run_command([self.binary, '-s', '-i', input_filepath, '-o',
                      output_filepath], timeout=timeout, verbose=verbose)
         return file_checksum(output_filepath)

--- a/fluster/decoders/h265_jct_vt.py
+++ b/fluster/decoders/h265_jct_vt.py
@@ -38,8 +38,10 @@ class H265JCTVTDecoder(Decoder):
         output_format: OutputFormat,
         timeout: int,
         verbose: bool,
+        keep_files: bool,
     ) -> str:
         '''Decodes input_filepath in output_filepath'''
+        # pylint: disable=unused-argument
         run_command([self.binary, '-b', input_filepath,
                      '-o', output_filepath], timeout=timeout, verbose=verbose)
         return file_checksum(output_filepath)

--- a/fluster/decoders/h266_vvdec.py
+++ b/fluster/decoders/h266_vvdec.py
@@ -31,8 +31,9 @@ class H266JCTVTDecoder(Decoder):
     binary = 'vvdecapp'
 
     def decode(self, input_filepath: str, output_filepath: str, output_format: OutputFormat, timeout: int,
-               verbose: bool) -> str:
+               verbose: bool, keep_files: bool) -> str:
         '''Decodes input_filepath in output_filepath'''
+        # pylint: disable=unused-argument
         run_command([self.binary, '-b', input_filepath,
                      '-o', output_filepath], timeout=timeout, verbose=verbose)
         return file_checksum(output_filepath)

--- a/fluster/decoders/iso_mpeg4_aac.py
+++ b/fluster/decoders/iso_mpeg4_aac.py
@@ -33,8 +33,9 @@ class ISOAACDecoder(Decoder):
     binary = 'mp4audec_mc'
 
     def decode(self, input_filepath: str, output_filepath: str, output_format: OutputFormat, timeout: int,
-               verbose: bool) -> str:
+               verbose: bool, keep_files: bool) -> str:
         '''Decodes input_filepath in output_filepath'''
+        # pylint: disable=unused-argument
         # Addition of .pcm as extension is a must. If it is something else, e.g. ".out" the decoder will output a
         # ".wav", which is undesirable.
         output_filepath += ".pcm"

--- a/fluster/decoders/libvpx.py
+++ b/fluster/decoders/libvpx.py
@@ -43,8 +43,10 @@ class VPXDecoder(Decoder):
         output_format: OutputFormat,
         timeout: int,
         verbose: bool,
+        keep_files: bool,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
+        # pylint: disable=unused-argument
         run_command(
             [self.binary, "--i420", input_filepath, "-o", output_filepath],
             timeout=timeout,

--- a/fluster/test.py
+++ b/fluster/test.py
@@ -74,6 +74,7 @@ class Test(unittest.TestCase):
                 self.test_vector.output_format,
                 self.timeout,
                 self.verbose,
+                self.keep_files,
             )
         except TimeoutExpired:
             self.test_suite.test_vectors[


### PR DESCRIPTION
When videocodectestsink is used, the MD5 sum can be computed directly by that sink without writing the image to disk. This improves slightly the test speed, specially with slow rootfs like some SD cards and NFS. This is currently only implemented for GStreamer, though other decoder have this capability. The file will be written to disk if the -k option is passed.