### PR TITLE
Add support for new decoders of Fluendo

### DIFF
--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
+# pylint: disable=too-many-lines
+
 import shlex
 import subprocess
 from functools import lru_cache
@@ -912,3 +914,105 @@ class FluendoFluLCEVCVAH264DecGst10Decoder(GStreamer10Video):
     api = "HW"
     hw_acceleration = True
     name = f"{provider}-{codec.value}-{api}-lcevchwvah264dec-Gst1.0"
+
+
+class FluendoFluHWVAH264DecBase(GStreamer10Video):
+    """Fluendo base class for fluhwva{backend}h264dec elements"""
+
+    provider = "Fluendo"
+    api = "INVALID"
+    codec = Codec.H264
+    decoder_bin_tmpl = " h264parse ! fluhwva{backend}h264dec "
+
+    def __init__(self) -> None:
+        self.decoder_bin = self.decoder_bin_tmpl.format(backend=self.api.lower())
+        super().__init__()
+
+
+class FluendoFluHWVAH265DecBase(GStreamer10Video):
+    """Fluendo base class for fluhwva{backend}h265dec elements"""
+
+    provider = "Fluendo"
+    api = "INVALID"
+    codec = Codec.H265
+    decoder_bin_tmpl = " h265parse ! fluhwva{backend}h265dec "
+
+    def __init__(self) -> None:
+        self.decoder_bin = self.decoder_bin_tmpl.format(backend=self.api.lower())
+        super().__init__()
+
+
+# fluhwva{backend}h264dec
+
+
+@register_decoder
+class FluendoFluHWVAVAAPIH264dec(FluendoFluHWVAH264DecBase):
+    """fluhwvavaapih264dec"""
+
+    api = "VAAPI"
+
+
+@register_decoder
+class FluendoFluHWVAVDPAUH264dec(FluendoFluHWVAH264DecBase):
+    """fluhwvavdpauh264dec"""
+
+    api = "VDPAU"
+
+
+@register_decoder
+class FluendoFluHWVADXVA2H264dec(FluendoFluHWVAH264DecBase):
+    """fluhwvadxva2h264dec"""
+
+    api = "DXVA2"
+
+
+@register_decoder
+class FluendoFluHWVAVDAH264dec(FluendoFluHWVAH264DecBase):
+    """fluhwvavdah264dec"""
+
+    api = "VDA"
+
+
+@register_decoder
+class FluendoFluHWVAVTH264dec(FluendoFluHWVAH264DecBase):
+    """fluhwvavth264dec"""
+
+    api = "VT"
+
+
+# fluhwva{backend}h265dec
+
+
+@register_decoder
+class FluendoFluHWVAVAAPIH265dec(FluendoFluHWVAH265DecBase):
+    """fluhwvavaapih265dec"""
+
+    api = "VAAPI"
+
+
+@register_decoder
+class FluendoFluHWVAVDPAUH265dec(FluendoFluHWVAH265DecBase):
+    """fluhwvavdpauh265dec"""
+
+    api = "VDPAU"
+
+
+@register_decoder
+class FluendoFluHWVADXVA2H265dec(FluendoFluHWVAH265DecBase):
+    """fluhwvadxva2h265dec"""
+
+    api = "DXVA2"
+
+
+@register_decoder
+class FluendoFluHWVAVDAH265dec(FluendoFluHWVAH265DecBase):
+    """fluhwvavdah265dec"""
+
+    api = "VDA"
+
+
+@register_decoder
+class FluendoFluHWVAVTH265dec(FluendoFluHWVAH265DecBase):
+    """fluhwvavth265dec"""
+
+    api = "VT"


### PR DESCRIPTION
Fluendo divided their decoders by backend and codec, so where before there were just `fluhwvadec` or `fluhwvah264dec`, now there are `fluhwva{backend}{codec}` (`fluhwvavaapih264dec` for example).

This commit generate the types for this decoders programmatically, to reduce the amount of code required otherwise.

