### PR TITLE
Fluster "installed" version

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ optional arguments:
   -r RESOURCES, --resources RESOURCES
                         set the directory where resources are taken from
   -o OUTPUT, --output OUTPUT
-                        set the directory where test results will be stored
+                        set the directory where decoder outputs will be stored
   -ne, --no-emoji       set to use plain text instead of emojis
   -tsd TEST_SUITES_DIR, --test-suites-dir TEST_SUITES_DIR
                         set the directory where test suite will be read from

--- a/fluster/fluster.py
+++ b/fluster/fluster.py
@@ -22,6 +22,7 @@ from functools import lru_cache
 from typing import List, Dict, Any, Tuple, Optional
 import sys
 from enum import Enum
+from shutil import rmtree
 
 # Import decoders that will auto-register
 # pylint: disable=wildcard-import, unused-wildcard-import
@@ -315,6 +316,9 @@ class Fluster:
                             sys.exit(3)
 
         self._show_summary_if_needed(ctx, results)
+
+        if not ctx.keep_files and os.path.isdir(self.results_dir):
+            rmtree(self.results_dir)
 
         if (error and (not ctx.threshold and not ctx.time_threshold)) or no_test_run:
             sys.exit(1)

--- a/fluster/fluster.py
+++ b/fluster/fluster.py
@@ -85,7 +85,7 @@ class Context:
     def to_test_suite_context(
         self,
         decoder: Decoder,
-        results_dir: str,
+        output_dir: str,
         test_vectors: List[str],
         skip_vectors: List[str],
     ) -> TestSuiteContext:
@@ -96,7 +96,7 @@ class Context:
             timeout=self.timeout,
             failfast=self.failfast,
             quiet=self.quiet,
-            results_dir=results_dir,
+            output_dir=output_dir,
             reference=self.reference,
             test_vectors=test_vectors,
             skip_vectors=skip_vectors,
@@ -141,14 +141,14 @@ class Fluster:
         test_suites_dir: str,
         decoders_dir: str,
         resources_dir: str,
-        results_dir: str,
+        output_dir: str,
         verbose: bool = False,
         use_emoji: bool = True,
     ):
         self.test_suites_dir = test_suites_dir
         self.decoders_dir = decoders_dir
         self.resources_dir = resources_dir
-        self.results_dir = results_dir
+        self.output_dir = output_dir
         self.verbose = verbose
         self.test_suites: List[TestSuite] = []
         self.decoders = DECODERS
@@ -158,7 +158,7 @@ class Fluster:
                 f"NOTE: Internal dirs used:\n"
                 f" * test_suites_dir: {self.test_suites_dir}\n"
                 f" * resources_dir: {self.resources_dir}\n"
-                f" * results_dir: {self.results_dir}"
+                f" * output_dir: {self.output_dir}"
             )
 
     @lru_cache(maxsize=128)
