### PR TITLE
Add GStreamer based VVdeC decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ application that runs a number of test suites with the supported decoders. Its
 purpose is to check different decoder implementations against known test suites
 with known and proven results. It was originally designed to check the
 conformance of H.265/HEVC decoders, but it also supports H.264/AVC, H.266/VVC,
-VP8, VP9, AV1 and AAC. It can easily be extended to add more decoders and test 
+VP8, VP9, AV1 and AAC. It can easily be extended to add more decoders and test
 suites.
 
 ## Table of Contents
@@ -248,6 +248,7 @@ AAC
     ISO-MPEG4-AAC: ISO MPEG4 AAC reference decoder... ✔️
 
 H266
+    GStreamer-H.266-VVdeC-Gst1.0: GStreamer H.266 VVdeC decoder for GStreamer 1.0... ✔
     VVdeC-H266: VVdeC H.266/VVC reference decoder... ✔️
 
 ```
@@ -294,6 +295,7 @@ H266
 - Fluendo's proprietary decoders for H.264/AVC and H.265/HEVC that are included
   in [Fluendo Codec
   Pack](https://fluendo.com/en/products/enterprise/fluendo-codec-pack/).
+- [GStreamer's](https://gstreamer.freedesktop.org/) for H.266/VVC.
 - [GStreamer's](https://gstreamer.freedesktop.org/) for H.265/HEVC.
 - [GStreamer's](https://gstreamer.freedesktop.org/) for H.264/AVC.
 - [FFmpeg's](https://FFmpeg.org) for H.265/HEVC.
@@ -512,7 +514,7 @@ results are obtained, we can do the following procedure:
    gstreamer1.0-tools gstreamer1.0-libav gstreamer1.0-plugins-bad ffmpeg
    vpx-tools aom-tools
    ```
-   
+
 5. Create a new PR with your changes.
 6. Make sure the GitHub Actions is running and its result is a pass.
 

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -45,6 +45,8 @@ def gst_element_exists(element: str) -> bool:
 def output_format_to_gst(output_format: OutputFormat) -> str:
     """Return GStreamer pixel format"""
     mapping = {
+        OutputFormat.GRAY: "GRAY8",
+        OutputFormat.GRAY16LE: "GRAY16_LE",
         OutputFormat.YUV420P: "I420",
         OutputFormat.YUV422P: "Y42B",
         OutputFormat.YUV420P10LE: "I420_10LE",
@@ -56,7 +58,8 @@ def output_format_to_gst(output_format: OutputFormat) -> str:
         OutputFormat.YUV444P12LE: "Y444_12LE",
     }
     if output_format not in mapping:
-        raise Exception(f"No matching output format found in GStreamer for {output_format}")
+        raise Exception(
+            f"No matching output format found in GStreamer for {output_format}")
     return mapping[output_format]
 
 
@@ -598,6 +601,15 @@ class GStreamerNvdecSLVP9Gst10Decoder(GStreamer10Video):
 
 
 @register_decoder
+class GStreamerVVdeCH266Decoder(GStreamer10Video):
+    '''GStreamer H.266/VVC VVdeC decoder implementation for GStreamer 1.0'''
+    codec = Codec.H266
+    decoder_bin = ' h266parse ! vvdec '
+    api = 'VVdeC'
+    hw_acceleration = False
+
+
+@register_decoder
 class FluendoH265Gst10Decoder(GStreamer10Video):
     '''Fluendo H.265 software decoder implementation for GStreamer 1.0'''
     codec = Codec.H265
@@ -747,6 +759,7 @@ class FluendoFluVAH264DecGst10Decoder(GStreamer10Video):
 @register_decoder
 class FluendoFluAACDecGst10Decoder(GStreamer10Audio):
     '''Fluendo AAC plugin decoder for GStreamer 1.0'''
+
     def __init__(self) -> None:
         self.codec = Codec.AAC
         self.decoder_bin = 'fluaacdec trim=0'

