### PR TITLE
Explicitly set CMAKE_GENERATOR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ FLUSTER+=--no-emoji
 else
 KERNEL_NAME=$(shell uname -s)
 endif
+CMAKE_GENERATOR=Unix Makefiles
 
 help:
 	@awk -F ':|##' '/^[^\t].+?:.*?##/ { printf "\033[36m%-30s\033[0m %s\n", $$1, $$NF }' $(MAKEFILE_LIST)


### PR DESCRIPTION
CMake based builds for reference decoder follow the schema:
`cmake <bla> && $(MAKE) -C build`
This only works for 'Unix Makefile' generator. This breaks if the user has set CMAKE_GENERATOR by default to something different, e.g. Ninja.