### PR TITLE
Fix parse argument error with Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ VP9
 ```bash
 ./fluster.py --help
 
-usage: fluster.py [-h] [-r RESOURCES] [-o OUTPUT] [-ne] [-tsd TEST_SUITES_DIR] {list,l,run,r,download,d,reference} ...
+usage: fluster.py [-h] [-r RESOURCES] [-o OUTPUT] [-ne] [-tsd TEST_SUITES_DIR] {list,l,run,r,download,d,reference,f} ...
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -234,7 +234,7 @@ subcommands:
     list (l)            show list of available test suites and decoders
     run (r)             run test suites for decoders
     download (d)        downloads test suites resources
-    reference (r)       use a specific decoder to set its results for the test suites given
+    reference (f)       use a specific decoder to set its results for the test suites given
 ```
 
 ### List

--- a/fluster/main.py
+++ b/fluster/main.py
@@ -249,7 +249,7 @@ class Main:
     def _add_reference_cmd(self, subparsers: Any) -> None:
         subparser = subparsers.add_parser(
             "reference",
-            aliases=["r"],
+            aliases=["f"],
             help="use a specific decoder to set its results for the test suites given",
         )
         subparser.add_argument(


### PR DESCRIPTION
"r" was used as alias for run and reference command. The solution was use "f" for the reference command.

Error:
```
root@5d2dda135e50:/fluster# python ./fluster.py
Traceback (most recent call last):
  File "/fluster/./fluster.py", line 25, in <module>
    main = Main()
           ^^^^^^
  File "/fluster/fluster/main.py", line 44, in __init__
    self.parser = self._create_parser()
                  ^^^^^^^^^^^^^^^^^^^^^
  File "/fluster/fluster/main.py", line 115, in _create_parser
    self._add_reference_cmd(subparsers)
  File "/fluster/fluster/main.py", line 244, in _add_reference_cmd
    subparser = subparsers.add_parser(
                ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/argparse.py", line 1188, in add_parser
    raise ArgumentError(
argparse.ArgumentError: argument {list,l,run,r,download,d}: conflicting subparser alias: r
```

Fix issue #120 reported by @ceyusa. Moitas grazas.