### PR TITLE
COM-12460: fix in mpeg4 ref dec and add mpeg2 ref dec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ lint: format-check ## run static analysis using pylint, flake8 and mypy
 
 create_dirs=mkdir -p $(CONTRIB_DIR) $(DECODERS_DIR)
 
-all_reference_decoders: h264_reference_decoder h265_reference_decoder h266_reference_decoder aac_reference_decoder ## build all reference decoders
+all_reference_decoders: h264_reference_decoder h265_reference_decoder h266_reference_decoder mpeg_4_aac_reference_decoder mpeg_2_aac_reference_decoder ## build all reference decoders
 
 h266_reference_decoder: ## build H.266 reference decoder
 	$(create_dirs)
@@ -91,7 +91,7 @@ h264_reference_decoder: ## build H.264 reference decoder
 	cd $(CONTRIB_DIR)/JM && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wno-stringop-truncation -Wno-stringop-overflow" && $(MAKE) -C build ldecod
 	find $(CONTRIB_DIR)/JM/bin/umake -name "ldecod" -type f -exec cp {} $(DECODERS_DIR)/ \;
 
-aac_reference_decoder: ## build ISO MPEG4 AAC reference decoder
+mpeg_4_aac_reference_decoder: ## build ISO MPEG4 AAC reference decoder
 ifeq ($(dpkg -l | grep gcc-multilib), "")
 	sudo apt-get install gcc-multilib
 endif
@@ -111,11 +111,11 @@ ifeq ($(wildcard $(CONTRIB_DIR)/C050470e_Electronic_inserts), )
 	'https://standards.iso.org/ittf/PubliclyAvailableStandards/c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip' > /dev/null
 	cd $(CONTRIB_DIR) && wget --keep-session-cookies --load-cookies iso_cookies.txt --post-data 'ok=I+accept' \
 	'https://standards.iso.org/ittf/PubliclyAvailableStandards/c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip'
-	cd $(CONTRIB_DIR) && unzip -q c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip
+	cd $(CONTRIB_DIR) && unzip -oq c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip
 	cd $(CONTRIB_DIR) && rm -f iso_cookies.txt c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip
 
 	cd $(CONTRIB_DIR) && git clone https://github.com/MPEGGroup/isobmff.git
-	cd $(CONTRIB_DIR)/isobmff && mkdir build && cd build && cmake .. -DCMAKE_C_FLAGS=-m32 && $(MAKE) libisomediafile
+	cd $(CONTRIB_DIR)/isobmff && mkdir build && cd build && cmake .. -DCMAKE_C_FLAGS=-m64 && $(MAKE) libisomediafile
 	cd $(CONTRIB_DIR)/isobmff && mv lib/liblibisomediafile.a lib/libisomediafile.a
 	cd $(CONTRIB_DIR) && cp isobmff/lib/libisomediafile.a C050470e_Electronic_inserts/audio/natural/import/lib/
 	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/src/ISOMovies.h C050470e_Electronic_inserts/audio/natural/import/include/
@@ -128,7 +128,7 @@ else ifeq ($(KERNEL_NAME), Darwin)
 	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/macosx/MP4OSMacros.h C050470e_Electronic_inserts/audio/natural/import/include/ || true
 endif
 	cd $(CONTRIB_DIR) && wget --no-check-certificate https://www-mmsp.ece.mcgill.ca/Documents/Downloads/libtsp/libtsp-v7r0.tar.gz
-	cd $(CONTRIB_DIR) && tar -zxf libtsp-v7r0.tar.gz && chmod -R ugo=rwx libtsp-v7r0/ && cd libtsp-v7r0/ && $(MAKE) -s COPTS=-m32
+	cd $(CONTRIB_DIR) && tar -zxf libtsp-v7r0.tar.gz && chmod -R ugo=rwx libtsp-v7r0/ && cd libtsp-v7r0/ && $(MAKE) -s COPTS=-m64
 	cd $(CONTRIB_DIR) && rm -f libtsp-v7r0.tar.gz
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/lib/libtsp.a C050470e_Electronic_inserts/audio/natural/import/lib/
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp.h C050470e_Electronic_inserts/audio/natural/import/include/
@@ -136,12 +136,72 @@ endif
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/AFpar.h C050470e_Electronic_inserts/audio/natural/import/include/libtsp/
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/UTpar.h C050470e_Electronic_inserts/audio/natural/import/include/libtsp/
 endif
-	cd $(CONTRIB_DIR)/C050470e_Electronic_inserts/audio/natural/mp4mcDec && MAKELEVEL=0 $(MAKE) mp4audec_mc REFSOFT_INCLUDE_PATH=../import/include REFSOFT_LIBRARY_PATH=../import/lib CFLAGS=-m32 LDFLAGS=-m32
+	cd $(CONTRIB_DIR)/C050470e_Electronic_inserts/audio/natural/mp4mcDec && MAKELEVEL=0 $(MAKE) mp4audec_mc REFSOFT_INCLUDE_PATH=../import/include REFSOFT_LIBRARY_PATH=../import/lib CFLAGS=-m64 LDFLAGS=-m64
 	find $(CONTRIB_DIR)/C050470e_Electronic_inserts/audio/natural/bin/mp4mcDec -name "mp4audec_mc" -type f -exec cp {} $(DECODERS_DIR) \;
 
 ifneq ($(wildcard /usr/include/asm), )
 ifneq ($(wildcard /usr/include/asm-generic), )
 		sudo unlink /usr/include/asm
