### PR TITLE
FFmpeg: Misc improvements, use MD5 muxer and add CUDA/NVDEC decoders

### DIFF
--- a/fluster/decoders/ffmpeg.py
+++ b/fluster/decoders/ffmpeg.py
@@ -403,3 +403,55 @@ class FFmpegAV1VulkanDecoder(FFmpegVulkanDecoder):
     """FFmpeg Vulkan decoder for AV1"""
 
     codec = Codec.AV1
+
+
+class FFmpegCudaDecoder(FFmpegDecoder):
+    """Generic class for FFmpeg CUDA decoder"""
+
+    hw_acceleration = True
+    api = "CUDA"
+    hw_output_format = "cuda"
+    hw_download = True
+    hw_download_mapping = {
+        OutputFormat.YUV420P: "nv12",
+        OutputFormat.YUV444P: "yuv444p",
+        OutputFormat.YUV420P10LE: "p010",
+        OutputFormat.YUV444P10LE: "yuv444p16le",
+        OutputFormat.YUV420P12LE: "p016",
+        OutputFormat.YUV444P12LE: "yuv444p16le",
+    }
+
+
+@register_decoder
+class FFmpegH264CudaDecoder(FFmpegCudaDecoder):
+    """FFmpeg CUDA decoder for H.264"""
+
+    codec = Codec.H264
+
+
+@register_decoder
+class FFmpegH265CudaDecoder(FFmpegCudaDecoder):
+    """FFmpeg CUDA decoder for H.265"""
+
+    codec = Codec.H265
+
+
+@register_decoder
+class FFmpegVP8CudaDecoder(FFmpegCudaDecoder):
+    """FFmpeg CUDA decoder for VP8"""
+
+    codec = Codec.VP8
+
+
+@register_decoder
+class FFmpegVP9CudaDecoder(FFmpegCudaDecoder):
+    """FFmpeg CUDA decoder for VP9"""
+
+    codec = Codec.VP9
+
+
+@register_decoder
+class FFmpegAV1VCudaDecoder(FFmpegCudaDecoder):
+    """FFmpeg CUDA decoder for AV1"""
+
+    codec = Codec.AV1

--- a/fluster/decoders/ffmpeg.py
+++ b/fluster/decoders/ffmpeg.py
@@ -67,7 +67,8 @@ class FFmpegDecoder(Decoder):
     api = ""
     wrapper = False
     hw_download = False
-    init_device = ""
+    init_hw_device = ""
+    hw_output_format = ""
 
     def __init__(self) -> None:
         super().__init__()
@@ -88,8 +89,10 @@ class FFmpegDecoder(Decoder):
         # pylint: disable=unused-argument
         cmd = self.binary
         if self.hw_acceleration:
-            if self.init_device:
-                cmd += f' -init_hw_device "{self.init_device}" -hwaccel_output_format {self.api.lower()}'
+            if self.init_hw_device:
+                cmd += f' -init_hw_device "{self.init_hw_device}"'
+            if self.hw_output_format:
+                cmd += f" -hwaccel_output_format {self.hw_output_format}"
             if self.wrapper:
                 cmd += f" -c:v {self.api.lower()}"
             else:
@@ -309,7 +312,8 @@ class FFmpegVulkanDecoder(FFmpegDecoder):
 
     hw_acceleration = True
     api = "Vulkan"
-    init_device = "vulkan"
+    init_hw_device = "vulkan"
+    hw_output_format = "vulkan"
     hw_download = True
 
 

--- a/fluster/decoders/ffmpeg.py
+++ b/fluster/decoders/ffmpeg.py
@@ -269,6 +269,13 @@ class FFmpegH265VdpauDecoder(FFmpegVdpauDecoder):
 
 
 @register_decoder
+class FFmpegVP9VdpauDecoder(FFmpegVdpauDecoder):
+    """FFmpeg VDPAU decoder for VP9"""
+
+    codec = Codec.VP9
+
+
+@register_decoder
 class FFmpegAV1VdpauDecoder(FFmpegVdpauDecoder):
     """FFmpeg VDPAU decoder for AV1"""
 

