### PR TITLE
ffmpeg: pass -nostdin to not alter the terminal settings to begin with.

### DIFF
--- a/fluster/decoders/ffmpeg.py
+++ b/fluster/decoders/ffmpeg.py
@@ -27,7 +27,7 @@ from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
 from fluster.utils import file_checksum, run_command
 
-FFMPEG_TPL = "{} -i {} {} -vf {}format=pix_fmts={} -f rawvideo {}"
+FFMPEG_TPL = "{} -nostdin -i {} {} -vf {}format=pix_fmts={} -f rawvideo {}"
 
 
 def output_format_to_ffformat(output_format: OutputFormat) -> str:


### PR DESCRIPTION
Fix issue with Bash Linux terminal does not echo the input characters after running a full test suite.

Thanks to Kerin Millar for the help in the bash list [1]

The issue could be reproduced with
```
from multiprocessing import Pool
from unittest.result import TestResult
from time import perf_counter
import subprocess

jobs=3
failfast=False
timeout=30
verbose=True
tests = [1,2,3]

def run_command(command, verbose = False, check = True, timeout = None):
    """Runs a command"""
    sout = subprocess.DEVNULL if not verbose else None
    serr = subprocess.DEVNULL if not verbose else None
    if verbose:
        print(f'\nRunning command "{" ".join(command)}"')
    try:
        subprocess.run(command, stdout=sout, stderr=serr, check=check, timeout=timeout)
    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
        raise ex

def _run_worker(test):
    print("running", test)
    cmd = ['ffmpeg']
    out = run_command(cmd, timeout=timeout, verbose=verbose)
    return out

with Pool(jobs) as pool:

    def _callback(test_result) -> None:
        print(
            test_result,
            flush=True,
        )
        if failfast:
            pool.terminate()

    start = perf_counter()
    for test in tests:
        pool.apply_async(_run_worker, (test,), callback=_callback)
    pool.close()
    pool.join()
```

Fixes #147

[1] https://lists.gnu.org/archive/html/help-bash/2024-02/msg00084.html