### PR TITLE
COM-5670: Fix GA CI failures due to distro upgrade from Ubuntu 20.04 to 22.04

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Latest changes to ubuntu-latest distro (before 20.04, after 22.04) introduced by github to GA broke our CI.

This is a fix that sets 20.04 as our preferred distro version