### PR TITLE
gst: va: Fix AV1 decoder to use parsebin

### DIFF
--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -494,7 +494,8 @@ class GStreamerV4l2VP9Gst10Decoder(GStreamer10Video):
 class GStreamerVaAV1Gst10Decoder(GStreamer10Video):
     '''GStreamer AV1 VA decoder implementation for GStreamer 1.0'''
     codec = Codec.AV1
-    decoder_bin = ' ivfparse ! av1parse ! vaav1dec '
+    check_decoder_bin = ' vaav1dec '
+    decoder_bin = f' parsebin ! {check_decoder_bin}'
     api = 'VA'
     hw_acceleration = True
 


### PR DESCRIPTION
Some AV1 tests are using matroska container, so forcing IFV parser cause some failures. This fixes:

  - av1-1-b8-03-sizedown
  - av1-1-b8-03-sizeup