### PR TITLE
Add FFmpeg VVC decoder

### DIFF
--- a/fluster/decoders/ffmpeg.py
+++ b/fluster/decoders/ffmpeg.py
@@ -143,6 +143,7 @@ class FFmpegDecoder(Decoder):
         codec_mapping = {
             Codec.H264: "h264",
             Codec.H265: "hevc",
+            Codec.H266: "vvc",
             Codec.VP8: "vp8",
             Codec.VP9: "vp9",
             Codec.AV1: "av1",
@@ -189,6 +190,13 @@ class FFmpegH265Decoder(FFmpegDecoder):
     """FFmpeg SW decoder for H.265"""
 
     codec = Codec.H265
+
+
+@register_decoder
+class FFmpegH266Decoder(FFmpegDecoder):
+    """FFmpeg SW decoder for H.265"""
+
+    codec = Codec.H266
 
 
 @register_decoder


### PR DESCRIPTION
Since FFmpeg 7.1, the VVC decoder is no longer marked as experimental.

During the execution of JVET-VVC_draft6, the FFmpeg VVC decoder got a a score of 239/282 (84.75%).

[Results](https://gist.github.com/cadubentzen/538d1063ca039392693c6907975a9fc0)