@@ -284,7 +284,7 @@ class Fluster:
                 test_suite_res = test_suite.run(
                     ctx.to_test_suite_context(
                         decoder,
-                        self.results_dir,
+                        self.output_dir,
                         ctx.test_vectors_names,
                         ctx.skip_vectors_names,
                     )
@@ -326,8 +326,8 @@ class Fluster:
 
         self._show_summary_if_needed(ctx, results)
 
-        if not ctx.keep_files and os.path.isdir(self.results_dir):
-            rmtree(self.results_dir)
+        if not ctx.keep_files and os.path.isdir(self.output_dir):
+            rmtree(self.output_dir)
 
         if (error and (not ctx.threshold and not ctx.time_threshold)) or no_test_run:
             sys.exit(1)

--- a/fluster/fluster.py
+++ b/fluster/fluster.py
@@ -153,6 +153,13 @@ class Fluster:
         self.test_suites: List[TestSuite] = []
         self.decoders = DECODERS
         self.emoji = EMOJI_RESULT if use_emoji else TEXT_RESULT
+        if self.verbose:
+            print(
+                f"NOTE: Internal dirs used:\n"
+                f" * test_suites_dir: {self.test_suites_dir}\n"
+                f" * resources_dir: {self.resources_dir}\n"
+                f" * results_dir: {self.results_dir}"
+            )
 
     @lru_cache(maxsize=128)
     def _load_test_suites(self) -> None:
@@ -210,6 +217,8 @@ class Fluster:
             if show_test_vectors:
                 for test_vector in test_suite.test_vectors.values():
                     print(test_vector)
+        if len(self.test_suites) == 0:
+            print(f'    No test suites found in "{self.test_suites_dir}"')
 
     def _get_matches(
         self, in_list: List[str], check_list: List[Any], name: str

--- a/fluster/main.py
+++ b/fluster/main.py
@@ -99,6 +99,7 @@ class Main:
                 resources_dir=args.resources,
                 output_dir=args.output,
                 use_emoji=not args.no_emoji,
+                verbose=args.verbose if "verbose" in args else False,
             )
             args.func(args, fluster)
         else:

--- a/fluster/main.py
+++ b/fluster/main.py
@@ -23,6 +23,7 @@ import multiprocessing
 import sys
 from importlib import util
 from typing import Any
+from tempfile import gettempdir
 
 from fluster.fluster import Fluster, Context, SummaryFormat
 
@@ -30,7 +31,7 @@ TEST_SUITES_DIR = "test_suites"
 TEST_SUITES_DIR_SYS = "/usr/share/fluster/test_suites"
 DECODERS_DIR = "decoders"
 RESOURCES_DIR = "resources"
-RESULTS_DIR = "results"
+RESULTS_DIR = "fluster_results"
 
 
 def fluster_main() -> None:
@@ -61,9 +62,7 @@ class Main:
         self.resources_dir = os.path.join(
             os.path.join(os.path.dirname(__file__), ".."), RESOURCES_DIR
         )
-        self.results_dir = os.path.join(
-            os.path.join(os.path.dirname(__file__), ".."), RESULTS_DIR
-        )
+        self.results_dir = os.path.join(gettempdir(), RESULTS_DIR)
 
         self.parser = self._create_parser()
 

--- a/fluster/main.py
+++ b/fluster/main.py
@@ -33,7 +33,7 @@ TEST_SUITES_DIR = "test_suites"
 TEST_SUITES_DIR_SYS = "/usr/share/fluster/test_suites"
 DECODERS_DIR = "decoders"
 RESOURCES_DIR = "resources"
-RESULTS_DIR = "fluster_results"
+OUTPUT_DIR = "fluster_output"
 
 
 def fluster_main() -> None:
@@ -55,7 +55,7 @@ class Main:
         self.resources_dir = os.path.join(
             os.path.dirname(__file__), "..", RESOURCES_DIR
         )
-        self.results_dir = os.path.join(gettempdir(), RESULTS_DIR)
+        self.output_dir = os.path.join(gettempdir(), OUTPUT_DIR)
 
         is_installed = not os.path.exists(
             os.path.join(os.path.dirname(__file__), "..", ".git")
@@ -97,7 +97,7 @@ class Main:
                 test_suites_dir=args.test_suites_dir,
                 decoders_dir=self.decoders_dir,
                 resources_dir=args.resources,
-                results_dir=args.output,
+                output_dir=args.output,
                 use_emoji=not args.no_emoji,
             )
             args.func(args, fluster)
@@ -145,8 +145,8 @@ class Main:
         parser.add_argument(
             "-o",
             "--output",
-            help="set the directory where test results will be stored",
-            default=self.results_dir,
+            help="set the directory where decoder outputs will be stored",
+            default=self.output_dir,
         )
         parser.add_argument(
             "-ne",

--- a/fluster/test.py
+++ b/fluster/test.py
@@ -37,7 +37,7 @@ class Test(unittest.TestCase):
         test_suite: Any,  # can't use TestSuite type because of circular dependency
         test_vector: TestVector,
         skip: bool,
-        results_dir: str,
+        output_dir: str,
         reference: bool,
         timeout: int,
         keep_files: bool,
@@ -48,7 +48,7 @@ class Test(unittest.TestCase):
         self.test_vector = test_vector
         self.skip = skip
         self.resources_dir = self.test_suite.resources_dir
-        self.results_dir = results_dir
+        self.output_dir = output_dir
         self.reference = reference
         self.timeout = timeout
         self.keep_files = keep_files
@@ -64,7 +64,7 @@ class Test(unittest.TestCase):
 
             return
 
-        output_filepath = os.path.join(self.results_dir, self.test_vector.name + ".out")
+        output_filepath = os.path.join(self.output_dir, self.test_vector.name + ".out")
 
         input_filepath = os.path.join(
             self.resources_dir,

--- a/fluster/test_suite.py
+++ b/fluster/test_suite.py
@@ -69,7 +69,7 @@ class Context:
         timeout: int,
         failfast: bool,
         quiet: bool,
-        results_dir: str,
+        output_dir: str,
         reference: bool = False,
         test_vectors: Optional[List[str]] = None,
         skip_vectors: Optional[List[str]] = None,
@@ -82,7 +82,7 @@ class Context:
         self.timeout = timeout
         self.failfast = failfast
         self.quiet = quiet
-        self.results_dir = results_dir
+        self.output_dir = output_dir
         self.reference = reference
         self.test_vectors = test_vectors
         self.skip_vectors = skip_vectors
@@ -405,10 +405,10 @@ class TestSuite:
             print(f"Skipping decoder {ctx.decoder.name} because it cannot be run")
             return None
 
-        ctx.results_dir = os.path.join(ctx.results_dir, self.name)
-        if os.path.exists(ctx.results_dir):
-            rmtree(ctx.results_dir)
-        os.makedirs(ctx.results_dir)
+        ctx.output_dir = os.path.join(ctx.output_dir, self.name)
+        if os.path.exists(ctx.output_dir):
+            rmtree(ctx.output_dir)
+        os.makedirs(ctx.output_dir)
 
         test_suite = self.clone()
         tests = test_suite.generate_tests(ctx)
@@ -434,8 +434,8 @@ class TestSuite:
         if ctx.reference:
             test_suite.to_json_file(test_suite.filename)
 
-        if not ctx.keep_files and os.path.isdir(ctx.results_dir):
-            rmtree(ctx.results_dir)
+        if not ctx.keep_files and os.path.isdir(ctx.output_dir):
+            rmtree(ctx.output_dir)
 
         return test_suite
 
@@ -457,7 +457,7 @@ class TestSuite:
                     self,
                     test_vector,
                     skip,
-                    ctx.results_dir,
+                    ctx.output_dir,
                     ctx.reference,
                     ctx.timeout,
                     ctx.keep_files,

--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -20,6 +20,7 @@ import hashlib
 import os
 import shutil
 import subprocess
+import sys
 import urllib.request
 import zipfile
 import platform
@@ -140,3 +141,34 @@ def normalize_path(path: str) -> str:
     if platform.system() == "Windows":
         return path.replace("\\", "/")
     return path
+
+
+def _linux_user_data_dir(appname: str) -> str:
+    """Return data directory tied to the user"""
+    path = os.environ.get("XDG_DATA_HOME", "")
+    if not path.strip():
+        path = os.path.expanduser("~/.local/share")
+    return os.path.join(path, appname)
+
+
+def _linux_site_data_dir(appname: str) -> str:
+    """Return data directory shared by users"""
+    path = os.environ.get("XDG_DATA_DIRS", "")
+    if not path.strip():
+        path = "/usr/local/share:/usr/share"
+    path = path.split(os.pathsep)[0]
+    return os.path.join(path, appname)
+
+
+def _win_user_data_dir(appname: str) -> str:
+    """Return data directory"""
+    path = os.path.expanduser(r"~\AppData\Local")
+    return os.path.join(path, appname)
+
+
+if sys.platform == "win32":
+    site_data_dir = _win_user_data_dir  # On Windows always user_data_dir
+    user_data_dir = _win_user_data_dir
+else:
+    site_data_dir = _linux_site_data_dir
+    user_data_dir = _linux_user_data_dir


### PR DESCRIPTION
* Use `tempfile.gettempdir()` for temporal results directory:

     * before commit results_dir is `__file__ /../results`
     * after commit results_dir is `/tmp/fluster_results`

    The global argument `output` can be used for custom temporal results dir.

*  Using platform dirs to execute installed fluster.

    Checking if fluster is uninstalled with the existence of the '.git' dir.

    For installed fluster, the site platform dirs is preferred if exists. If not, user platform dirs will be used, that is, `~/.local/share/fluster` (or `XDG_DATA_HOME`) will be used if `/usr/share/fluster` (or `XDG_DATA_DIRS`) doesn't exist.

    Fluster tries to use the platformdirs[1] lib. But if not found, it fallbacks to a simple implementation. The reason is to avoid introducing the first external dependency.

    [1] https://github.com/platformdirs/platformdirs