--- a/test_suites/h266/JVET-VVC_draft6.json
+++ b/test_suites/h266/JVET-VVC_draft6.json
@@ -8,7 +8,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b400_A_Bytedance_2.zip",
             "source_checksum": "36b6db0ef4992c4f1c00d5f43e7fb405",
             "input_file": "10b400_A_Bytedance_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "gray",
             "result": "9607a0890e78ad7b3ca728356e919670"
         },
         {
@@ -16,7 +16,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b400_B_Bytedance_2.zip",
             "source_checksum": "fe845074ca1771ce480956d434bb049c",
             "input_file": "10b400_B_Bytedance_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "gray",
             "result": "b5fcc1c52de8ed51844a9bd2895bda75"
         },
         {
@@ -24,7 +24,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b422_A_Sony_4.zip",
             "source_checksum": "743f6e4fb9a7c58964122baa1dcc8193",
             "input_file": "10b422_A_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "d533b392ba919081dfe18b05d7486577"
         },
         {
@@ -32,7 +32,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b422_B_Sony_4.zip",
             "source_checksum": "03cacbd2d2afc04808940575c2720758",
             "input_file": "10b422_B_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "07b7afb458a9af6eefe97cbd9ee427b6"
         },
         {
@@ -40,7 +40,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b422_C_Sony_4.zip",
             "source_checksum": "5713f5b64c58a1b2c41e145ddaaf5787",
             "input_file": "10b422_C_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "72e8cb16b5c7fe0bd4afe8b559a76a2b"
         },
         {
@@ -48,7 +48,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b422_D_Sony_4.zip",
             "source_checksum": "2a9b822aab285dc821eff0982c9cee71",
             "input_file": "10b422_D_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "5dd0001c69c72aad6d36147dcbc12306"
         },
         {
@@ -56,7 +56,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b422_E_Sony_4.zip",
             "source_checksum": "328605f71000ce0df12630dc37c5c8fc",
             "input_file": "10b422_E_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "ec6598bf2b2a0911839cd05abd556d6d"
         },
         {
@@ -64,7 +64,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b422_F_Sony_4.zip",
             "source_checksum": "fdf918d6dcc1b9e955420c520a8007fc",
             "input_file": "10b422_F_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "bac3571fa37265eb33d2db2ce50764c3"
         },
         {
@@ -72,7 +72,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b422_G_Sony_4.zip",
             "source_checksum": "efb2cafdca2ac62a818c45ad2a80a160",
             "input_file": "10b422_G_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "a0c2214bb4314e6988265644a8d04dd"
         },
         {
@@ -80,7 +80,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b422_H_Sony_4.zip",
             "source_checksum": "6c7dfe197c7c745fd492668c5276f6b7",
             "input_file": "10b422_H_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "94bf2c6a9b6fbe44cdac60f9e0f4546"
         },
         {
@@ -88,7 +88,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b422_I_Sony_4.zip",
             "source_checksum": "4e9066a9861d9d4e86037294478f6d8b",
             "input_file": "10b422_I_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "df80063e016f93e1c38f6c19e662523"
         },
         {
@@ -96,7 +96,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b422_J_Sony_4.zip",
             "source_checksum": "73f72770e36a50ca0ffb31205de95d1e",
             "input_file": "10b422_J_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "36023e5941125bbd22427579b781167"
         },
         {
@@ -104,7 +104,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b422_K_Sony_4.zip",
             "source_checksum": "a9762f8c5a65e002b7fa02dd4b5638d0",
             "input_file": "10b422_K_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "e43e9e77af39e642116affc270aa861"
         },
         {
@@ -112,7 +112,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b422_L_Sony_4.zip",
             "source_checksum": "ecaa38dd80610be0c779a7663f0892c2",
             "input_file": "10b422_L_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "64006ce220defda7d56162a663eba68"
         },
         {
@@ -120,7 +120,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b444_A_Kwai_3.zip",
             "source_checksum": "7ded2342d1ccf642f502ec4f2ef34045",
             "input_file": "10b444_A_Kwai_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p10le",
             "result": "a276feb78b6802d0fc677949756f3b56"
         },
         {
@@ -128,7 +128,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/10b444_B_Kwai_3.zip",
             "source_checksum": "1e5997a8eec1dde218076739947f856e",
             "input_file": "10b444_B_Kwai_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p10le",
             "result": "ce315ce9703c865686ae2acbb7527f5d"
         },
         {
@@ -136,7 +136,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b400_A_Bytedance_2.zip",
             "source_checksum": "cc78af98aedadad36fa2314b50a06c0e",
             "input_file": "8b400_A_Bytedance_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "gray",
             "result": "87e14541c2b6568a109a5505c73950db"
         },
         {
@@ -144,7 +144,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b400_B_Bytedance_2.zip",
             "source_checksum": "11431e0d1e44997a6e72e32a60301cde",
             "input_file": "8b400_B_Bytedance_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "gray",
             "result": "7fc9d86c78d08a8cdcaf097367ad2754"
         },
         {
@@ -168,7 +168,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b422_A_Sony_4.zip",
             "source_checksum": "74dae5cdb6e517b0a2f0013a0bf6d405",
             "input_file": "8b422_A_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "f64390cbd838aa2946bed2f7ab80b501"
         },
         {
@@ -176,7 +176,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b422_B_Sony_4.zip",
             "source_checksum": "bee7332961b227ae5ff12f10c7cef78e",
             "input_file": "8b422_B_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "7cc342e2d705207e12228dd6474e2ea0"
         },
         {
@@ -184,7 +184,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b422_C_Sony_4.zip",
             "source_checksum": "96c2f6b3294998255a15765c11d3ea67",
             "input_file": "8b422_C_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "4046611e823c3676de77743195780350"
         },
         {
@@ -192,7 +192,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b422_D_Sony_4.zip",
             "source_checksum": "fab5de9ae6cb167f5d4ea295639d4865",
             "input_file": "8b422_D_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "6de6008cfcf7d56bfb63716a5a799547"
         },
         {
@@ -200,7 +200,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b422_E_Sony_4.zip",
             "source_checksum": "7f1d5082adc0fcbf63dc97e4a26c9dc2",
             "input_file": "8b422_E_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "12a912d71fcb006412e1ff15b86bf6d9"
         },
         {
@@ -208,7 +208,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b422_F_Sony_4.zip",
             "source_checksum": "0234226b96753983c12dc0d27d29bde9",
             "input_file": "8b422_F_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "23c2413cf3e2d5f432e328cbd766155b"
         },
         {
@@ -216,7 +216,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b422_G_Sony_4.zip",
             "source_checksum": "2c65e721d95eb2fcede38998f2a7cc8c",
             "input_file": "8b422_G_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "a9c89f267dd7e12a1de2edbd4402f90"
         },
         {
@@ -224,7 +224,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b422_H_Sony_4.zip",
             "source_checksum": "7a433e7cb5a3ca5ffbc59430d108dd90",
             "input_file": "8b422_H_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "e578d185867ec608ee7b2870097a987"
         },
         {
@@ -232,7 +232,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b422_I_Sony_4.zip",
             "source_checksum": "ac2b779443f9b7a30772e6606027c4bc",
             "input_file": "8b422_I_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "932b829861b061d02eb05a3daf6839e"
         },
         {
@@ -240,7 +240,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b422_J_Sony_4.zip",
             "source_checksum": "2fb2f5b67847eefdbe29609ed74ee5da",
             "input_file": "8b422_J_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "c19a6128a9b3a8bb0d9a43e5c003bba"
         },
         {
@@ -248,7 +248,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b422_K_Sony_4.zip",
             "source_checksum": "092db552d66bb14db9189e096f57f012",
             "input_file": "8b422_K_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "71cdb0d3a1092a39058fd760c140c40"
         },
         {
@@ -256,7 +256,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b422_L_Sony_4.zip",
             "source_checksum": "c8694d127161080da961e961595995e8",
             "input_file": "8b422_L_Sony_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv422p10le",
             "result": "be226c5b19556208329b3a05a987ecd"
         },
         {
@@ -264,7 +264,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b444_A_Kwai_2.zip",
             "source_checksum": "42cf3592bbc7fc2b7ea16f397220c0ea",
             "input_file": "8b444_A_Kwai_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p",
             "result": "a09794d71c019f39ec2e8c24a7ddd66"
         },
         {
@@ -272,7 +272,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/8b444_B_Kwai_2.zip",
             "source_checksum": "22d22a3c7c4d5e68963b2a4f0247e41b",
             "input_file": "8b444_B_Kwai_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p",
             "result": "9eed80777631a3ddb465962a9540f8f"
         },
         {
@@ -280,7 +280,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ACT_A_Kwai_3.zip",
             "source_checksum": "76482612ce25776c5fb8f7aebea7b5b8",
             "input_file": "ACT_A_Kwai_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "01e987b04081c75215a5c1f7d64ffd5"
         },
         {
@@ -288,7 +288,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ACT_B_Kwai_3.zip",
             "source_checksum": "62238d991341e3e671db799bdda87b98",
             "input_file": "ACT_B_Kwai_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "86a2a29e40369937c64bb567ed702e0"
         },
         {
@@ -296,7 +296,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ACTPIC_A_Huawei_3.zip",
             "source_checksum": "1ad1276719d67fc57c6904ac2295b3d5",
             "input_file": "ACTPIC_A_Huawei_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "d0e3566e21ee4a969f8a7d14885834b9"
         },
         {
@@ -304,7 +304,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ACTPIC_B_Huawei_3.zip",
             "source_checksum": "56acdabe762da595a77f6a97cd0ac681",
             "input_file": "ACTPIC_B_Huawei_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "adc5cd053f833bd677ffdaa04d018c00"
         },
         {
@@ -312,7 +312,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ACTPIC_C_Huawei_3.zip",
             "source_checksum": "cb94a491cba6370b0ac03b4d50bd8775",
             "input_file": "ACTPIC_C_Huawei_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "d0e3566e21ee4a969f8a7d14885834b9"
         },
         {
@@ -320,7 +320,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/AFF_A_HUAWEI_2.zip",
             "source_checksum": "55b1afb4b910c064527fc882614211ee",
             "input_file": "AFF_A_HUAWEI_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "8732ee1301282050a105f5549c2e18ed"
         },
         {
@@ -328,7 +328,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/AFF_B_HUAWEI_2.zip",
             "source_checksum": "5329e089c6e872240dd40ee55ab01a55",
             "input_file": "AFF_B_HUAWEI_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "8ebbbd37e7837550d98cf62996eb89be"
         },
         {
@@ -336,7 +336,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ALF_A_Huawei_3.zip",
             "source_checksum": "8d83451f65e1f2f58801aacd8ae9deec",
             "input_file": "ALF_A_Huawei_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "c74f2112dcf7c7621d5780e70c304f16"
         },
         {
@@ -344,7 +344,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ALF_B_Huawei_3.zip",
             "source_checksum": "bcb72d4318fe7f249c5335aeeb268971",
             "input_file": "ALF_B_Huawei_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "708118e71c27cc409dfd7310dc787cc7"
         },
         {
@@ -352,7 +352,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ALF_C_KDDI_3.zip",
             "source_checksum": "9ef3120283e87d770576960ba5c5c5de",
             "input_file": "ALF_C_KDDI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "3abac29208179fef1664347126da5dbc"
         },
         {
@@ -360,7 +360,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ALF_D_Qualcomm_2.zip",
             "source_checksum": "60b3f63674cfef04b7e4d1c8f76da7ae",
             "input_file": "ALF_D_Qualcomm_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "7aebfea44c63e17ca00d39886e71d1fb"
         },
         {
@@ -368,7 +368,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/AMVR_A_HHI_3.zip",
             "source_checksum": "adbdeaac8217f9d2d05473d88325105e",
             "input_file": "AMVR_A_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "df0859af7e5e787c7875e81cc5232ea2"
         },
         {
@@ -376,7 +376,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/AMVR_B_HHI_3.zip",
             "source_checksum": "1adddf44e8ffdd5275dfef63068f5481",
             "input_file": "AMVR_B_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "d6ca91941fbed14c437549be665bbcd0"
         },
         {
@@ -384,7 +384,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/APSALF_A_Qualcomm_2.zip",
             "source_checksum": "c43abdc0fb551951c20dd88a52c49b5e",
             "input_file": "APSALF_A_Qualcomm_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "7aebfea44c63e17ca00d39886e71d1fb"
         },
         {
@@ -392,7 +392,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/APSLMCS_A_Dolby_3.zip",
             "source_checksum": "1412c7e05b8fd137f3b62bdaad911184",
             "input_file": "APSLMCS_A_Dolby_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "391ffc3c77fb4ec244030bbb45d0464d"
         },
         {
@@ -400,7 +400,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/APSLMCS_B_Dolby_3.zip",
             "source_checksum": "0c122aa9891dc5865b1a3a24d448b261",
             "input_file": "APSLMCS_B_Dolby_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "c07378acf6b111fd506d89458f592993"
         },
         {
@@ -408,7 +408,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/APSLMCS_C_Dolby_2.zip",
             "source_checksum": "d5dae25457fc4588497ac50ebe0d39b0",
             "input_file": "APSLMCS_C_Dolby_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "7ae6e3706bbaab4cb025b77ed917146d"
         },
         {
@@ -416,7 +416,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/APSLMCS_D_Dolby_1.zip",
             "source_checksum": "03ea51c8fdb3fa5ad850bde203fbf765",
             "input_file": "APSLMCS_D_Dolby_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "2aa1e8a92bb5fb2b93099d56ee9d53e2"
         },
         {
@@ -424,7 +424,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/APSLMCS_E_Dolby_1.zip",
             "source_checksum": "69cb3bd07807fb70842bd8079283d9f2",
             "input_file": "APSLMCS_E_Dolby_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "1adcd17ef8d441243507de20cb4914d5"
         },
         {
@@ -432,7 +432,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/APSMULT_A_MediaTek_4.zip",
             "source_checksum": "5518f0ab1432c0c1e903998ceacba1c1",
             "input_file": "APSMULT_A_MediaTek_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "29957adb94778ef3f4fcbaadd54a8095"
         },
         {
@@ -440,7 +440,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/APSMULT_B_MediaTek_4.zip",
             "source_checksum": "83b118f26d1ad28b96e2096d42a83b1a",
             "input_file": "APSMULT_B_MediaTek_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "18d54fb93415be2c2902ffa37565162c"
         },
         {
@@ -448,7 +448,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/AUD_A_Broadcom_3.zip",
             "source_checksum": "097925e3365509b7191b7aec4c74d537",
             "input_file": "AUD_A_Broadcom_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "5318620364f1f8f6153da3212a62a1f6"
         },
         {
@@ -456,7 +456,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/BCW_A_MediaTek_4.zip",
             "source_checksum": "0dbc6610fb454be39c0b9210d06bd0bf",
             "input_file": "BCW_A_MediaTek_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "9804d9d9c53fd4732a4fc7acce633fb6"
         },
         {
@@ -464,7 +464,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/BDOF_A_MediaTek_4.zip",
             "source_checksum": "a656bbf473c24ca5dbe959aa205b24e2",
             "input_file": "BDOF_A_MediaTek_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "0494d8059dcb77344e3489c6fb4e3dfe"
         },
         {
@@ -472,7 +472,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/BDPCM_A_Orange_2.zip",
             "source_checksum": "e89e89c1cd7ec1667a18c0805c02f357",
             "input_file": "BDPCM_A_Orange_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "8add42eff974256a352c802e95ec9196"
         },
         {
@@ -480,7 +480,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/BOUNDARY_A_Huawei_3.zip",
             "source_checksum": "2262a19d6ef53c654efa7099926588b3",
             "input_file": "BOUNDARY_A_Huawei_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "2d194d115e7e9c05d7883571a2908e3b"
         },
         {
@@ -488,7 +488,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/BUMP_A_LGE_2.zip",
             "source_checksum": "0d7f0e827f02d8ce1cbc608133a37c1e",
             "input_file": "BUMP_A_LGE_2/BUMP_A_LGE_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "390895aec22ab1cb9a38a2e08b1b297b"
         },
         {
@@ -496,7 +496,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/BUMP_B_LGE_2.zip",
             "source_checksum": "7bde2b030d6fc40d77045f2ae30d3b2e",
             "input_file": "BUMP_B_LGE_2/BUMP_B_LGE_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "390895aec22ab1cb9a38a2e08b1b297b"
         },
         {
@@ -504,7 +504,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/BUMP_C_LGE_2.zip",
             "source_checksum": "36fd305711aee5b7738e45cabf5db1b7",
             "input_file": "BUMP_C_LGE_2/BUMP_C_LGE_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "390895aec22ab1cb9a38a2e08b1b297b"
         },
         {
@@ -512,7 +512,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CCALF_A_Sharp_3.zip",
             "source_checksum": "b50a86478f35b5c08e830be5c5a29a8c",
             "input_file": "CCALF_A_Sharp_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "3749afdcffa73b9da0e53b57c7f7bbe8"
         },
         {
@@ -520,7 +520,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CCALF_B_Sharp_3.zip",
             "source_checksum": "340fd737ed3e1d6251ad9b21ebcd1377",
             "input_file": "CCALF_B_Sharp_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "430ea233ad4f9d72a92fbece14dc010d"
         },
         {
@@ -528,7 +528,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CCALF_C_Sharp_3.zip",
             "source_checksum": "dd31bac2642e54fb138fd2bc2f90abad",
             "input_file": "CCALF_C_Sharp_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "dba16561d87ae452d95fdba7512c81b4"
         },
         {
@@ -536,7 +536,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CCALF_D_Sharp_3.zip",
             "source_checksum": "c290b6a6e7bab022bf717bcf6241ae57",
             "input_file": "CCALF_D_Sharp_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "81ffb84c91b73c6858322423d2355570"
         },
         {
@@ -544,7 +544,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CCLM_A_KDDI_2.zip",
             "source_checksum": "e6dea74c8390de49e280e7c44043fed1",
             "input_file": "CCLM_A_KDDI_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "deffc9c6f33da9d28f6e17955bc939d8"
         },
         {
@@ -552,7 +552,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CIIP_A_MediaTek_4.zip",
             "source_checksum": "099718ef5f93d35185583b2ae0af53e2",
             "input_file": "CIIP_A_MediaTek_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "5e2ecadc49c897ad466f325474d78467"
         },
         {
@@ -576,7 +576,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CodingToolsSets_C_Tencent_2.zip",
             "source_checksum": "b08534a83f9d5168085641f008009434",
             "input_file": "CodingToolsSets_C_Tencent_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "0d71aaa3bd6449f58deeca24fd9f4789"
         },
         {
@@ -584,7 +584,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CodingToolsSets_D_Tencent_2.zip",
             "source_checksum": "49a8f5d5e7003c63f3e10db3fecbf2a8",
             "input_file": "CodingToolsSets_D_Tencent_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "23746a9ccab972cf26e6948a56d2bb96"
         },
         {
@@ -592,7 +592,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CodingToolsSets_E_Tencent_1.zip",
             "source_checksum": "6fe72ed5936202258579e1dcb24939d2",
             "input_file": "CodingToolsSets_E_Tencent_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "304093bb838857d32d8d2f197b13da7d"
         },
         {
@@ -600,7 +600,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CROP_A_Panasonic_3.zip",
             "source_checksum": "0f178441152aea0375a3eee0d2647b8d",
             "input_file": "CROP_A_Panasonic_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "54ea60d96a4602fd61572e383050abd4"
         },
         {
@@ -608,7 +608,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CROP_B_Panasonic_4.zip",
             "source_checksum": "c85a61e0919d61bd8f54f12dc6af55f1",
             "input_file": "CROP_B_Panasonic_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p10le",
             "result": "bc7aa270283fbadfc7c74fd754a4fa64"
         },
         {
@@ -616,7 +616,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CST_A_MediaTek_4.zip",
             "source_checksum": "64eb59c00971b03d01b0a0d1c7e079e2",
             "input_file": "CST_A_MediaTek_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "f920c5e0d02fd24f0dc68a6f9ff9b439"
         },
         {
@@ -624,7 +624,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CTU_A_MediaTek_4.zip",
             "source_checksum": "e6c66de86d87932c069c74ad3ce4bd4b",
             "input_file": "CTU_A_MediaTek_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "86bd5f24f6cd633d1a81e1cb38b1c3bc"
         },
         {
@@ -632,7 +632,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CTU_B_MediaTek_4.zip",
             "source_checksum": "438e7f5d9b6886e301d90e19bcf9e047",
             "input_file": "CTU_B_MediaTek_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "9a99f7fc6a19bde180169773098384db"
         },
         {
@@ -640,7 +640,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CTU_C_MediaTek_4.zip",
             "source_checksum": "338c8591af6c084e92057f3be9b6eea2",
             "input_file": "CTU_C_MediaTek_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "aab83fe630972dc3c98d93baa853e3a6"
         },
         {
@@ -648,7 +648,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CUBEMAP_A_MediaTek_3.zip",
             "source_checksum": "5efecb54ee777a4cd6020a7b86d42382",
             "input_file": "CUBEMAP_A_MediaTek_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "c21e46ca755ac54bc08b5a10087effb7"
         },
         {
@@ -656,7 +656,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CUBEMAP_B_MediaTek_3.zip",
             "source_checksum": "f057ac011f4f38aa2d1dbde5a6035b90",
             "input_file": "CUBEMAP_B_MediaTek_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "78cc534a99ea16595d9393afb551a7f5"
         },
         {
@@ -664,7 +664,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/CUBEMAP_C_MediaTek_3.zip",
             "source_checksum": "b8eed8d69254dbc8b7d24e2bc387a832",
             "input_file": "CUBEMAP_C_MediaTek_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "98a8fa9f24e1bb019484f58bd3ad7e3d"
         },
         {
@@ -672,7 +672,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/DCI_A_Tencent_3.zip",
             "source_checksum": "d6ae548d9ef3a07359640212335c77e1",
             "input_file": "DCI_A_Tencent_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "3c28960461ee746886032ada5ca32336"
         },
         {
@@ -680,7 +680,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/DCI_B_Tencent_3.zip",
             "source_checksum": "b0b915bd68ff17d00a583081f539c244",
             "input_file": "DCI_B_Tencent_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "3c28960461ee746886032ada5ca32336"
         },
         {
@@ -688,7 +688,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/DEBLOCKING_A_Sharp_3.zip",
             "source_checksum": "a2c2bfab128c76a9b71afe2de28617a8",
             "input_file": "DEBLOCKING_A_Sharp_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "566bbee74cd034e892f82a7a49099a22"
         },
         {
@@ -696,7 +696,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/DEBLOCKING_B_Sharp_2.zip",
             "source_checksum": "dbf577b36b18ba8ff1edfea28ecf3afc",
             "input_file": "DEBLOCKING_B_Sharp_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "6a8992d65d430a4ce086f26b87997ea3"
         },
         {
@@ -704,7 +704,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/DEBLOCKING_C_Huawei_3.zip",
             "source_checksum": "bf10c7331358ab87dd0f45f7ce728e56",
             "input_file": "DEBLOCKING_C_Huawei_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "df88d9af5bf2452aff0b9121d79d835d"
         },
         {
@@ -712,7 +712,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/DEBLOCKING_E_Ericsson_3.zip",
             "source_checksum": "00cb7f8ffa5bcbd38117bdcbfc4971ec",
             "input_file": "DEBLOCKING_E_Ericsson_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "dc522c0c4e901f111b2f1d26cd7f551e"
         },
         {
@@ -720,7 +720,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/DEBLOCKING_F_Ericsson_2.zip",
             "source_checksum": "fdca8adf95cf3a878d4e79b53492ed75",
             "input_file": "DEBLOCKING_F_Ericsson_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "9c278adbfdbb06a5c59184e275638fd0"
         },
         {
@@ -728,7 +728,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/DMVR_A_Huawei_3.zip",
             "source_checksum": "d4c0917498520e71426a8cab731e32e8",
             "input_file": "DMVR_A_Huawei_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "1b912fde6dbafeca0abb3097a592abf2"
         },
         {
@@ -736,7 +736,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/DMVR_B_KDDI_4.zip",
             "source_checksum": "fdb321db19d6aae04212ffaa3cd8e2a7",
             "input_file": "DMVR_B_KDDI_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "e83247cc74d5af9405f111db983ccfe5"
         },
         {
@@ -744,7 +744,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/DPB_A_Sharplabs_2.zip",
             "source_checksum": "874f07a04cfb61a247eceab1cd1a6f32",
             "input_file": "DPB_A_Sharplabs_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "51e5086343b7eb68328a254fd7dade66"
         },
         {
@@ -752,7 +752,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/DPB_B_Sharplabs_2.zip",
             "source_checksum": "99229b7ba63bb369091751f03921fe69",
             "input_file": "DPB_B_Sharplabs_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "23906b3a201def46f1e807f9d24c2ffd"
         },
         {
@@ -760,7 +760,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/DQ_A_HHI_3.zip",
             "source_checksum": "f1a983c298b452a4ba6d28a8e30a54ad",
             "input_file": "DQ_A_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "ffe7baaeb44540b641c517a5c056286d"
         },
         {
@@ -768,7 +768,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/DQ_B_HHI_3.zip",
             "source_checksum": "f19e87b91da5d0db54a6e91c701d5ded",
             "input_file": "DQ_B_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "af3463963b4aed8d1ebaf5e885f68fcb"
         },
         {
@@ -776,7 +776,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENT444HIGHTIER_A_Sony_3.zip",
             "source_checksum": "c9ccb170fd748594ccc0efeac57b7bb9",
             "input_file": "ENT444HIGHTIER_A_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p10le",
             "result": "60159f91d52810e78a750b3e9b1cbc06"
         },
         {
@@ -784,7 +784,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENT444HIGHTIER_B_Sony_3.zip",
             "source_checksum": "1550af71f36014db947267a320f5f4c5",
             "input_file": "ENT444HIGHTIER_B_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p10le",
             "result": "171e0ce9a6f5cc4a09b0872eb87f37d2"
         },
         {
@@ -792,7 +792,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENT444HIGHTIER_C_Sony_3.zip",
             "source_checksum": "ee057dec83b70a3b5ff6e1b430c1ddf6",
             "input_file": "ENT444HIGHTIER_C_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p10le",
             "result": "abdf00d83bdabb19bec4db40bd4f7f08"
         },
         {
@@ -800,7 +800,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENT444HIGHTIER_D_Sony_3.zip",
             "source_checksum": "8c3ff487c1809ed9a5e7dbad344b4eea",
             "input_file": "ENT444HIGHTIER_D_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p10le",
             "result": "33400f6fe368eec04a0d553b8221e758"
         },
         {
@@ -808,7 +808,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENT444MAINTIER_A_Sony_3.zip",
             "source_checksum": "af302bc135ce7402de4d097bf6b2ac57",
             "input_file": "ENT444MAINTIER_A_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p10le",
             "result": "1a39aced80bba580d7d4648d2c0d2074"
         },
         {
@@ -816,7 +816,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENT444MAINTIER_B_Sony_3.zip",
             "source_checksum": "a175e2b82fbce2d06b7ef4dd85ca53f4",
             "input_file": "ENT444MAINTIER_B_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p10le",
             "result": "4a98c695c25d3d447dd86c889242eb11"
         },
         {
@@ -824,7 +824,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENT444MAINTIER_C_Sony_3.zip",
             "source_checksum": "71d02b89466ddab42acb19c0fa382ba7",
             "input_file": "ENT444MAINTIER_C_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p10le",
             "result": "66da9632b5fa836c37d5659b87ec7678"
         },
         {
@@ -832,7 +832,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENT444MAINTIER_D_Sony_3.zip",
             "source_checksum": "d3a8b49886cf156fe9b7525557e0cd06",
             "input_file": "ENT444MAINTIER_D_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p10le",
             "result": "696f6b65df1f973c4b0f46db71c6e66f"
         },
         {
@@ -840,7 +840,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENTHIGHTIER_A_Sony_3.zip",
             "source_checksum": "9c18b32409d8344e10067f04102d541d",
             "input_file": "ENTHIGHTIER_A_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "29ddbf7c22c7e58c89e774f1ae643047"
         },
         {
@@ -848,7 +848,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENTHIGHTIER_B_Sony_3.zip",
             "source_checksum": "916e6c5ae75d1c8132e4e1eec28e095a",
             "input_file": "ENTHIGHTIER_B_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "0dc20ad0c41c042b69e1660b4f3f3ac9"
         },
         {
@@ -856,7 +856,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENTHIGHTIER_C_Sony_3.zip",
             "source_checksum": "d90237f09d36e7b052d5afdf93c4080c",
             "input_file": "ENTHIGHTIER_C_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "9cee630da86a81c7b8f8c6c99a0f6987"
         },
         {
@@ -864,7 +864,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENTHIGHTIER_D_Sony_3.zip",
             "source_checksum": "43f73a1263fe6b88a3b9a161e8271871",
             "input_file": "ENTHIGHTIER_D_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "3736a21a66f595e9a7406de54a3ede8c"
         },
         {
@@ -872,7 +872,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENTMAINTIER_A_Sony_3.zip",
             "source_checksum": "a637ecbb3899894d0539e71553280cac",
             "input_file": "ENTMAINTIER_A_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "86a8dd47aa908bc8d5f833e38d8e127d"
         },
         {
@@ -880,7 +880,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENTMAINTIER_B_Sony_3.zip",
             "source_checksum": "8b5dfee7f94edf729658f48a84c32d33",
             "input_file": "ENTMAINTIER_B_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "2d1835bcf0588189f16ad0e83360a544"
         },
         {
@@ -888,7 +888,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENTMAINTIER_C_Sony_3.zip",
             "source_checksum": "21eb683a70dd0a64910713bf6b8aaa5a",
             "input_file": "ENTMAINTIER_C_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "7dbd4bfa9ca5dee6fc11189f2e22154e"
         },
         {
@@ -896,7 +896,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENTMAINTIER_D_Sony_3.zip",
             "source_checksum": "02dc25d3c2931a81cd51715e4a2f6923",
             "input_file": "ENTMAINTIER_D_Sony_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "1fceaaa35c03a1b9547b6df6b76b742e"
         },
         {
@@ -904,7 +904,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENTROPY_A_Chipsnmedia_2.zip",
             "source_checksum": "7ff81fec4fde82db67b5163db2fe5d02",
             "input_file": "ENTROPY_A_Chipsnmedia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "113e64270f3473869efb739e0273ffed"
         },
         {
@@ -912,7 +912,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENTROPY_B_Sharp_2.zip",
             "source_checksum": "6f0c03b906059c9ed8b644f24c38b4ad",
             "input_file": "ENTROPY_B_Sharp_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "2277bc22b8c8fc0f6578c377e032b237"
         },
         {
@@ -920,7 +920,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ENTROPY_C_Qualcomm_1.zip",
             "source_checksum": "52e58c9afcf76cedf9eb2d3cadfb8a1f",
             "input_file": "ENTROPY_C_Qualcomm_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "6ebeb9db422e0b9b7077dc25268891a6"
         },
         {
@@ -928,7 +928,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ERP_A_MediaTek_3.zip",
             "source_checksum": "0e7271205ab2a221f4ec7a5fb3a3caef",
             "input_file": "ERP_A_MediaTek_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "3772b6d395d348d7b6323a3f908ada83"
         },
         {
@@ -936,7 +936,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/FIELD_A_Panasonic_4.zip",
             "source_checksum": "c10dbb5efa0074a09b97cf246246d60b",
             "input_file": "FIELD_A_Panasonic_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "4c05faea2d7bbc3f242280a14dc12696"
         },
         {
@@ -944,7 +944,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/FIELD_B_Panasonic_2.zip",
             "source_checksum": "3cd57fe5519dfc5c583cef536ba9151a",
             "input_file": "FIELD_B_Panasonic_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "b2eea065bd3a014bb8045f24d792f40c"
         },
         {
@@ -952,7 +952,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/FILLER_A_Bytedance_1.zip",
             "source_checksum": "ff6d6bf18f512f582d29782d19a0279e",
             "input_file": "FILLER_A_Bytedance_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "d3d03203c69728d6926582b1bbe9f40a"
         },
         {
@@ -960,7 +960,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/GDR_A_ERICSSON_2.zip",
             "source_checksum": "5b4a5e390db317248a584741e9bd154f",
             "input_file": "GDR_A_ERICSSON_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "19b31563d3a927f0e60acffd6a54646b"
         },
         {
@@ -968,7 +968,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/GDR_B_NOKIA_2.zip",
             "source_checksum": "1309aea7cd10e208f19c55136fb10286",
             "input_file": "GDR_B_NOKIA_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "cc74c53ae82d761f0868ecdf11e951ae"
         },
         {
@@ -976,7 +976,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/GDR_C_NOKIA_2.zip",
             "source_checksum": "150cd17349e4510f21828fd4bcfcb557",
             "input_file": "GDR_C_NOKIA_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "f554ac1c59d053992e201703a5abb2d9"
         },
         {
@@ -984,7 +984,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/GDR_D_ERICSSON_1.zip",
             "source_checksum": "bbc2168685338f8520d0cd06c0265c1a",
             "input_file": "GDR_D_ERICSSON_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "72800687190db582b46b1d0e7ce04285"
         },
         {
@@ -992,7 +992,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/GPM_A_Alibaba_3.zip",
             "source_checksum": "1ceb9a72c83646ba63184a371e9dcb78",
             "input_file": "GPM_A_Alibaba_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "468e46fd7d6c362677eeda53d0695b38"
         },
         {
@@ -1000,7 +1000,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/GPM_B_Alibaba_1.zip",
             "source_checksum": "e4d249d84871bc9c7a26820a2c451f19",
             "input_file": "GPM_B_Alibaba_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "82892deee3497f789882e4d7eb959254"
         },
         {
@@ -1008,7 +1008,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/HLG_A_NHK_4.zip",
             "source_checksum": "3d8d4171c872036780dbf5fe7c243aa1",
             "input_file": "HLG_A_NHK_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "5b1710cdb45fb0e0f519c118589c1b50"
         },
         {
@@ -1016,7 +1016,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/HLG_B_NHK_4.zip",
             "source_checksum": "6eabeb0f3cc0a6ffa510cc90983cc84e",
             "input_file": "HLG_B_NHK_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "5b1710cdb45fb0e0f519c118589c1b50"
         },
         {
@@ -1024,7 +1024,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/HRD_A_Fujitsu_3.zip",
             "source_checksum": "ff5ea35455c10d48e4028762009da648",
             "input_file": "HRD_A_Fujitsu_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "cde6c0d2416335173cf9d2ff8d32e460"
         },
         {
@@ -1032,7 +1032,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/HRD_B_Fujitsu_2.zip",
             "source_checksum": "540056b0f9cf2e94aadadb7de1bf527e",
             "input_file": "HRD_B_Fujitsu_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "3bd31f8094e9df345aba8cc401a97c23"
         },
         {
@@ -1040,7 +1040,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/IBC_A_Tencent_2.zip",
             "source_checksum": "3c3e6e9f7a88a90fd53926965a555eb3",
             "input_file": "IBC_A_Tencent_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "1ed62c56e2a2f2698aadf59d8a3bd60d"
         },
         {
@@ -1048,7 +1048,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/IBC_B_Tencent_2.zip",
             "source_checksum": "9fe40bf731bcc138dbf0e9956d9a8ca0",
             "input_file": "IBC_B_Tencent_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "62f32ae1c7a4f56f1492468dd85095f2"
         },
         {
@@ -1056,7 +1056,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/IBC_C_Tencent_2.zip",
             "source_checksum": "2771a586deb169b42309f0c99d58d780",
             "input_file": "IBC_C_Tencent_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "cbea0370a4a5bf4fab9dcd18054d857a"
         },
         {
@@ -1064,7 +1064,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/IBC_D_Tencent_2.zip",
             "source_checksum": "9f679f9c6d5475bd6422b31e2c3afd8d",
             "input_file": "IBC_D_Tencent_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "42f812cebfd702e5bf20bf143a60c1e0"
         },
         {
@@ -1072,7 +1072,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ILRPL_A_Huawei_2.zip",
             "source_checksum": "39303261921828d3a60823520230e544",
             "input_file": "ILRPL_A_Huawei_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "6dcef29e83c3a7d2c024c259976f6c9"
         },
         {
@@ -1080,7 +1080,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/IP_A_Huawei_2.zip",
             "source_checksum": "84035045dfe40fd18e967f2b40fffeea",
             "input_file": "IP_A_Huawei_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "3bee6bf5a5ed09a87063d213c3a7c0d9"
         },
         {
@@ -1088,7 +1088,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/IP_B_Nokia_1.zip",
             "source_checksum": "1087f2e948079a70e80155c380a8d824",
             "input_file": "IP_B_Nokia_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "3284d53e34752c301c982c41f89551d8"
         },
         {
@@ -1096,7 +1096,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ISP_A_HHI_3.zip",
             "source_checksum": "833753172d5aea802f525793cf4fa668",
             "input_file": "ISP_A_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "dde5df2c0d28719a341b3b8123b53155"
         },
         {
@@ -1104,7 +1104,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/ISP_B_HHI_3.zip",
             "source_checksum": "e0e25aff59bff4037c3049f5554e7bff",
             "input_file": "ISP_B_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "0c7dc45ca345ec005513cb5448aec238"
         },
         {
@@ -1112,7 +1112,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/JCCR_A_Nokia_2.zip",
             "source_checksum": "079742dd86ea06df90480f17ac199c7e",
             "input_file": "JCCR_A_Nokia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "a25211dcd6cf0a8e6b0323fe91fbf8e0"
         },
         {
@@ -1120,7 +1120,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/JCCR_B_Nokia_2.zip",
             "source_checksum": "6c0bf864661fd920a66c9f50a27c07ef",
             "input_file": "JCCR_B_Nokia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "bb19fad491b1ff045ac4cea15b4984fa"
         },
         {
@@ -1128,7 +1128,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/JCCR_C_HHI_3.zip",
             "source_checksum": "36c1c79651a276fc904779b3467fe437",
             "input_file": "JCCR_C_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "c0303878a568dc0a29a12728c53dd999"
         },
         {
@@ -1136,7 +1136,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/JCCR_D_HHI_3.zip",
             "source_checksum": "4239c5712fe596a62ce545cf077a04cb",
             "input_file": "JCCR_D_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "6832b0cb62cb894383c3421ca3df39d4"
         },
         {
@@ -1144,7 +1144,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/JCCR_E_Nokia_1.zip",
             "source_checksum": "d455d564c317486541eea7d8d65897f8",
             "input_file": "JCCR_E_Nokia_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "a25211dcd6cf0a8e6b0323fe91fbf8e0"
         },
         {
@@ -1152,7 +1152,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/JCCR_F_Nokia_1.zip",
             "source_checksum": "4c55ece0c188180f902f5f6c8292b1d6",
             "input_file": "JCCR_F_Nokia_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "bb19fad491b1ff045ac4cea15b4984fa"
         },
         {
@@ -1160,7 +1160,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/LFNST_A_LGE_4.zip",
             "source_checksum": "e9bc368a83adc9a59d68899d438440d3",
             "input_file": "LFNST_A_LGE_4/LFNST_A_LGE_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "f3e07a3fcc920c67d32ecf8b52b3e732"
         },
         {
@@ -1168,7 +1168,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/LFNST_B_LGE_4.zip",
             "source_checksum": "2bc93e7703dfa49922b39119da836416",
             "input_file": "LFNST_B_LGE_4/LFNST_B_LGE_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "b220dae185f1ef32a6b593f7415f133b"
         },
         {
@@ -1176,7 +1176,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/LFNST_C_HHI_3.zip",
             "source_checksum": "827f217d2c678f88dee976560506c0cb",
             "input_file": "LFNST_C_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "bcc285f77fe11485add459e4f99160c1"
         },
         {
@@ -1184,7 +1184,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/LFNST_D_HHI_3.zip",
             "source_checksum": "4d70e0919137c0f04a1a86fdafcd8a0a",
             "input_file": "LFNST_D_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "52546e593e2c40db8cf98029773191f9"
         },
         {
@@ -1192,7 +1192,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/LMCS_A_Dolby_3.zip",
             "source_checksum": "1f814262f21d51ef175eee8eee4013f1",
             "input_file": "LMCS_A_Dolby_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "0922d6d08c4ebc7b5d063144cfa95b04"
         },
         {
@@ -1200,7 +1200,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/LMCS_B_Dolby_2.zip",
             "source_checksum": "ce1fc976779ec89d5bc8cade3df23d1e",
             "input_file": "LMCS_B_Dolby_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "fddd9675977585a0d823c0e8b0f9188e"
         },
         {
@@ -1208,7 +1208,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/LMCS_C_Dolby_1.zip",
             "source_checksum": "a8bccc90f9073bfa42481f8eb9d8a458",
             "input_file": "LMCS_C_Dolby_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "298c63181d0d367314c9692c204de426"
         },
         {
@@ -1224,7 +1224,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/LOSSLESS_B_HHI_3.zip",
             "source_checksum": "59cb2b3e26b86e59907c218daa752c00",
             "input_file": "LOSSLESS_B_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "7c5b7623ecff86b67a52f7707d187307"
         },
         {
@@ -1232,7 +1232,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/LTRP_A_ERICSSON_3.zip",
             "source_checksum": "c40978305f336475f2637321fc925818",
             "input_file": "LTRP_A_ERICSSON_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "b0b9bc26555669594149b3ef81d80c5c"
         },
         {
@@ -1240,7 +1240,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MERGE_A_Qualcomm_2.zip",
             "source_checksum": "afd1007378612764daccfaf59e1e9d2c",
             "input_file": "MERGE_A_Qualcomm_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "6da2ed0dad1473e70cadadd9ca43e76a"
         },
         {
@@ -1248,7 +1248,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MERGE_B_Qualcomm_2.zip",
             "source_checksum": "98d177ab743227a972278e55e5d88034",
             "input_file": "MERGE_B_Qualcomm_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "843465c6a50fa031499d99c24e0f11d5"
         },
         {
@@ -1256,7 +1256,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MERGE_C_Qualcomm_2.zip",
             "source_checksum": "084dceca82d94a958835ab2ce19670fa",
             "input_file": "MERGE_C_Qualcomm_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "c680825dd0c616ad6367a2af8e6b8497"
         },
         {
@@ -1264,7 +1264,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MERGE_D_Qualcomm_2.zip",
             "source_checksum": "43faba23a2292017f91fb5b3d8c1b8f7",
             "input_file": "MERGE_D_Qualcomm_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "b7138942cbbf26fad54c0810591e9323"
         },
         {
@@ -1272,7 +1272,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MERGE_E_Qualcomm_2.zip",
             "source_checksum": "691e8842697f07f5a681030109d7d740",
             "input_file": "MERGE_E_Qualcomm_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "4a09f879018317fda2973a15cdda1695"
         },
         {
@@ -1280,7 +1280,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MERGE_F_Qualcomm_2.zip",
             "source_checksum": "a3fa3844271b4454068510e0f4fa0a2a",
             "input_file": "MERGE_F_Qualcomm_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "a5f9950269eac2507baf0d7a243eea41"
         },
         {
@@ -1288,7 +1288,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MERGE_G_Qualcomm_2.zip",
             "source_checksum": "c8a4f0ba48e6e7a817d2ca85149cdb5e",
             "input_file": "MERGE_G_Qualcomm_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "502a76151adedf1b8beee7f0d67ee735"
         },
         {
@@ -1296,7 +1296,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MERGE_H_Qualcomm_2.zip",
             "source_checksum": "e3eecb2f56d94d20abb91529ae4d54a0",
             "input_file": "MERGE_H_Qualcomm_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "ebe3ff7bbacaf3dc3d7b0ca94f44e854"
         },
         {
@@ -1304,7 +1304,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MERGE_I_Qualcomm_2.zip",
             "source_checksum": "e488597089e21c7553616d534f951280",
             "input_file": "MERGE_I_Qualcomm_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "a8c0daf0591151f2b6824ca6daecdc55"
         },
         {
@@ -1312,7 +1312,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MERGE_J_Qualcomm_2.zip",
             "source_checksum": "d85b3d2a6eb423b16bd57fc38b7b9809",
             "input_file": "MERGE_J_Qualcomm_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "93712d08d1efc2d9c2db4c32a9f1fe59"
         },
         {
@@ -1320,7 +1320,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MIP_A_HHI_3.zip",
             "source_checksum": "41dce508aed6a8f8855bdb03ecaddc7c",
             "input_file": "MIP_A_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "38833c21863182d37467f3fabf13e72c"
         },
         {
@@ -1328,7 +1328,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MIP_B_HHI_3.zip",
             "source_checksum": "f3a42779dc1bb45e03c49ad3f79c8215",
             "input_file": "MIP_B_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "43708959d70cf4ea1704bd11ba8ce4f8"
         },
         {
@@ -1336,7 +1336,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MMVD_A_SAMSUNG_3.zip",
             "source_checksum": "bcd2887f254db36c020f5eb0c64c3a47",
             "input_file": "MMVD_A_SAMSUNG_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "e07e524588f9a7e939924ae0a2a419e8"
         },
         {
@@ -1344,7 +1344,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MNUT_A_Nokia_3.zip",
             "source_checksum": "e26d46c79970021742f0696016220a3a",
             "input_file": "MNUT_A_Nokia_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "9efb8eeb6095c361bf6f092e4bb145f8"
         },
         {
@@ -1352,7 +1352,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MNUT_B_Nokia_2.zip",
             "source_checksum": "2b6394fdefdf620245daf84a514d6867",
             "input_file": "MNUT_B_Nokia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "e90ab172fc157094ef4c78f80a3771da"
         },
         {
@@ -1360,7 +1360,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MPM_A_LGE_3.zip",
             "source_checksum": "4576a42bac5ccab807267881d858cf54",
             "input_file": "MPM_A_LGE_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "5c1aa18256a778df681d18c536c2f42b"
         },
         {
@@ -1368,7 +1368,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MRLP_A_HHI_2.zip",
             "source_checksum": "fe3517016e4214e80635239e9b935f7b",
             "input_file": "MRLP_A_HHI_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "4251da59fb65df2b036ff82ae4558911"
         },
         {
@@ -1376,7 +1376,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MRLP_B_HHI_2.zip",
             "source_checksum": "8c30ac6884b871ee4a7729b02ff7a9ed",
             "input_file": "MRLP_B_HHI_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "47b850cabc37c8d2bd75fdd6877f1a73"
         },
         {
@@ -1384,7 +1384,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MTS_A_LGE_4.zip",
             "source_checksum": "5446a54b3ae81364f5e2472642f1d1be",
             "input_file": "MTS_A_LGE_4/MTS_A_LGE_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "5ea1937a54fbd2c7920a08a835ee7e96"
         },
         {
@@ -1392,7 +1392,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MTS_B_LGE_4.zip",
             "source_checksum": "c19a8a7fffbe7f7f5becf73fa0a8c2f7",
             "input_file": "MTS_B_LGE_4/MTS_B_LGE_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "5ab7a01af1ee383fcf8edf7c77831b19"
         },
         {
@@ -1400,7 +1400,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MTS_LFNST_A_LGE_4.zip",
             "source_checksum": "7708fcefef7b56332b49443089b4da9b",
             "input_file": "MTS_LFNST_A_LGE_4/MTS_LFNST_A_LGE_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "b52aaff2beb076d5f9413719387647ed"
         },
         {
@@ -1408,7 +1408,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MTS_LFNST_B_LGE_4.zip",
             "source_checksum": "5fbab59a49df2ed430ead9acc80b768c",
             "input_file": "MTS_LFNST_B_LGE_4/MTS_LFNST_B_LGE_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "7aaa05fa83a36d627f30a4723df26106"
         },
         {
@@ -1416,7 +1416,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MVCOMP_A_Sharp_2.zip",
             "source_checksum": "b9a112c9fcf1c4a7eb70451099672044",
             "input_file": "MVCOMP_A_Sharp_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "cfcc312b90ec8822524c12e5c6ce9917"
         },
         {
@@ -1424,7 +1424,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/OLS_A_Tencent_4.zip",
             "source_checksum": "f1246ae73a2e5a9ce1fe0140f155042f",
             "input_file": "OLS_A_Tencent_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "0DD8FADF466DC68466AF7848B7CC85F0"
         },
         {
@@ -1432,7 +1432,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/OLS_B_Tencent_4.zip",
             "source_checksum": "963139b3f1b0d9021815543fa1d1d6e3",
             "input_file": "OLS_B_Tencent_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "0DD8FADF466DC68466AF7848B7CC85F"
         },
         {
@@ -1440,7 +1440,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/OLS_C_Tencent_4.zip",
             "source_checksum": "ee38a835bfc85ba23a02afb06a40ac0d",
             "input_file": "OLS_C_Tencent_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "3664F81912A6DC0849AB761C11504F9"
         },
         {
@@ -1448,7 +1448,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/OPI_A_Nokia_1.zip",
             "source_checksum": "118302483bd51f6503326ca348d353de",
             "input_file": "OPI_A_Nokia_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "efc9fbae919838646cda71e21dc2e2f4"
         },
         {
@@ -1456,7 +1456,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/OPI_B_Nokia_2.zip",
             "source_checksum": "349b116ba6aac4803c3f0b8f1539a923",
             "input_file": "OPI_B_Nokia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "ac58502ff7032f8f1e1a64df628d1543"
         },
         {
@@ -1464,7 +1464,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PALETTE_A_Alibaba_2.zip",
             "source_checksum": "3c7b04f21cdc8aa11c3db0f4e4ce4982",
             "input_file": "PALETTE_A_Alibaba_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "310fb033d67098a3babd6b9a95305338"
         },
         {
@@ -1472,7 +1472,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PALETTE_B_Alibaba_2.zip",
             "source_checksum": "5c0ab4e1ee6fd5e34a23018e2c96a4e6",
             "input_file": "PALETTE_B_Alibaba_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "692872850ff1cd8fece4a19ca833749f"
         },
         {
@@ -1480,7 +1480,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PALETTE_C_Alibaba_2.zip",
             "source_checksum": "eb0a2f291992cf4f832e5595f6027e7f",
             "input_file": "PALETTE_C_Alibaba_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "3e71927c00237b0728fa9d3f7a065544"
         },
         {
@@ -1488,7 +1488,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PALETTE_D_Alibaba_2.zip",
             "source_checksum": "05439580e357779606b0a8dcbaead707",
             "input_file": "PALETTE_D_Alibaba_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "2449232d09b1e4845f1358464dde6d5e"
         },
         {
@@ -1496,7 +1496,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PALETTE_E_Alibaba_2.zip",
             "source_checksum": "8d5af2d36848e916d094fd98a0d5b419",
             "input_file": "PALETTE_E_Alibaba_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "540b198ac47d2021139006014cd89fde "
         },
         {
@@ -1504,7 +1504,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PDPC_A_Qualcomm_3.zip",
             "source_checksum": "44fa95fb3c68ff9bc344f64a4d442ddb",
             "input_file": "PDPC_A_Qualcomm_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "2732a1789fb6b2a264b3fb47c8c711e2"
         },
         {
@@ -1512,7 +1512,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PDPC_B_Qualcomm_3.zip",
             "source_checksum": "5022105ac52f2795307385c6249ed700",
             "input_file": "PDPC_B_Qualcomm_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "0ffe729c9090ce9f57e9fe3ea97349d2"
         },
         {
@@ -1520,7 +1520,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PDPC_C_Qualcomm_2.zip",
             "source_checksum": "17082beff909ace71ab8edb2439391d3",
             "input_file": "PDPC_C_Qualcomm_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "04491709971aad732f4f1ff74ecb68b4"
         },
         {
@@ -1528,7 +1528,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PHSH_B_Sharp_1.zip",
             "source_checksum": "b7fec19b8dab937accd1589877fd6843",
             "input_file": "PHSH_B_Sharp_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "5ccbb8c904da44dd3ab1245e7db65682"
         },
         {
@@ -1536,7 +1536,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PMERGE_A_MediaTek_1.zip",
             "source_checksum": "6574b1c0614efa67de422d764460f9fd",
             "input_file": "PMERGE_A_MediaTek_1/PMERGE_A_MediaTek_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "1b14b6dcf16db28c23533a33d8fafac3"
         },
         {
@@ -1544,7 +1544,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PMERGE_B_MediaTek_1.zip",
             "source_checksum": "9cd4ae95a54f89dbb039fced91cfdb5e",
             "input_file": "PMERGE_B_MediaTek_1/PMERGE_B_MediaTek_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "bff5571bad527e2f5369e6dbfda7e6b0"
         },
         {
@@ -1552,7 +1552,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PMERGE_C_MediaTek_1.zip",
             "source_checksum": "4c198403788ddf59af92f04885bb345a",
             "input_file": "PMERGE_C_MediaTek_1/PMERGE_C_MediaTek_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "f18acbdd88b341d1d92ae73bc99190a5"
         },
         {
@@ -1560,7 +1560,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PMERGE_D_MediaTek_1.zip",
             "source_checksum": "d81af6e31dd184556be176d3082b55c4",
             "input_file": "PMERGE_D_MediaTek_1/PMERGE_D_MediaTek_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "701f1885de764fba9e8ab3e66c4a9afe"
         },
         {
@@ -1568,7 +1568,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PMERGE_E_MediaTek_1.zip",
             "source_checksum": "3cb912fa2fda61c6d671d00c55fa952d",
             "input_file": "PMERGE_E_MediaTek_1/PMERGE_E_MediaTek_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "b92953ba977a56c73445fed54da2f8a6"
         },
         {
@@ -1576,7 +1576,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/POC_A_Nokia_1.zip",
             "source_checksum": "7aecc887620217cb953877fca180def5",
             "input_file": "POC_A_Nokia_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "7679445289c4eed21cc87e15b88dfb48"
         },
         {
@@ -1584,7 +1584,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/POUT_A_Sharplabs_2.zip",
             "source_checksum": "341c950dd2cf75c5c5b9ca644a2283ed",
             "input_file": "POUT_A_Sharplabs_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "498e121d4fe57d1edc55505e9631a7bf"
         },
         {
@@ -1592,7 +1592,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PPS_A_Bytedance_1.zip",
             "source_checksum": "59e34ba04f932e07bdf0a0eaf6ce3061",
             "input_file": "PPS_A_Bytedance_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "bf74179530bf7e837ae3ebaf82079d2c"
         },
         {
@@ -1600,7 +1600,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PPS_B_Bytedance_1.zip",
             "source_checksum": "0df398d9cae6bdc925aed55874dc8571",
             "input_file": "PPS_B_Bytedance_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "6e3577283bb1e8e26d883c03d89cb3f8"
         },
         {
@@ -1608,7 +1608,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PPS_C_Bytedance_1.zip",
             "source_checksum": "6bb93a285c308865cbff56912d805ae8",
             "input_file": "PPS_C_Bytedance_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "ad797d5dbd052dc9ef6bdf9fc522f340"
         },
         {
@@ -1616,7 +1616,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PQ_A_Dolby_1.zip",
             "source_checksum": "cbd5c826818ab2414694439019b4f450",
             "input_file": "PQ_A_Dolby_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "c07378acf6b111fd506d89458f592993"
         },
         {
@@ -1624,7 +1624,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PROF_A_Interdigital_3.zip",
             "source_checksum": "14a9ad109ec065bf68327b7e586c30bf",
             "input_file": "PROF_A_Interdigital_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "65badf01204e757ec8fc70c325db5107"
         },
         {
@@ -1632,7 +1632,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PROF_B_Interdigital_3.zip",
             "source_checksum": "2dac3be0306a44d2cb310c5121476b37",
             "input_file": "PROF_B_Interdigital_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "1b643d2c1bb439410a80d12519506abe"
         },
         {
@@ -1640,7 +1640,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PSEXT_A_Nokia_2.zip",
             "source_checksum": "ad39a2dfc90f2b8140332fc2668bd10c",
             "input_file": "PSEXT_A_Nokia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "ce9bd27e6a5ce5b839d054b8513f794b"
         },
         {
@@ -1648,7 +1648,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/PSEXT_B_Nokia_2.zip",
             "source_checksum": "c300dcc042b3de2956194679f7fe5357",
             "input_file": "PSEXT_B_Nokia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "ce9bd27e6a5ce5b839d054b8513f794b"
         },
         {
@@ -1656,7 +1656,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/QTBTT_A_MediaTek_4.zip",
             "source_checksum": "95facea134e7768230003e558668b6ed",
             "input_file": "QTBTT_A_MediaTek_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "136ea6884f665a18104fbd056b95038a"
         },
         {
@@ -1664,7 +1664,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/QUANT_A_Huawei_2.zip",
             "source_checksum": "f286b1d3c4a4e446fbd13240d0386caf",
             "input_file": "QUANT_A_Huawei_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "f2c06ae9b5195a4e5cd10d3e288a42ae"
         },
         {
@@ -1672,7 +1672,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/QUANT_B_Huawei_2.zip",
             "source_checksum": "c7dd125e282d56022754d58cfe8b3ca9",
             "input_file": "QUANT_B_Huawei_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "12f717e96ec4fcc91b69a2faacfae962"
         },
         {
@@ -1696,7 +1696,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/QUANT_E_Interdigital_1.zip",
             "source_checksum": "7cd1804ff0355e5ac97489b07439269c",
             "input_file": "QUANT_E_Interdigital_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "2a0c27f6481e7226faa54920bd6fd561"
         },
         {
@@ -1704,7 +1704,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/RAP_A_HHI_1.zip",
             "source_checksum": "9a3cd5514fa4ed9ddbe51e838c300ea5",
             "input_file": "RAP_A_HHI_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "f46da2475bd22db8757dfa82f036a84f"
         },
         {
@@ -1712,7 +1712,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/RAP_B_HHI_1.zip",
             "source_checksum": "58beb44a5ba9ddcd68df716f1b7f6db1",
             "input_file": "RAP_B_HHI_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "562412a45e9592b8bfe54bc64d0a7092"
         },
         {
@@ -1720,7 +1720,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/RAP_C_HHI_1.zip",
             "source_checksum": "c3155aafc17a815896031d0971c437f0",
             "input_file": "RAP_C_HHI_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "2c75ed985df67e09dfea70a16fc3d91a"
         },
         {
@@ -1728,7 +1728,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/RAP_D_HHI_1.zip",
             "source_checksum": "066e8b18fd17eec9e13b5015e3c0a294",
             "input_file": "RAP_D_HHI_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "4907419d59e00a8c2789732205e31a47"
         },
         {
@@ -1736,7 +1736,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/RPL_A_ERICSSON_2.zip",
             "source_checksum": "d0398e003adc03ed0dcc23e3c67713f0",
             "input_file": "RPL_A_ERICSSON_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "d7fed587fea32a2b107adcc9e35e6980"
         },
         {
@@ -1744,7 +1744,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/RPR_A_Alibaba_4.zip",
             "source_checksum": "47f9992a3513c26127ac459b59a888e7",
             "input_file": "RPR_A_Alibaba_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "8ec0e217cde95699eebec47cacc9679f"
         },
         {
@@ -1752,7 +1752,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/RPR_B_Alibaba_3.zip",
             "source_checksum": "b669a9b3239cb08774ffd0f29ed55ada",
             "input_file": "RPR_B_Alibaba_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "d677077f1a2ae9bd7ed74aae1ea66855"
         },
         {
@@ -1760,7 +1760,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/RPR_C_Alibaba_3.zip",
             "source_checksum": "b01921d929cfa98ab0fee3504b4c1211",
             "input_file": "RPR_C_Alibaba_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "68d5f70493dfef6dfc3a1d83477f138f"
         },
         {
@@ -1768,7 +1768,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/RPR_D_Qualcomm_1.zip",
             "source_checksum": "53ad2f47c640a055a38e65c13c313db6",
             "input_file": "RPR_D_Qualcomm_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "a2ec75e0438865d2189b6f29e0416807"
         },
         {
@@ -1776,7 +1776,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SAO_A_SAMSUNG_3.zip",
             "source_checksum": "327f5353be83f9cecbf72d139e5d9ae4",
             "input_file": "SAO_A_SAMSUNG_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "85176b10e59d49a985c62e24fb23ee10"
         },
         {
@@ -1784,7 +1784,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SAO_B_SAMSUNG_3.zip",
             "source_checksum": "3acaeb055446e971ae87fc00b3f594aa",
             "input_file": "SAO_B_SAMSUNG_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "403e8104a15f82129a9048ffedb25ef0"
         },
         {
@@ -1792,7 +1792,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SAO_C_SAMSUNG_3.zip",
             "source_checksum": "9fe816ff32c570e45ffec14e34c251cb",
             "input_file": "SAO_C_SAMSUNG_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "0c303d7f065249226990eb26edda7431"
         },
         {
@@ -1800,7 +1800,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SBT_A_HUAWEI_2.zip",
             "source_checksum": "26e637c731b63641d755694d3ae83b86",
             "input_file": "SBT_A_HUAWEI_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "953c9457641688e0f3cd2bd6e292d696"
         },
         {
@@ -1808,7 +1808,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SbTMVP_A_Bytedance_3.zip",
             "source_checksum": "d046b8b7a0c7f1915b85b17485f9a9cf",
             "input_file": "SbTMVP_A_Bytedance_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "bf62526a8cd73e71be6d5c81d511324e"
         },
         {
@@ -1816,7 +1816,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SbTMVP_B_Bytedance_3.zip",
             "source_checksum": "9448d84cb137a5409041f052c1b62625",
             "input_file": "SbTMVP_B_Bytedance_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "e102e6b1d16def184273c33fc6555102"
         },
         {
@@ -1824,7 +1824,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SCALING_A_InterDigital_1.zip",
             "source_checksum": "1b5a690364dee391a28972ac2ec314cf",
             "input_file": "SCALING_A_InterDigital_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "f990d21ef21896b64d0ba2dfbca1b338"
         },
         {
@@ -1832,7 +1832,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SCALING_B_InterDigital_1.zip",
             "source_checksum": "1b9026b6120d7c77ae9d31fbfd70f3dc",
             "input_file": "SCALING_B_InterDigital_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "c301642f54815ee04ef5ab9f51dd63e4"
         },
         {
@@ -1840,7 +1840,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SCALING_C_InterDigital_1.zip",
             "source_checksum": "8a7fb1ceab6647eb2ab65b4f1f7bd90a",
             "input_file": "SCALING_C_InterDigital_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "9c1ae8953c24d97c85f57739a78b7019"
         },
         {
@@ -1848,7 +1848,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SDH_A_Dolby_2.zip",
             "source_checksum": "cd3d572e66c907989abe1fe9be23ae7c",
             "input_file": "SDH_A_Dolby_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "c4b9d94df3afa92008aad37398ee5741"
         },
         {
@@ -1856,7 +1856,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SLICES_A_HUAWEI_2.zip",
             "source_checksum": "0bdf2eee2153fd5558b23805c786a16a",
             "input_file": "SLICES_A_HUAWEI_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "24ae3a07cda1a9522a39910a0c0a1ba5"
         },
         {
@@ -1864,7 +1864,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SMVD_A_HUAWEI_2.zip",
             "source_checksum": "10c3e859a5ad0f687690eff1dc931a53",
             "input_file": "SMVD_A_HUAWEI_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "37ac855d34621ace68384c0fd87f8947"
         },
         {
@@ -1872,7 +1872,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SPATSCAL444_A_Qualcomm_2.zip",
             "source_checksum": "5d8cc69ee7a76c278ac83b297efd4a30",
             "input_file": "SPATSCAL444_A_Qualcomm_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "54f2f1769ef87fcfa1989ee8b5ecb893"
         },
         {
@@ -1880,7 +1880,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SPATSCAL_A_Qualcomm_3.zip",
             "source_checksum": "5d75dad484ef0ef6fbcb49b922f0dbb6",
             "input_file": "SPATSCAL_A_Qualcomm_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "48fec497bbef1757a21096feda8cb71e"
         },
         {
@@ -1888,7 +1888,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SPS_A_Bytedance_1.zip",
             "source_checksum": "7b9707372dd79fbbb3d9bf3e869390f2",
             "input_file": "SPS_A_Bytedance_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "bf74179530bf7e837ae3ebaf82079d2c"
         },
         {
@@ -1896,7 +1896,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SPS_B_Bytedance_1.zip",
             "source_checksum": "5456dcc6a4a3b35e498f1657bb22918f",
             "input_file": "SPS_B_Bytedance_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "301ec80d334d4b5c4420c50c026b8167"
         },
         {
@@ -1904,7 +1904,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SPS_C_Bytedance_1.zip",
             "source_checksum": "f020bbb8a68a818c1b44a35ef06e2609",
             "input_file": "SPS_C_Bytedance_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "4c4930c353e2668f61079b8fed0c25da"
         },
         {
@@ -1912,7 +1912,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/STILL444_A_KDDI_1.zip",
             "source_checksum": "25b4000a30502ada5c8cc4c9c4b104c0",
             "input_file": "STILL444_A_KDDI_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p10le",
             "result": "9bc53c0afd614cb872627bca12c8b54e"
         },
         {
@@ -1920,7 +1920,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/STILL444_B_ERICSSON_1.zip",
             "source_checksum": "e6e21e44d50ad59131e75a6c92cb15df",
             "input_file": "STILL444_B_ERICSSON_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv444p10le",
             "result": "c5f4ff05ee061876d801bdcf6dc17f66"
         },
         {
@@ -1928,7 +1928,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/STILL_A_KDDI_1.zip",
             "source_checksum": "0b23e4cc2f768655011a67f7758716bf",
             "input_file": "STILL_A_KDDI_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "a01e9805e94c9995edc54cac45b12918"
         },
         {
@@ -1936,7 +1936,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/STILL_B_ERICSSON_1.zip",
             "source_checksum": "e563fc4f2f2df772b085e78e8cb0f4ad",
             "input_file": "STILL_B_ERICSSON_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "64ef9f7915c500aabfa83d6a278d7579"
         },
         {
@@ -1944,7 +1944,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SUBPIC_A_HUAWEI_3.zip",
             "source_checksum": "3b3db34d8c8127bde4bce5f1965aeade",
             "input_file": "SUBPIC_A_HUAWEI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "0676202fde6a161a7025193465b685a2"
         },
         {
@@ -1952,7 +1952,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SUBPIC_B_HUAWEI_3.zip",
             "source_checksum": "b61c9b5b7ad0689a0452114bdcebe22a",
             "input_file": "SUBPIC_B_HUAWEI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "c5733d26eaed5e85f5b384cb2d843e5a"
         },
         {
@@ -1960,7 +1960,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SUBPIC_C_ERICSSON_1.zip",
             "source_checksum": "c7f52bfadc93cc418b6f426669541cbb",
             "input_file": "SUBPIC_C_ERICSSON_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "cab9bc6ae7f0bb6045b4b4d533a97495"
         },
         {
@@ -1968,7 +1968,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SUBPIC_D_ERICSSON_1.zip",
             "source_checksum": "2a42772ab65ac31fb84cd370eaa571cd",
             "input_file": "SUBPIC_D_ERICSSON_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "4b7461f334c4711fa2f5e8b60a3c31c8"
         },
         {
@@ -1976,7 +1976,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SUBPIC_E_MediaTek_1.zip",
             "source_checksum": "43c017a0307f38c6250d52e93a06ed6f",
             "input_file": "SUBPIC_E_MediaTek_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "d9f68237f59ebd24ada82e89bccad1ea"
         },
         {
@@ -1984,7 +1984,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SUFAPS_A_HHI_1.zip",
             "source_checksum": "1562a0e4df17c6a3fe6d5e06609bc2a7",
             "input_file": "SUFAPS_A_HHI_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "2b708610cca907b56bfb2dc1fcbc1792"
         },
         {
@@ -1992,7 +1992,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TEMPSCAL_A_Panasonic_4.zip",
             "source_checksum": "1bc06e1d4e4b9d32753a974f4ffb2302",
             "input_file": "TEMPSCAL_A_Panasonic_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "be24468840eef19a7e1e8efdd259ba28"
         },
         {
@@ -2000,7 +2000,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TEMPSCAL_B_Panasonic_5.zip",
             "source_checksum": "ed110f67f91a4863b600af0722a3186d",
             "input_file": "TEMPSCAL_B_Panasonic_5.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "bf2cc7d88f82397505c3b591990a9fc9"
         },
         {
@@ -2008,7 +2008,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TEMPSCAL_C_Panasonic_3.zip",
             "source_checksum": "79123afd78f69560c516f594e1b4622a",
             "input_file": "TEMPSCAL_C_Panasonic_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "40e6e5d4c210e7ee03ab7e293d0adea0"
         },
         {
@@ -2016,7 +2016,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TILE_A_Nokia_2.zip",
             "source_checksum": "6efa3ca754ae9aff845d10b66a6f5af4",
             "input_file": "TILE_A_Nokia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "84c1ac923243f008cf04234bd2b8515d"
         },
         {
@@ -2024,7 +2024,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TILE_B_Nokia_2.zip",
             "source_checksum": "c709f0a2c427dae9a3ec7e5162632888",
             "input_file": "TILE_B_Nokia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "43bff2d63819814129c9d2744687b16b"
         },
         {
@@ -2032,7 +2032,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TILE_C_Nokia_2.zip",
             "source_checksum": "767424d7d917258cfe10ac1dd26e2697",
             "input_file": "TILE_C_Nokia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "66261992cba7a828058d6761cdddc888"
         },
         {
@@ -2040,7 +2040,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TILE_D_Nokia_2.zip",
             "source_checksum": "def0e3ad8a6f221afc992b77cbf7d4af",
             "input_file": "TILE_D_Nokia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "6d56ab4ee6636c39b2a6fef135a5f11e"
         },
         {
@@ -2048,7 +2048,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TILE_E_Nokia_2.zip",
             "source_checksum": "4b136e6aa169a7d543abfe1f36616f39",
             "input_file": "TILE_E_Nokia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "964fb8ba8b9147917e2cfc2087811123"
         },
         {
@@ -2056,7 +2056,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TILE_F_Nokia_2.zip",
             "source_checksum": "7767410506a2e16bc5b2b56fda23d123",
             "input_file": "TILE_F_Nokia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "fc2e6f73676d9f9ecfe4b76bf576340c"
         },
         {
@@ -2064,7 +2064,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TILE_G_Nokia_2.zip",
             "source_checksum": "61389dd5763f0db1e141ee4798a54e4a",
             "input_file": "TILE_G_Nokia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "81aad2be0e559542380c09b2d1afd613"
         },
         {
@@ -2072,7 +2072,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TMVP_A_Chipsnmedia_3.zip",
             "source_checksum": "8a71fe98940a1b912893cb5cc774fbe5",
             "input_file": "TMVP_A_Chipsnmedia_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "a41e06dc095f81648a691ef05d611911"
         },
         {
@@ -2080,7 +2080,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TMVP_B_Chipsnmedia_3.zip",
             "source_checksum": "57e0654a0aa30c3b5485edea2832b9f2",
             "input_file": "TMVP_B_Chipsnmedia_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "a6eae3a8165d41c5879894e3221a33db"
         },
         {
@@ -2088,7 +2088,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TMVP_C_Chipsnmedia_3.zip",
             "source_checksum": "b3b75f1683e0fd2530e7d87985046965",
             "input_file": "TMVP_C_Chipsnmedia_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "673d7c7c39fe0e20d5953aa3ce7cf94d"
         },
         {
@@ -2096,7 +2096,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TMVP_D_Chipsnmedia_3.zip",
             "source_checksum": "aee76a2b8c4eea612c0db42a4a8f21d4",
             "input_file": "TMVP_D_Chipsnmedia_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "fa27e8c13579eb41fb85dace741b48d6"
         },
         {
@@ -2104,7 +2104,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TRANS_A_Chipsnmedia_2.zip",
             "source_checksum": "057790984c43c0cb62ac0f15a17e7506",
             "input_file": "TRANS_A_Chipsnmedia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "a8e5514d7f9b91cdc8c72dc1585b4624"
         },
         {
@@ -2112,7 +2112,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TRANS_B_Chipsnmedia_2.zip",
             "source_checksum": "5eee11382aee9c535f2ba8fa7569daea",
             "input_file": "TRANS_B_Chipsnmedia_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "973c3fb027287a9da0cd7b08dbe435c8"
         },
         {
@@ -2120,7 +2120,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TRANS_C_Chipsnmedia_4.zip",
             "source_checksum": "7f50cbadd522aff44ac002a3f9e29e4a",
             "input_file": "TRANS_C_Chipsnmedia_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "ae3d11d9c86ce906d8d76b4d65ae72c1"
         },
         {
@@ -2128,7 +2128,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TRANS_D_Chipsnmedia_4.zip",
             "source_checksum": "6c7e0057c26f3d7021ef877397ff4c70",
             "input_file": "TRANS_D_Chipsnmedia_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "cd6886010ea573c14f310400e09f8e52"
         },
         {
@@ -2136,7 +2136,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TREE_A_HHI_3.zip",
             "source_checksum": "ceb55b350ba64a97b93ac6186f84f861",
             "input_file": "TREE_A_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "fffc6bc2778989543bca5112c1de97e7"
         },
         {
@@ -2144,7 +2144,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TREE_B_HHI_3.zip",
             "source_checksum": "593ee7a707082ec3aea8821aa7970a1a",
             "input_file": "TREE_B_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "8547c6f156ad1cf9838d7844430cc24a"
         },
         {
@@ -2152,7 +2152,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/TREE_C_HHI_3.zip",
             "source_checksum": "285ce43473c77a505f14301332443076",
             "input_file": "TREE_C_HHI_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "9776ba9d54f57a33be2d9807bc33c783"
         },
         {
@@ -2160,7 +2160,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/VIRTUAL_A_MediaTek_3.zip",
             "source_checksum": "64d99b7aae3bab24185495273b013658",
             "input_file": "VIRTUAL_A_MediaTek_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "ec790ccc6e1e4e1ded0689821e11e787"
         },
         {
@@ -2168,7 +2168,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/VIRTUAL_B_MediaTek_3.zip",
             "source_checksum": "d63fe2563b53598a7a5d1b6317da747d",
             "input_file": "VIRTUAL_B_MediaTek_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "5c64969ce1cb2d4b960f5809ac998874"
         },
         {
@@ -2176,7 +2176,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/VPS_A_INTEL_3.zip",
             "source_checksum": "61aa914c529d3e4c2f8b73a82289e006",
             "input_file": "VPS_A_INTEL_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "688e5c047e1979a7f61c51c744c6d0e"
         },
         {
@@ -2184,7 +2184,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/VPS_B_ERICSSON_1.zip",
             "source_checksum": "d1b2a924605e9ab3b20552add17c4f87",
             "input_file": "VPS_B_ERICSSON_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "71f312807953304f6bec1d4b568de17"
         },
         {
@@ -2192,7 +2192,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/VPS_C_ERICSSON_1.zip",
             "source_checksum": "4a7a2f3a42ed96e0f313ad17bcedc1b7",
             "input_file": "VPS_C_ERICSSON_1.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "bb0ace58ab48edf36d3ebbcaf5e5a39"
         },
         {
@@ -2200,7 +2200,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/WP_A_InterDigital_3.zip",
             "source_checksum": "9c1293b2c165cb466da50fc66c7c693b",
             "input_file": "WP_A_InterDigital_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "40223c81e308ddb9e98ab5524960e0aa"
         },
         {
@@ -2208,7 +2208,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/WP_B_InterDigital_3.zip",
             "source_checksum": "a700f1ef85de2491afc0114f2a8b1986",
             "input_file": "WP_B_InterDigital_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "eb9aa1b005b6777e8aa3b3f47548e84d"
         },
         {
@@ -2216,7 +2216,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/WPP_A_Sharp_3.zip",
             "source_checksum": "7fe2a17bceafb4a03b5606799bb41c98",
             "input_file": "WPP_A_Sharp_3.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "8b2803b4d95dc20adf94e077a139860b"
         },
         {
@@ -2224,7 +2224,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/WPP_B_Sharp_2.zip",
             "source_checksum": "562b454ad6edd8c86daedf7ead6a12d9",
             "input_file": "WPP_B_Sharp_2.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "62a5d70c50c13842ac85e55aa1fc0f3d"
         },
         {
@@ -2232,7 +2232,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/WRAP_A_InterDigital_4.zip",
             "source_checksum": "887e99483c24f95fb91c161c2ad0b817",
             "input_file": "WRAP_A_InterDigital_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "d7f2687231a1f2f9ec70fa3ff5782f38"
         },
         {
@@ -2240,7 +2240,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/WRAP_B_InterDigital_4.zip",
             "source_checksum": "9784fe29832456f186681904422a28b2",
             "input_file": "WRAP_B_InterDigital_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "871713a03837f406d524f372d3c97bdc"
         },
         {
@@ -2248,7 +2248,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/WRAP_C_InterDigital_4.zip",
             "source_checksum": "9584c5bcaf9698e73bad2186beedac3d",
             "input_file": "WRAP_C_InterDigital_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "7d2db606e7ffefd254a73f5faac5e164"
         },
         {
@@ -2256,7 +2256,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/WRAP_D_InterDigital_4.zip",
             "source_checksum": "b448e9886fc744eacc5f75eb64360ff2",
             "input_file": "WRAP_D_InterDigital_4.bit",
-            "output_format": "yuv420p",
+            "output_format": "yuv420p10le",
             "result": "e369f002a46e92338db1271dd6166157"
         }
     ]


### PR DESCRIPTION
This PR adds the GStreamer-based based VVdeC decoder.

gst-vvdec is a GStreamer element that uses VVdeC via Rust bindings.

As of now, it has conformance results (243/282) close to vvdecapp (250/282), with the failures in addition being:
- Grayscale: element and videocodectestsink don't support it yet
- Interlaced: not supported by the element yet

I also fixed the output formats in the h266 test suite. The previous values were not used by the VVdeC decoder, but get used by the GStreamer-based VVdeC decoder. This was causing different checksums.

[Results](https://gist.github.com/cadubentzen/48aacf4ae3b709411c60f3a12f956942)