### PR TITLE
junitxml: Add each vector test time

### DIFF
--- a/fluster/fluster.py
+++ b/fluster/fluster.py
@@ -382,6 +382,8 @@ class Fluster:
                     ]:
                         jcase.result = _parse_vector_errors(vector)
 
+                    jcase.time = vector.test_time
+
                     jsuite.add_testcase(jcase)
 
                     if vector.test_result is TestVectorResult.TIMEOUT and ctx.jobs == 1:

--- a/fluster/test.py
+++ b/fluster/test.py
@@ -19,6 +19,7 @@ import os
 from subprocess import TimeoutExpired
 import unittest
 from typing import Any
+from time import perf_counter
 
 from fluster.decoder import Decoder
 from fluster.test_vector import TestVector, TestVectorResult
@@ -75,6 +76,7 @@ class Test(unittest.TestCase):
         input_filepath = normalize_path(input_filepath)
 
         try:
+            start = perf_counter()
             result = self.decoder.decode(
                 input_filepath,
                 output_filepath,
@@ -83,15 +85,24 @@ class Test(unittest.TestCase):
                 self.verbose,
                 self.keep_files,
             )
+            self.test_suite.test_vectors[self.test_vector.name].test_time = (
+                perf_counter() - start
+            )
         except TimeoutExpired:
             self.test_suite.test_vectors[
                 self.test_vector.name
             ].test_result = TestVectorResult.TIMEOUT
+            self.test_suite.test_vectors[self.test_vector.name].test_time = (
+                perf_counter() - start
+            )
             raise
         except Exception:
             self.test_suite.test_vectors[
                 self.test_vector.name
             ].test_result = TestVectorResult.ERROR
+            self.test_suite.test_vectors[self.test_vector.name].test_time = (
+                perf_counter() - start
+            )
             raise
 
         if (

--- a/fluster/test_vector.py
+++ b/fluster/test_vector.py
@@ -60,6 +60,7 @@ class TestVector:
 
         # Not included in JSON
         self.test_result = TestVectorResult.NOT_RUN
+        self.test_time = 0.0
         self.errors: List[List[str]] = []
 
     @classmethod
@@ -76,6 +77,7 @@ class TestVector:
         data = self.__dict__.copy()
         data.pop("test_result")
         data.pop("errors")
+        data.pop("test_time")
         data["output_format"] = str(self.output_format.value)
         return data
 


### PR DESCRIPTION
In gitlab junit reports, the testsuite time is not used to show the complete test time and is shown as 0.0 even if set.

Instead, it shows the sum of each test case time.

This adds each test case time in the junit report.
The sum will not give the actual total time when multiple threads are used, but it can already give an idea of the used time.