### PR TITLE
test-suites-dir: Allow multiple dirs with OS path separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ optional arguments:
                         set the directory where decoder outputs will be stored
   -ne, --no-emoji       set to use plain text instead of emojis
   -tsd TEST_SUITES_DIR, --test-suites-dir TEST_SUITES_DIR
-                        set the directory where test suite will be read from
+                        set directory where test suite will be read from, multiple directories are supported with OS path separator (:)
 
 subcommands:
   {list,l,run,r,download,d,reference,f}

--- a/fluster/fluster.py
+++ b/fluster/fluster.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 import os
 import os.path
 from functools import lru_cache
-from typing import List, Dict, Any, Tuple, Optional
+from typing import List, Dict, Any, Tuple, Optional, Iterator
 import sys
 from enum import Enum
 from shutil import rmtree
@@ -161,9 +161,14 @@ class Fluster:
                 f" * output_dir: {self.output_dir}"
             )
 
+    def _walk_test_suite_dir(self) -> Iterator[Tuple[str, List[str], List[str]]]:
+        for test_suite_dir in self.test_suites_dir.split(os.pathsep):
+            for root, dirnames, files in os.walk(test_suite_dir):
+                yield (root, dirnames, files)
+
     @lru_cache(maxsize=128)
     def _load_test_suites(self) -> None:
-        for root, _, files in os.walk(self.test_suites_dir):
+        for root, _, files in self._walk_test_suite_dir():
             for file in files:
                 if os.path.splitext(file)[1] == ".json":
                     try:

--- a/fluster/main.py
+++ b/fluster/main.py
@@ -161,7 +161,10 @@ class Main:
         parser.add_argument(
             "-tsd",
             "--test-suites-dir",
-            help="set the directory where test suite will be read from",
+            help=(
+                "set directory where test suite will be read from, "
+                f"multiple directories are supported with OS path separator ({os.pathsep})"
+            ),
             default=self.test_suites_dir,
         )
         subparsers = parser.add_subparsers(title="subcommands")


### PR DESCRIPTION
Allowing multiple directories allows the creation of private test suites. Implemented using OS path separator (`os.pathsep`). For instance, on Linux:

```
python3 ./fluster.py -tsd "/opt/fluster_tsd:/opt/priv_f_tsd" list
```