+endif
+endif
+
+mpeg_2_aac_reference_decoder: ## build ISO MPEG2 AAC reference decoder
+ifeq ($(dpkg -l | grep gcc-multilib), "")
+	sudo apt-get install gcc-multilib
+endif
+ifeq ($(dpkg -l | grep g++-multilib), "")
+	sudo apt-get install g++-multilib
+endif
+ifeq ($(wildcard /usr/include/asm), )
+ifneq ($(wildcard /usr/include/asm-generic), )
+	sudo ln -s /usr/include/asm-generic /usr/include/asm
+endif
+endif
+
+ifeq ($(wildcard $(CONTRIB_DIR)/C039486_Electronic_inserts), )
+	$(create_dirs)
+	cd $(CONTRIB_DIR) && rm -f iso_cookies.txt
+	cd $(CONTRIB_DIR) && wget -qO- --keep-session-cookies --save-cookies iso_cookies.txt \
+	'https://standards.iso.org/ittf/PubliclyAvailableStandards/c039486_ISO_IEC_13818-5_2005_Reference_Software.zip' > /dev/null
+	cd $(CONTRIB_DIR) && wget --keep-session-cookies --load-cookies iso_cookies.txt --post-data 'ok=I+accept' \
+	'https://standards.iso.org/ittf/PubliclyAvailableStandards/c039486_ISO_IEC_13818-5_2005_Reference_Software.zip'
+	cd $(CONTRIB_DIR) && unzip -oq c039486_ISO_IEC_13818-5_2005_Reference_Software.zip
+	cd $(CONTRIB_DIR) && rm -f iso_cookies.txt c039486_ISO_IEC_13818-5_2005_Reference_Software.zip ipmp.zip mpeg2audio.zip systems.zip video.zip
+
+	# Unzip and setup MPEG-2 AAC decoder files
+	cd $(CONTRIB_DIR) && unzip -oq mpeg2aac.zip
+	cd $(CONTRIB_DIR) && rm -f mpeg2aac.zip
+
+	cd $(CONTRIB_DIR) && git clone https://github.com/MPEGGroup/isobmff.git
+	cd $(CONTRIB_DIR)/isobmff && mkdir build && cd build && cmake .. -DCMAKE_C_FLAGS=-m64 && $(MAKE) libisomediafile
+	cd $(CONTRIB_DIR)/isobmff && mv lib/liblibisomediafile.a lib/libisomediafile.a
+	cd $(CONTRIB_DIR) && cp isobmff/lib/libisomediafile.a mpeg2aac/import/lib/
+	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/src/ISOMovies.h mpeg2aac/import/include/
+	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/src/MP4Movies.h mpeg2aac/import/include/
+ifeq ($(OS), Windows_NT)
+	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/w32/MP4OSMacros.h mpeg2aac/import/include/
+else ifeq ($(KERNEL_NAME), Linux)
+	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/linux/MP4OSMacros.h mpeg2aac/import/include/ || true
+else ifeq ($(KERNEL_NAME), Darwin)
+	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/macosx/MP4OSMacros.h mpeg2aac/import/include/ || true
+endif
+	cd $(CONTRIB_DIR) && wget --no-check-certificate https://www-mmsp.ece.mcgill.ca/Documents/Downloads/libtsp/libtsp-v7r0.tar.gz
+	cd $(CONTRIB_DIR) && tar -zxf libtsp-v7r0.tar.gz && chmod -R ugo=rwx libtsp-v7r0/ && cd libtsp-v7r0/ && $(MAKE) -s COPTS=-m64
+	cd $(CONTRIB_DIR) && rm -f libtsp-v7r0.tar.gz
+	cd $(CONTRIB_DIR) && cp libtsp-v7r0/lib/libtsp.a mpeg2aac/import/lib/
+	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp.h mpeg2aac/import/include/
+	cd $(CONTRIB_DIR) && mkdir mpeg2aac/import/include/libtsp/
+	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/AFpar.h mpeg2aac/import/include/libtsp/
+	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/UTpar.h mpeg2aac/import/include/libtsp/
+endif
+
+	# Build the MPEG-2 AAC decoder
+	cd $(CONTRIB_DIR)/mpeg2aac/aacDec && MAKELEVEL=0 $(MAKE) aacdec_mc REFSOFT_INCLUDE_PATH=../import/include REFSOFT_LIBRARY_PATH=../import/lib CFLAGS=-m64 LDFLAGS=-m64
+	find $(CONTRIB_DIR)/mpeg2aac/bin/mp4mcDec -name "aacdec_mc" -type f -exec cp {} $(DECODERS_DIR) \;
+
+ifneq ($(wildcard /usr/include/asm), )
+ifneq ($(wildcard /usr/include/asm-generic), )
+	sudo unlink /usr/include/asm
 endif
 endif
 
@@ -151,4 +211,4 @@ clean: ## remove contrib temporary folder
 dbg-%:
 	echo "Value of $* = $($*)"
 
-.PHONY: help all_reference_decoders h264_reference_decoder h265_reference_decoder aac_reference_decoder lint check format install_deps clean
+.PHONY: help all_reference_decoders h264_reference_decoder h265_reference_decoder mpeg_4_aac_reference_decoder mpeg_2_aac_reference_decoder lint check format install_deps clean


### PR DESCRIPTION
fix in mpeg4 reference decoder generation x32 to x64 bits and add mpeg2 reference decoder generation in Makefile