### PR TITLE
Fallback to cwd as a base path for resources_dir & results_dir

### DIFF
--- a/fluster/main.py
+++ b/fluster/main.py
@@ -58,12 +58,21 @@ class Main:
         ):
             self.test_suites_dir = TEST_SUITES_DIR_SYS
 
+        # If the resources dir doesn't exist under the script location, fallback
+        # to the current working directory.
         self.resources_dir = os.path.join(
             os.path.join(os.path.dirname(__file__), ".."), RESOURCES_DIR
         )
+        if not os.path.exists(self.resources_dir):
+            self.resources_dir = os.path.join(os.getcwd(), RESOURCES_DIR)
+
+        # If the results dir doesn't exist under the script location, fallback
+        # to the current working directory.
         self.results_dir = os.path.join(
             os.path.join(os.path.dirname(__file__), ".."), RESULTS_DIR
         )
+        if not os.path.exists(self.results_dir):
+            self.results_dir = os.path.join(os.getcwd(), RESULTS_DIR)
 
         self.parser = self._create_parser()
 


### PR DESCRIPTION
Fluster defaults to using the script location as a base path for the resources & results. This works fine for local runs of fluster, when one is just calling fluster from a directory (e.g. ./fluster.py) but when fluster is installed in a read-only system directory (e.g. /usr/lib/python3.11/dist-packages/fluster for Debian) then the resources and results cannot be written unless running as superuser.

Modify this behavior so that if the resources or results directories cannot be found under the script path, use the current working directory as a base path for these directories to allow fluster to be ran from a system installation.