--- a/fluster/decoders/ffmpeg.py
+++ b/fluster/decoders/ffmpeg.py
@@ -52,6 +52,7 @@ class FFmpegDecoder(Decoder):
     hw_download_mapping: Dict[OutputFormat, str] = {}
     init_hw_device = ""
     hw_output_format = ""
+    thread_count = 1
 
     def __init__(self) -> None:
         super().__init__()
@@ -71,6 +72,7 @@ class FFmpegDecoder(Decoder):
         keep_files: bool,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
+        # pylint: disable=too-many-branches
         command = [self.binary, "-hide_banner", "-nostdin"]
 
         # Hardware acceleration
@@ -81,6 +83,10 @@ class FFmpegDecoder(Decoder):
                 command.extend(["-hwaccel", self.api.lower()])
             if self.hw_output_format:
                 command.extend(["-hwaccel_output_format", self.hw_output_format])
+
+        # Number of threads
+        if self.thread_count:
+            command.extend(["-threads", str(self.thread_count)])
 
         # Codec
         if self.hw_acceleration and self.wrapper:

--- a/fluster/decoders/ffmpeg.py
+++ b/fluster/decoders/ffmpeg.py
@@ -324,34 +324,48 @@ class FFmpegH265D3d11vaDecoder(FFmpegD3d11vaDecoder):
     codec = Codec.H265
 
 
+class FFmpegV4L2m2mDecoder(FFmpegDecoder):
+    """Generic class for FFmpeg V4L2 mem2mem decoder"""
+
+    hw_acceleration = True
+    wrapper = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = f"FFmpeg-{self.codec.value}-v4l2m2m"
+        self.description = f"FFmpeg {self.codec.value} v4l2m2m decoder"
+
+
 @register_decoder
-class FFmpegVP8V4L2m2mDecoder(FFmpegDecoder):
-    """FFmpeg V4L2m2m decoder for VP8"""
+class FFmpegVP8V4L2m2mDecoder(FFmpegV4L2m2mDecoder):
+    """FFmpeg V4L2 mem2mem decoder for VP8"""
 
     codec = Codec.VP8
-    hw_acceleration = True
     api = "vp8_v4l2m2m"
-    wrapper = True
 
 
 @register_decoder
-class FFmpegVP9V4L2m2mDecoder(FFmpegDecoder):
-    """FFmpeg V4L2m2m decoder for VP9"""
+class FFmpegVP9V4L2m2mDecoder(FFmpegV4L2m2mDecoder):
+    """FFmpeg V4L2 mem2mem decoder for VP9"""
 
     codec = Codec.VP9
-    hw_acceleration = True
     api = "vp9_v4l2m2m"
-    wrapper = True
 
 
 @register_decoder
-class FFmpegH264V4L2m2mDecoder(FFmpegDecoder):
-    """FFmpeg V4L2m2m decoder for H264"""
+class FFmpegH264V4L2m2mDecoder(FFmpegV4L2m2mDecoder):
+    """FFmpeg V4L2 mem2mem decoder for H.264"""
 
     codec = Codec.H264
-    hw_acceleration = True
     api = "h264_v4l2m2m"
-    wrapper = True
+
+
+@register_decoder
+class FFmpegH265V4L2m2mDecoder(FFmpegV4L2m2mDecoder):
+    """FFmpeg V4L2 mem2mem decoder for H.265"""
+
+    codec = Codec.H265
+    api = "hevc_v4l2m2m"
 
 
 class FFmpegVulkanDecoder(FFmpegDecoder):

--- a/fluster/decoders/ffmpeg.py
+++ b/fluster/decoders/ffmpeg.py
@@ -75,6 +75,10 @@ class FFmpegDecoder(Decoder):
         # pylint: disable=too-many-branches
         command = [self.binary, "-hide_banner", "-nostdin"]
 
+        # Loglevel
+        if not verbose:
+            command.extend(["-loglevel", "warning"])
+
         # Hardware acceleration
         if self.hw_acceleration:
             if self.init_hw_device:

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -111,13 +111,10 @@ class GStreamer(Decoder):
             self.cmd, input_filepath, self.decoder_bin, self.caps, self.sink, output
         )
 