Decoders generated:
```
Fluendo-H.264-DXVA2-Gst1.0: Fluendo H.264 DXVA2 decoder for GStreamer 1.0
Fluendo-H.264-VAAPI-Gst1.0: Fluendo H.264 VAAPI decoder for GStreamer 1.0
Fluendo-H.264-VDA-Gst1.0: Fluendo H.264 VDA decoder for GStreamer 1.0
Fluendo-H.264-VDPAU-Gst1.0: Fluendo H.264 VDPAU decoder for GStreamer 1.0
Fluendo-H.264-VT-Gst1.0: Fluendo H.264 VT decoder for GStreamer 1.0
Fluendo-H.265-byte-stream-au-DXVA2-Gst1.0: Fluendo H.265-byte-stream-au DXVA2 decoder for GStreamer 1.0
Fluendo-H.265-byte-stream-au-VAAPI-Gst1.0: Fluendo H.265-byte-stream-au VAAPI decoder for GStreamer 1.0
Fluendo-H.265-byte-stream-au-VDA-Gst1.0: Fluendo H.265-byte-stream-au VDA decoder for GStreamer 1.0
Fluendo-H.265-byte-stream-au-VDPAU-Gst1.0: Fluendo H.265-byte-stream-au VDPAU decoder for GStreamer 1.0
Fluendo-H.265-byte-stream-au-VT-Gst1.0: Fluendo H.265-byte-stream-au VT decoder for GStreamer 1.0
Fluendo-H.265-byte-stream-nal-DXVA2-Gst1.0: Fluendo H.265-byte-stream-nal DXVA2 decoder for GStreamer 1.0
Fluendo-H.265-byte-stream-nal-VAAPI-Gst1.0: Fluendo H.265-byte-stream-nal VAAPI decoder for GStreamer 1.0
Fluendo-H.265-byte-stream-nal-VDA-Gst1.0: Fluendo H.265-byte-stream-nal VDA decoder for GStreamer 1.0
Fluendo-H.265-byte-stream-nal-VDPAU-Gst1.0: Fluendo H.265-byte-stream-nal VDPAU decoder for GStreamer 1.0
Fluendo-H.265-byte-stream-nal-VT-Gst1.0: Fluendo H.265-byte-stream-nal VT decoder for GStreamer 1.0
Fluendo-H.265-hev1-au-DXVA2-Gst1.0: Fluendo H.265-hev1-au DXVA2 decoder for GStreamer 1.0
Fluendo-H.265-hev1-au-VAAPI-Gst1.0: Fluendo H.265-hev1-au VAAPI decoder for GStreamer 1.0
Fluendo-H.265-hev1-au-VDA-Gst1.0: Fluendo H.265-hev1-au VDA decoder for GStreamer 1.0
Fluendo-H.265-hev1-au-VDPAU-Gst1.0: Fluendo H.265-hev1-au VDPAU decoder for GStreamer 1.0
Fluendo-H.265-hev1-au-VT-Gst1.0: Fluendo H.265-hev1-au VT decoder for GStreamer 1.0
Fluendo-H.265-hev1-nal-DXVA2-Gst1.0: Fluendo H.265-hev1-nal DXVA2 decoder for GStreamer 1.0
Fluendo-H.265-hev1-nal-VAAPI-Gst1.0: Fluendo H.265-hev1-nal VAAPI decoder for GStreamer 1.0
Fluendo-H.265-hev1-nal-VDA-Gst1.0: Fluendo H.265-hev1-nal VDA decoder for GStreamer 1.0
Fluendo-H.265-hev1-nal-VDPAU-Gst1.0: Fluendo H.265-hev1-nal VDPAU decoder for GStreamer 1.0
Fluendo-H.265-hev1-nal-VT-Gst1.0: Fluendo H.265-hev1-nal VT decoder for GStreamer 1.0
Fluendo-H.265-hvc1-au-DXVA2-Gst1.0: Fluendo H.265-hvc1-au DXVA2 decoder for GStreamer 1.0
Fluendo-H.265-hvc1-au-VAAPI-Gst1.0: Fluendo H.265-hvc1-au VAAPI decoder for GStreamer 1.0
Fluendo-H.265-hvc1-au-VDA-Gst1.0: Fluendo H.265-hvc1-au VDA decoder for GStreamer 1.0
Fluendo-H.265-hvc1-au-VDPAU-Gst1.0: Fluendo H.265-hvc1-au VDPAU decoder for GStreamer 1.0
Fluendo-H.265-hvc1-au-VT-Gst1.0: Fluendo H.265-hvc1-au VT decoder for GStreamer 1.0
Fluendo-H.265-hvc1-nal-DXVA2-Gst1.0: Fluendo H.265-hvc1-nal DXVA2 decoder for GStreamer 1.0
Fluendo-H.265-hvc1-nal-VAAPI-Gst1.0: Fluendo H.265-hvc1-nal VAAPI decoder for GStreamer 1.0
Fluendo-H.265-hvc1-nal-VDA-Gst1.0: Fluendo H.265-hvc1-nal VDA decoder for GStreamer 1.0
Fluendo-H.265-hvc1-nal-VDPAU-Gst1.0: Fluendo H.265-hvc1-nal VDPAU decoder for GStreamer 1.0
Fluendo-H.265-hvc1-nal-VT-Gst1.0: Fluendo H.265-hvc1-nal VT decoder for GStreamer 1.0
```

Issue: OCP_5454