### PR TITLE
OCP-5946 Fix H266 output format

### DIFF
--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -59,7 +59,7 @@ def output_format_to_gst(output_format: OutputFormat) -> str:
     """Return GStreamer pixel format"""
     mapping = {
         OutputFormat.GRAY: "GRAY8",
-        OutputFormat.GRAY10LE: "GRAY10_LE32",
+        OutputFormat.GRAY10LE: "GRAY10_LE16",
         OutputFormat.GRAY16LE: "GRAY16_LE",
         OutputFormat.YUV420P: "I420",
         OutputFormat.YUV422P: "Y42B",


### PR DESCRIPTION
Fix H266 TS output format gray10le32->gray10le16

The proper output format of the decoder is 16b aligned, instead of 32.