-    def parse_videocodectestsink_md5sum(self, data: List[str], verbose: bool) -> str:
+    def parse_videocodectestsink_md5sum(self, data: List[str]) -> str:
         """Parse the MD5 sum out of commandline output produced when using
         videocodectestsink."""
-        md5sum = None
         for line in data:
-            if verbose:
-                print(line)
             pattern = (
                 "conformance/checksum, checksum-type=(string)MD5, checksum=(string)"
             )
@@ -135,14 +132,9 @@ class GStreamer(Decoder):
                     continue
                 else:
                     sum_end += sum_start
-                    md5sum = line[sum_start:sum_end]
-                    if not verbose:
-                        return md5sum
+                    return line[sum_start:sum_end]
 
-        if not md5sum:
-            raise Exception("No MD5 found in the program trace.")
-
-        return md5sum
+        raise Exception("No MD5 found in the program trace.")
 
     def decode(
         self,
@@ -165,7 +157,7 @@ class GStreamer(Decoder):
             data = run_pipe_command_with_std_output(
                 command, timeout=timeout, verbose=verbose
             )
-            return self.parse_videocodectestsink_md5sum(data, verbose)
+            return self.parse_videocodectestsink_md5sum(data)
 
         pipeline = self.gen_pipeline(input_filepath, output_filepath, output_format)
         run_command(shlex.split(pipeline), timeout=timeout, verbose=verbose)

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -28,7 +28,7 @@ from fluster.decoder import Decoder, register_decoder
 from fluster.utils import (
     file_checksum,
     run_command,
-    run_pipe_command_with_std_output,
+    run_command_with_output,
     normalize_binary_cmd,
 )
 
@@ -154,9 +154,9 @@ class GStreamer(Decoder):
             pipeline = self.gen_pipeline(input_filepath, output_param, output_format)
             command = shlex.split(pipeline)
             command.append("-m")
-            data = run_pipe_command_with_std_output(
+            data = run_command_with_output(
                 command, timeout=timeout, verbose=verbose
-            )
+            ).splitlines()
             return self.parse_videocodectestsink_md5sum(data)
 
         pipeline = self.gen_pipeline(input_filepath, output_filepath, output_format)

--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -84,6 +84,8 @@ def run_pipe_command_with_std_output(
         data = subprocess.check_output(
             command, stderr=serr, timeout=timeout, universal_newlines=True
         )
+        if verbose:
+            print(data)
         return data.splitlines()
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
         odata: List[str] = []

--- a/scripts/gen_jct_vc.py
+++ b/scripts/gen_jct_vc.py
@@ -160,7 +160,7 @@ class JCTVTGenerator:
                            'default=nokey=1:noprint_wrappers=1',
                            absolute_input_path]
 
-                result = utils.run_pipe_command_with_std_output(command)
+                result = utils.run_command_with_output(command).splitlines()
                 pix_fmt = result[0]
                 try:
                     test_vector.output_format = OutputFormat[pix_fmt.upper()]


### PR DESCRIPTION
This PR include misc improvements and refactorings to simplify building the FFmpeg command line.

- Rename and refactor of `utils.run_pipe_command_with_std_output()`
- Use shared `@lru_cache` for ffmpeg commands used in `check()`
- Fix version detect of `<master>`.`<minor>` releases
- Separate handling of `-hw_output_format` and `-hwaccel_output_format`
- Convert `output_format_to_ffformat()` to `hw_download_mapping` property
- Refactor to build command line in `decode()` using a string list
- Validate and inform what codec to use using `-codec`
- Use `md5` muxer when supported to avoid always having to save output files
- Use single-threaded decoding, `fluster` support running multiple jobs
- Rename V4L2 mem2mem decoders
- Add VDPAU VP9 decoder
- Add CUDA/NVDEC decoders

This was tested using FFmpeg `4.2.1` and `7.0.1` along with GStreamer `1.24.5`.