### PR TITLE
COM-12575: Investigate erratic behaviour of AAC audio reference decoders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,10 @@ h264_reference_decoder: ## build H.264 reference decoder
 	find $(CONTRIB_DIR)/JM/bin/umake -name "ldecod" -type f -exec cp {} $(DECODERS_DIR)/ \;
 
 mpeg_4_aac_reference_decoder: ## build ISO MPEG4 AAC reference decoder
-ifeq ($(dpkg -l | grep gcc-multilib), "")
+ifeq ("$(dpkg -l | grep gcc-multilib)", "")
 	sudo apt-get install gcc-multilib
 endif
-ifeq ($(dpkg -l | grep g++-multilib), "")
+ifeq ("$(dpkg -l | grep g++-multilib)", "")
 	sudo apt-get install g++-multilib
 endif
 ifeq ($(wildcard /usr/include/asm), )
@@ -114,9 +114,9 @@ ifeq ($(wildcard $(CONTRIB_DIR)/C050470e_Electronic_inserts), )
 	cd $(CONTRIB_DIR) && unzip -oq c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip
 	cd $(CONTRIB_DIR) && rm -f iso_cookies.txt c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip
 
-	cd $(CONTRIB_DIR) && [ -d isobmff ] && rm -rf isobmff && git clone https://github.com/MPEGGroup/isobmff.git
+	cd $(CONTRIB_DIR) && rm -rf isobmff && git clone https://github.com/MPEGGroup/isobmff.git
 	cd $(CONTRIB_DIR)/isobmff && git checkout tags/v0.2.0 -b v0.2.0
-	cd $(CONTRIB_DIR)/isobmff && mkdir -p build && cd build && cmake .. -DCMAKE_C_FLAGS=-m64 && $(MAKE) libisomediafile
+	cd $(CONTRIB_DIR)/isobmff && mkdir -p build && cd build && cmake .. -DCMAKE_C_FLAGS=-m32 && $(MAKE) libisomediafile
 	cd $(CONTRIB_DIR)/isobmff && mv lib/liblibisomediafile.a lib/libisomediafile.a
 	cd $(CONTRIB_DIR) && cp isobmff/lib/libisomediafile.a C050470e_Electronic_inserts/audio/natural/import/lib/
 	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/src/ISOMovies.h C050470e_Electronic_inserts/audio/natural/import/include/
@@ -129,7 +129,7 @@ else ifeq ($(KERNEL_NAME), Darwin)
 	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/macosx/MP4OSMacros.h C050470e_Electronic_inserts/audio/natural/import/include/ || true
 endif
 	cd $(CONTRIB_DIR) && wget --no-check-certificate https://www-mmsp.ece.mcgill.ca/Documents/Downloads/libtsp/libtsp-v7r0.tar.gz
-	cd $(CONTRIB_DIR) && tar -zxf libtsp-v7r0.tar.gz && chmod -R ugo=rwx libtsp-v7r0/ && cd libtsp-v7r0/ && $(MAKE) -s COPTS=-m64
+	cd $(CONTRIB_DIR) && tar -zxf libtsp-v7r0.tar.gz && chmod -R ugo=rwx libtsp-v7r0/ && cd libtsp-v7r0/ && $(MAKE) -s COPTS=-m32
 	cd $(CONTRIB_DIR) && rm -f libtsp-v7r0.tar.gz
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/lib/libtsp.a C050470e_Electronic_inserts/audio/natural/import/lib/
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp.h C050470e_Electronic_inserts/audio/natural/import/include/
@@ -137,7 +137,7 @@ endif
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/AFpar.h C050470e_Electronic_inserts/audio/natural/import/include/libtsp/
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/UTpar.h C050470e_Electronic_inserts/audio/natural/import/include/libtsp/
 endif
-	cd $(CONTRIB_DIR)/C050470e_Electronic_inserts/audio/natural/mp4mcDec && MAKELEVEL=0 $(MAKE) mp4audec_mc REFSOFT_INCLUDE_PATH=../import/include REFSOFT_LIBRARY_PATH=../import/lib CFLAGS=-m64 LDFLAGS=-m64
+	cd $(CONTRIB_DIR)/C050470e_Electronic_inserts/audio/natural/mp4mcDec && MAKELEVEL=0 $(MAKE) mp4audec_mc REFSOFT_INCLUDE_PATH=../import/include REFSOFT_LIBRARY_PATH=../import/lib CFLAGS=-m32 LDFLAGS=-m32
 	find $(CONTRIB_DIR)/C050470e_Electronic_inserts/audio/natural/bin/mp4mcDec -name "mp4audec_mc" -type f -exec cp {} $(DECODERS_DIR) \;
 
 ifneq ($(wildcard /usr/include/asm), )
@@ -147,10 +147,10 @@ endif
 endif
 
 mpeg_2_aac_reference_decoder: ## build ISO MPEG2 AAC reference decoder
-ifeq ($(dpkg -l | grep gcc-multilib), "")
+ifeq ("$(dpkg -l | grep gcc-multilib)", "")
 	sudo apt-get install gcc-multilib
 endif
-ifeq ($(dpkg -l | grep g++-multilib), "")
+ifeq ("$(dpkg -l | grep g++-multilib)", "")
 	sudo apt-get install g++-multilib
 endif
 ifeq ($(wildcard /usr/include/asm), )
@@ -172,9 +172,9 @@ ifeq ($(wildcard $(CONTRIB_DIR)/C039486_Electronic_inserts), )
 	cd $(CONTRIB_DIR) && unzip -oq mpeg2aac.zip
 	cd $(CONTRIB_DIR) && rm -f mpeg2aac.zip
 
-	cd $(CONTRIB_DIR) && [ -d isobmff ] && rm -rf isobmff && git clone https://github.com/MPEGGroup/isobmff.git
+	cd $(CONTRIB_DIR) && rm -rf isobmff && git clone https://github.com/MPEGGroup/isobmff.git
 	cd $(CONTRIB_DIR)/isobmff && git checkout tags/v0.2.0 -b v0.2.0
-	cd $(CONTRIB_DIR)/isobmff && mkdir -p build && cd build && cmake .. -DCMAKE_C_FLAGS=-m64 && $(MAKE) libisomediafile
+	cd $(CONTRIB_DIR)/isobmff && mkdir -p build && cd build && cmake .. -DCMAKE_C_FLAGS=-m32 && $(MAKE) libisomediafile
 	cd $(CONTRIB_DIR)/isobmff && mv lib/liblibisomediafile.a lib/libisomediafile.a
 	cd $(CONTRIB_DIR) && cp isobmff/lib/libisomediafile.a mpeg2aac/import/lib/
 	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/src/ISOMovies.h mpeg2aac/import/include/
@@ -187,7 +187,7 @@ else ifeq ($(KERNEL_NAME), Darwin)
 	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/macosx/MP4OSMacros.h mpeg2aac/import/include/ || true
 endif
 	cd $(CONTRIB_DIR) && wget --no-check-certificate https://www-mmsp.ece.mcgill.ca/Documents/Downloads/libtsp/libtsp-v7r0.tar.gz
-	cd $(CONTRIB_DIR) && tar -zxf libtsp-v7r0.tar.gz && chmod -R ugo=rwx libtsp-v7r0/ && cd libtsp-v7r0/ && $(MAKE) -s COPTS=-m64
+	cd $(CONTRIB_DIR) && tar -zxf libtsp-v7r0.tar.gz && chmod -R ugo=rwx libtsp-v7r0/ && cd libtsp-v7r0/ && $(MAKE) -s COPTS=-m32
 	cd $(CONTRIB_DIR) && rm -f libtsp-v7r0.tar.gz
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/lib/libtsp.a mpeg2aac/import/lib/
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp.h mpeg2aac/import/include/
@@ -195,7 +195,7 @@ endif
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/AFpar.h mpeg2aac/import/include/libtsp/
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/UTpar.h mpeg2aac/import/include/libtsp/
 endif
-	cd $(CONTRIB_DIR)/mpeg2aac/aacDec && MAKELEVEL=0 $(MAKE) aacdec_mc REFSOFT_INCLUDE_PATH=../import/include REFSOFT_LIBRARY_PATH=../import/lib CFLAGS=-m64 LDFLAGS=-m64
+	cd $(CONTRIB_DIR)/mpeg2aac/aacDec && MAKELEVEL=0 $(MAKE) aacdec_mc REFSOFT_INCLUDE_PATH=../import/include REFSOFT_LIBRARY_PATH=../import/lib CFLAGS=-m32 LDFLAGS=-m32
 	find $(CONTRIB_DIR)/mpeg2aac/bin/mp4mcDec -name "aacdec_mc" -type f -exec cp {} $(DECODERS_DIR) \;
 
 ifneq ($(wildcard /usr/include/asm), )

--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,9 @@ ifeq ($(wildcard $(CONTRIB_DIR)/C050470e_Electronic_inserts), )
 	cd $(CONTRIB_DIR) && unzip -oq c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip
 	cd $(CONTRIB_DIR) && rm -f iso_cookies.txt c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip
 
-	cd $(CONTRIB_DIR) && git clone https://github.com/MPEGGroup/isobmff.git
-	cd $(CONTRIB_DIR)/isobmff && mkdir build && cd build && cmake .. -DCMAKE_C_FLAGS=-m64 && $(MAKE) libisomediafile
+	cd $(CONTRIB_DIR) && [ -d isobmff ] && rm -rf isobmff && git clone https://github.com/MPEGGroup/isobmff.git
+	cd $(CONTRIB_DIR)/isobmff && git checkout tags/v0.2.0 -b v0.2.0
+	cd $(CONTRIB_DIR)/isobmff && mkdir -p build && cd build && cmake .. -DCMAKE_C_FLAGS=-m64 && $(MAKE) libisomediafile
 	cd $(CONTRIB_DIR)/isobmff && mv lib/liblibisomediafile.a lib/libisomediafile.a
 	cd $(CONTRIB_DIR) && cp isobmff/lib/libisomediafile.a C050470e_Electronic_inserts/audio/natural/import/lib/
 	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/src/ISOMovies.h C050470e_Electronic_inserts/audio/natural/import/include/
@@ -132,7 +133,7 @@ endif
 	cd $(CONTRIB_DIR) && rm -f libtsp-v7r0.tar.gz
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/lib/libtsp.a C050470e_Electronic_inserts/audio/natural/import/lib/
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp.h C050470e_Electronic_inserts/audio/natural/import/include/
-	cd $(CONTRIB_DIR) && mkdir C050470e_Electronic_inserts/audio/natural/import/include/libtsp/
+	cd $(CONTRIB_DIR) && mkdir -p C050470e_Electronic_inserts/audio/natural/import/include/libtsp/
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/AFpar.h C050470e_Electronic_inserts/audio/natural/import/include/libtsp/
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/UTpar.h C050470e_Electronic_inserts/audio/natural/import/include/libtsp/
 endif
@@ -168,12 +169,12 @@ ifeq ($(wildcard $(CONTRIB_DIR)/C039486_Electronic_inserts), )
 	cd $(CONTRIB_DIR) && unzip -oq c039486_ISO_IEC_13818-5_2005_Reference_Software.zip
 	cd $(CONTRIB_DIR) && rm -f iso_cookies.txt c039486_ISO_IEC_13818-5_2005_Reference_Software.zip ipmp.zip mpeg2audio.zip systems.zip video.zip
 
-	# Unzip and setup MPEG-2 AAC decoder files
 	cd $(CONTRIB_DIR) && unzip -oq mpeg2aac.zip
 	cd $(CONTRIB_DIR) && rm -f mpeg2aac.zip
 
-	cd $(CONTRIB_DIR) && git clone https://github.com/MPEGGroup/isobmff.git
-	cd $(CONTRIB_DIR)/isobmff && mkdir build && cd build && cmake .. -DCMAKE_C_FLAGS=-m64 && $(MAKE) libisomediafile
+	cd $(CONTRIB_DIR) && [ -d isobmff ] && rm -rf isobmff && git clone https://github.com/MPEGGroup/isobmff.git
+	cd $(CONTRIB_DIR)/isobmff && git checkout tags/v0.2.0 -b v0.2.0
+	cd $(CONTRIB_DIR)/isobmff && mkdir -p build && cd build && cmake .. -DCMAKE_C_FLAGS=-m64 && $(MAKE) libisomediafile
 	cd $(CONTRIB_DIR)/isobmff && mv lib/liblibisomediafile.a lib/libisomediafile.a
 	cd $(CONTRIB_DIR) && cp isobmff/lib/libisomediafile.a mpeg2aac/import/lib/
 	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/src/ISOMovies.h mpeg2aac/import/include/
@@ -190,12 +191,10 @@ endif
 	cd $(CONTRIB_DIR) && rm -f libtsp-v7r0.tar.gz
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/lib/libtsp.a mpeg2aac/import/lib/
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp.h mpeg2aac/import/include/
-	cd $(CONTRIB_DIR) && mkdir mpeg2aac/import/include/libtsp/
+	cd $(CONTRIB_DIR) && mkdir -p mpeg2aac/import/include/libtsp/
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/AFpar.h mpeg2aac/import/include/libtsp/
 	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/UTpar.h mpeg2aac/import/include/libtsp/
 endif
-
-	# Build the MPEG-2 AAC decoder
 	cd $(CONTRIB_DIR)/mpeg2aac/aacDec && MAKELEVEL=0 $(MAKE) aacdec_mc REFSOFT_INCLUDE_PATH=../import/include REFSOFT_LIBRARY_PATH=../import/lib CFLAGS=-m64 LDFLAGS=-m64
 	find $(CONTRIB_DIR)/mpeg2aac/bin/mp4mcDec -name "aacdec_mc" -type f -exec cp {} $(DECODERS_DIR) \;
 

--- a/fluster/decoders/iso_mpeg2_aac.py
+++ b/fluster/decoders/iso_mpeg2_aac.py
@@ -60,7 +60,6 @@ class ISOAACDecoder(Decoder):
         output_files = glob.glob(f"{base_output}_f[0-9][0-9].pcm")
 
         for pcm_file in output_files:
-            if os.path.exists(pcm_file):
-                return file_checksum(pcm_file)
+            return file_checksum(pcm_file)
 
         return file_checksum(output_filepath)

--- a/fluster/decoders/iso_mpeg2_aac.py
+++ b/fluster/decoders/iso_mpeg2_aac.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
+import glob
 import os
 
 from fluster.codec import Codec, OutputFormat
@@ -56,7 +57,7 @@ class ISOAACDecoder(Decoder):
         if os.path.exists(pcm_out_f00_file):
             return file_checksum(pcm_out_f00_file)
 
-        output_files = [f"{base_output}_f{str(i).zfill(2)}.pcm" for i in range(20)]
+        output_files = glob.glob(f"{base_output}_f[0-9][0-9].pcm")
 
         for pcm_file in output_files:
             if os.path.exists(pcm_file):

--- a/fluster/decoders/iso_mpeg2_aac.py
+++ b/fluster/decoders/iso_mpeg2_aac.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
+import os
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -42,10 +43,23 @@ class ISOAACDecoder(Decoder):
         # pylint: disable=unused-argument
         # Addition of .pcm as extension is a must. If it is something else, e.g. ".out" the decoder will output a
         # ".wav", which is undesirable.
-        output_filepath += ".wav"
+        output_filepath += ".pcm"
         run_command(
-            [self.binary, "-w", input_filepath, output_filepath],
+            [self.binary, input_filepath, output_filepath],
             timeout=timeout,
             verbose=verbose,
         )
+
+        base_output = output_filepath[:-4]
+        pcm_out_f00_file = f"{base_output}_f00.pcm"
+
+        if os.path.exists(pcm_out_f00_file):
+            return file_checksum(pcm_out_f00_file)
+
+        output_files = [f"{base_output}_f{str(i).zfill(2)}.pcm" for i in range(20)]
+
+        for pcm_file in output_files:
+            if os.path.exists(pcm_file):
+                return file_checksum(pcm_file)
+
         return file_checksum(output_filepath)

--- a/test_suites/aac/MPEG2_AAC-ADIF.json
+++ b/test_suites/aac/MPEG2_AAC-ADIF.json
@@ -57,7 +57,7 @@
             "source_checksum": "4c278383fa9edb672dc4791937a88594",
             "input_file": "am07_12.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "3e31c667670cbef6cdf7ee86a3ae285d"
         },
         {
             "name": "as17_16",
@@ -81,7 +81,7 @@
             "source_checksum": "0705453d99447b89ca3aa8c63dd50fa6",
             "input_file": "am07_48.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "ee5d33f95ec836e851bf19c6ae7a211d"
         },
         {
             "name": "as15_08",
@@ -161,7 +161,7 @@
             "source_checksum": "1475e6cd49ed90c4c5d05e4ad5e1da7d",
             "input_file": "am06_32.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "4ef096224da763ac43090955d64cfba1"
         },
         {
             "name": "as01_44",
@@ -241,7 +241,7 @@
             "source_checksum": "c98dff5e8b6e432e4b760c3dbaf4e4a8",
             "input_file": "am01_08.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "2fcc843014bca5b1ac137a5227478579"
         },
         {
             "name": "as11_96",
@@ -281,7 +281,7 @@
             "source_checksum": "9e9c153d09af52d1488d2dfd5c653b6d",
             "input_file": "am00_64.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "3fb7576e4821be816a5a20f373fe8779"
         },
         {
             "name": "al15_96",
@@ -313,7 +313,7 @@
             "source_checksum": "724abd826d9714603bdeacd89297c8a3",
             "input_file": "am02_12.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "81e3ce4054eac8fc69e85c305aacee0a"
         },
         {
             "name": "am00_32",
@@ -321,7 +321,7 @@
             "source_checksum": "3be458cd387a67ad17f593fd3d00f87b",
             "input_file": "am00_32.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "dff0a5b583b837e9b7586b54299dddba"
         },
         {
             "name": "as11_12",
@@ -449,7 +449,7 @@
             "source_checksum": "c179ce68743ccbe32eb9c0525604cfde",
             "input_file": "am05_16.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "5064cca0c1dee59a214d9e20165af1e1"
         },
         {
             "name": "as03_48",
@@ -481,7 +481,7 @@
             "source_checksum": "55be33373a7bc4505b919a0e1caef076",
             "input_file": "am00_88.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "2c28bbe633abb0995a7d9d6b2bbd163c"
         },
         {
             "name": "al01_16",
@@ -561,7 +561,7 @@
             "source_checksum": "1cc2e1231962e87ab3f04461fb352cb7",
             "input_file": "am06_48.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "a2c5debfac5d778137cff876f8787bb2"
         },
         {
             "name": "al07_48",
@@ -577,7 +577,7 @@
             "source_checksum": "338dcd98cded8c3f528d369a5479aaf3",
             "input_file": "am06_08.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "d164df2cf24ddf609c46a31a74e69f99"
         },
         {
             "name": "as13_44",
@@ -657,7 +657,7 @@
             "source_checksum": "6bfcef3f5ce0f22232fc28520e43f516",
             "input_file": "am01_11.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "104361bdcc1b9d4d24e5863e2c35e050"
         },
         {
             "name": "as17_08",
@@ -673,7 +673,7 @@
             "source_checksum": "2cd0217b1e1ea822e7894ea67efd111b",
             "input_file": "am04_44.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "6b124b1f9b0d8b5942b803db436ba439"
         },
         {
             "name": "as13_24",
@@ -729,7 +729,7 @@
             "source_checksum": "f8a86e9fc00e991edc14d197b53b1474",
             "input_file": "am01_96.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "12ea7bf04bce95c5c3ae286b17f6907e"
         },
         {
             "name": "as14_24",
@@ -745,7 +745,7 @@
             "source_checksum": "cec91a4c806b6b73dfc3241f62e840e9",
             "input_file": "am04_64.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "9526a9dca60fba036bb04ad28e8deacc"
         },
         {
             "name": "al07_44",
@@ -769,7 +769,7 @@
             "source_checksum": "ea11c15002bc0ce36cbd25a61c6a5993",
             "input_file": "am02_88.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "4fe01b15aaf82e7121652ffffb489d36"
         },
         {
             "name": "al14_96",
@@ -857,7 +857,7 @@
             "source_checksum": "88ac1a9710fff86f8b8e2a2d63d28b35",
             "input_file": "am00_96.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "60095c11878cfbedd806518168312f3d"
         },
         {
             "name": "as06_12",
@@ -873,7 +873,7 @@
             "source_checksum": "7194a61412f153fc0582ba81d817da1d",
             "input_file": "am06_88.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "e6494513d14046b56ab2ca98def4d2ca"
         },
         {
             "name": "al05_64",
@@ -905,7 +905,7 @@
             "source_checksum": "cd8ea7bbdb10df386596da86d68a2f6d",
             "input_file": "am05_24.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "938c26465f99f8c49948a749e3549f96"
         },
         {
             "name": "as02_44",
@@ -929,7 +929,7 @@
             "source_checksum": "4bcafc3db934eea2555383c7cdb575bc",
             "input_file": "am00_12.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "2365631d91808e0aaf921944dd078466"
         },
         {
             "name": "al17_08",
@@ -985,7 +985,7 @@
             "source_checksum": "0bda098d9898033a46f48e2720c78ccf",
             "input_file": "am02_64.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "f2a0570e3ee6227c76d2b151cf959347"
         },
         {
             "name": "al05_08",
@@ -1025,7 +1025,7 @@
             "source_checksum": "65e81cad01a0e6af123a9bef9799a280",
             "input_file": "am02_44.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "a6411c703a1ac140889d5eb6dd0d9bf1"
         },
         {
             "name": "al14_11",
@@ -1145,7 +1145,7 @@
             "source_checksum": "a07b6a477935908696a1a8754435dd7b",
             "input_file": "am05_96.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "c07028fc7e64703ba94ba863fcb14802"
         },
         {
             "name": "as17_11",
@@ -1193,7 +1193,7 @@
             "source_checksum": "6e16189535ee42a3b74f9b9e79907a1f",
             "input_file": "am07_32.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "642fcea1aa872cb9deb8051eb67b723f"
         },
         {
             "name": "am01_24",
@@ -1201,7 +1201,7 @@
             "source_checksum": "806d34a4e2cbe4e73a249e51d5dbe0fc",
             "input_file": "am01_24.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "383fe028008446dc9540854da6b1122a"
         },
         {
             "name": "as02_11",
@@ -1249,7 +1249,7 @@
             "source_checksum": "f9cb1b11e8571ab7b8c5c0e713cc2666",
             "input_file": "am05_11.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "30b703181556f60e1befb1ced67338be"
         },
         {
             "name": "al11_96",
@@ -1305,7 +1305,7 @@
             "source_checksum": "bf4a83b0b6c3b94746b3462d68f654c4",
             "input_file": "am05_12.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "31cc64498f9c11ed507a24ca3bd169ec"
         },
         {
             "name": "al15_22",
@@ -1329,7 +1329,7 @@
             "source_checksum": "a9421c6811dafd836da05d037f9fcbf4",
             "input_file": "am06_24.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "19eea88a19f933b2c6a98b555d427fa7"
         },
         {
             "name": "as16_12",
@@ -1361,7 +1361,7 @@
             "source_checksum": "3aff314027f3b08129ba3cfedca95011",
             "input_file": "am04_48.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "21787f144ab240452a7c0b32016f0c0c"
         },
         {
             "name": "am01_16",
@@ -1369,7 +1369,7 @@
             "source_checksum": "60fe7b6600282ba2932e052916358e20",
             "input_file": "am01_16.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "f49b1f4d1aa9471cf83b838eaac185a7"
         },
         {
             "name": "as03_16",
@@ -1401,7 +1401,7 @@
             "source_checksum": "75268f551cca8f1cf69755a80ca59243",
             "input_file": "am01_48.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "caefa9d212de6d4553691071d144d98c"
         },
         {
             "name": "al10_64",
@@ -1569,7 +1569,7 @@
             "source_checksum": "36c3ac9e1cdfaee199fece84578a89e1",
             "input_file": "am01_88.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "aa3b7e61c9327bd386bbddf54519a571"
         },
         {
             "name": "am06_11",
@@ -1577,7 +1577,7 @@
             "source_checksum": "463fd1a62a3d64b9f0f870c31b18cdc5",
             "input_file": "am06_11.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "35d539f4bf37499cf1b0f5e960ffcdc8"
         },
         {
             "name": "al06_16",
@@ -1633,7 +1633,7 @@
             "source_checksum": "486014e224f9979e004d171cb6d89301",
             "input_file": "am00_08.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "5421b0bfa2287dd9a0b4abbcd784d924"
         },
         {
             "name": "al15_64",
@@ -1705,7 +1705,7 @@
             "source_checksum": "2f8610445d67d522dfae66c55791844d",
             "input_file": "am04_96.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "82e79eac474dc6bda0337aa3871ee962"
         },
         {
             "name": "al03_22",
@@ -1761,7 +1761,7 @@
             "source_checksum": "2b26096ce17d6e6fc3cfbdb23fb36ee7",
             "input_file": "am04_12.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "e34d7c1761878e8a32dad69d8065ee37"
         },
         {
             "name": "as17_64",
@@ -1817,7 +1817,7 @@
             "source_checksum": "f9d9a02cd9595587cc59a2f05e9b7a58",
             "input_file": "am04_08.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "c38e48672d70d47fbf2712935eb94cc4"
         },
         {
             "name": "as01_16",
@@ -1865,7 +1865,7 @@
             "source_checksum": "5953a6cf627bab3032706c4f67baa709",
             "input_file": "am00_22.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "3a5c20bbd8e6da448b58f24fcc1406e4"
         },
         {
             "name": "al02_96",
@@ -1897,7 +1897,7 @@
             "source_checksum": "fc2f23c3e0018defc658e7ba53285fc3",
             "input_file": "am02_16.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "424bf0862916cb427c09a4c3a1a1f05a"
         },
         {
             "name": "as04_64",
@@ -1929,7 +1929,7 @@
             "source_checksum": "7c0c22ed3b15be29afcbc46f179fddf7",
             "input_file": "am00_24.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "d91800bc70282ef0bfca4c96812e03fe"
         },
         {
             "name": "al03_32",
@@ -1945,7 +1945,7 @@
             "source_checksum": "09ac88daefcf469da375592eee3d2d10",
             "input_file": "am01_12.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "0257eecdaaf011bd58ea3000fcbd089d"
         },
         {
             "name": "al08_32",
@@ -2033,7 +2033,7 @@
             "source_checksum": "2be3b02613dd9b680ddc3c1dec538190",
             "input_file": "am05_64.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "5b096940b5f4f548e8be21081dd8e188"
         },
         {
             "name": "as04_11",
@@ -2057,7 +2057,7 @@
             "source_checksum": "07592518d2fbc33f5f2e5ba04c72be05",
             "input_file": "am05_44.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "561255dc09da4e3cc62a6a568c023186"
         },
         {
             "name": "al00_11",
@@ -2073,7 +2073,7 @@
             "source_checksum": "75cb5ed0631e83714602af7f70c92920",
             "input_file": "am04_16.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "558b5b0b4eb34fc35f0a81289f710458"
         },
         {
             "name": "al01_32",
@@ -2201,7 +2201,7 @@
             "source_checksum": "6907839260332d03ab0fe526487f6a2e",
             "input_file": "am07_16.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "7ff6c169606329283d442bdf69017cb7"
         },
         {
             "name": "al07_64",
@@ -2257,7 +2257,7 @@
             "source_checksum": "c700995285943645467e0bca4be4203b",
             "input_file": "am01_64.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "a6f2f72dbb23e693d815cdcb77d4e0e7"
         },
         {
             "name": "as09_96",
@@ -2297,7 +2297,7 @@
             "source_checksum": "651df35d42e4ff5c2de6012778578a56",
             "input_file": "am04_32.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "ec52fee00142a4c1c7777d5ed7348ac6"
         },
         {
             "name": "as06_32",
@@ -2345,7 +2345,7 @@
             "source_checksum": "318901fe746911a3ab79b7705298a089",
             "input_file": "am02_24.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "5af42c51a7b2968efb484f0ad933a157"
         },
         {
             "name": "al15_08",
@@ -2409,7 +2409,7 @@
             "source_checksum": "7055d3ac07b0e7240fdb385b682bcc93",
             "input_file": "am07_44.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "6ecc879ff4cf68e13ac061e8408c98cd"
         },
         {
             "name": "al14_22",
@@ -2425,7 +2425,7 @@
             "source_checksum": "da2ce2e8909132d9fe7d5965b13b2398",
             "input_file": "am00_16.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "2f5b31721e04afd861d59a6194308565"
         },
         {
             "name": "al06_24",
@@ -2457,7 +2457,7 @@
             "source_checksum": "3bbc106d00d15af257c60ed8c919bb06",
             "input_file": "am07_24.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "4478b0d80332c389dfd048641dd225c8"
         },
         {
             "name": "as16_24",
@@ -2593,7 +2593,7 @@
             "source_checksum": "3595d955fc9d5b1e8f9e12bd03d784a8",
             "input_file": "am02_32.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "a88295fef84eb1c1d62083daec20c9b2"
         },
         {
             "name": "am07_22",
@@ -2601,7 +2601,7 @@
             "source_checksum": "3a8242c2464e4a0b3225d6a1874b638d",
             "input_file": "am07_22.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "bfd80104fd69bdea14cc746d185d6b44"
         },
         {
             "name": "am05_08",
@@ -2609,7 +2609,7 @@
             "source_checksum": "07a00475dd08af84b7c5b5b3a18d7bb2",
             "input_file": "am05_08.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "e76a4fad9680315bdebd7df663554222"
         },
         {
             "name": "al05_11",
@@ -2657,7 +2657,7 @@
             "source_checksum": "103a80fd7149ca10c77a06d0cec6b4bd",
             "input_file": "am01_44.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "bd59a63283c94d5f5c0c0046d06481e9"
         },
         {
             "name": "as12_08",
@@ -2705,7 +2705,7 @@
             "source_checksum": "9ee732353f7e053d2ee756f768d10a7e",
             "input_file": "am07_11.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "ea443195941ce65c0cf6be5e64433271"
         },
         {
             "name": "am07_64",
@@ -2713,7 +2713,7 @@
             "source_checksum": "db76927fcbc32bea6e604479f32f67d4",
             "input_file": "am07_64.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "c46be40e124ce8c2aea9610d61e25e26"
         },
         {
             "name": "al00_32",
@@ -2753,7 +2753,7 @@
             "source_checksum": "339a14afbdff567391e8e7637add2997",
             "input_file": "am02_08.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "c1e3516dadbb4efbae4dd6103276e4e2"
         },
         {
             "name": "as04_44",
@@ -2769,7 +2769,7 @@
             "source_checksum": "90a0e04fc17447cc2f788e11ebabe204",
             "input_file": "am05_22.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "86fb8e82f33af5d740b856f81a80eb71"
         },
         {
             "name": "am07_96",
@@ -2777,7 +2777,7 @@
             "source_checksum": "404dd06f53f9daed60c5a7b785da28e2",
             "input_file": "am07_96.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "06e1bc42c0173b3f1541983b8ab8d5d9"
         },
         {
             "name": "as03_11",
@@ -2817,7 +2817,7 @@
             "source_checksum": "739386e9c6d4095912e6e3a4da5d4e85",
             "input_file": "am07_88.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "06ef16e7803a494af0c19ad949273c62"
         },
         {
             "name": "al06_64",
@@ -2849,7 +2849,7 @@
             "source_checksum": "e6572538093228240b1b37f7114c59da",
             "input_file": "am02_11.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "90a57c1f6b8d6d79b8356b734c1c98e4"
         },
         {
             "name": "as07_88",
@@ -3137,7 +3137,7 @@
             "source_checksum": "06d8d6da499c16119d0e5a7780af81ea",
             "input_file": "am06_64.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "22cddc2b971b072b7f2157fd5d07f67a"
         },
         {
             "name": "as00_48",
@@ -3265,7 +3265,7 @@
             "source_checksum": "0f558fd21f4ee90728acfe660a5b2397",
             "input_file": "am05_88.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "ae07362973a109e13ad7aa7a01fe2eef"
         },
         {
             "name": "am06_44",
@@ -3273,7 +3273,7 @@
             "source_checksum": "bc279de3c3e7962bdf47b64216f33900",
             "input_file": "am06_44.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "c0bbfd973867fec9ed598abd1656761e"
         },
         {
             "name": "al04_32",
@@ -3345,7 +3345,7 @@
             "source_checksum": "5e54a0d219e31d7a264311f12ad56644",
             "input_file": "am06_12.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "4f57d72e18b9c3417387a09e27beb851"
         },
         {
             "name": "al16_64",
@@ -3409,7 +3409,7 @@
             "source_checksum": "a536f7ee51b1d842d61cc65f5cabddcd",
             "input_file": "am05_48.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "566d54b65ae740b80676ab9adb7feb9f"
         },
         {
             "name": "as05_08",
@@ -3425,7 +3425,7 @@
             "source_checksum": "a142562a01bd209c256a124888f1e10a",
             "input_file": "am04_11.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "71ef16be1fc6d6ff5bb2907959ba6f56"
         },
         {
             "name": "am01_22",
@@ -3433,7 +3433,7 @@
             "source_checksum": "441bf198af41e64289480052dba0b3f2",
             "input_file": "am01_22.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "7d384f1aebb4f9f6d919d534f72abf2e"
         },
         {
             "name": "al10_88",
@@ -3481,7 +3481,7 @@
             "source_checksum": "2af028a7d8538d424b1b2e27e83683b7",
             "input_file": "am00_11.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "bbb2a347eb79692e8162d364b3e2e851"
         },
         {
             "name": "am07_08",
@@ -3489,7 +3489,7 @@
             "source_checksum": "da8f616c1ff96b93de7cfcf01350fe38",
             "input_file": "am07_08.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "1eaa7584eda43146cd197cf43ee31336"
         },
         {
             "name": "as08_96",
@@ -3513,7 +3513,7 @@
             "source_checksum": "203b22bb326c936ddb9b18314f9a64b2",
             "input_file": "am04_22.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "3c613c9af057696d31579ec816f1dffa"
         },
         {
             "name": "am05_32",
@@ -3521,7 +3521,7 @@
             "source_checksum": "7629c8af0f38a4f3382d8fe9e887d9b7",
             "input_file": "am05_32.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "a19172db2537dcd34cfe08298bce7028"
         },
         {
             "name": "am03_24",
@@ -3553,7 +3553,7 @@
             "source_checksum": "e7dc757057fbfbb9c198f08f4d5a3387",
             "input_file": "am02_22.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "e1e025741b3432606b8ff69965b7f3d0"
         },
         {
             "name": "as14_22",
@@ -3569,7 +3569,7 @@
             "source_checksum": "3ace5dbd49daa0f5180e8c72348d80fc",
             "input_file": "am00_48.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "8b30d5a5a799d5f59f3cd6ab973dbed9"
         },
         {
             "name": "as10_96",
@@ -3617,7 +3617,7 @@
             "source_checksum": "bbec3d56a852642ac36f362e671c60cc",
             "input_file": "am04_88.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "c08d877e3c11ac5d6897487fc64809bb"
         },
         {
             "name": "as17_48",
@@ -3665,7 +3665,7 @@
             "source_checksum": "dce4c4c15e1dd16a0f672069ed0f530f",
             "input_file": "am06_22.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "660e495bf6ef3dbd6e4d1c0b7b62a73a"
         },
         {
             "name": "as01_08",
@@ -3681,7 +3681,7 @@
             "source_checksum": "b2aa87427e18b45f2f31fc49743c61c1",
             "input_file": "am04_24.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "b1f7a855024212ea1278a995b014dc21"
         },
         {
             "name": "am06_96",
@@ -3689,7 +3689,7 @@
             "source_checksum": "7191ad8979bc199124040cbf02aa0378",
             "input_file": "am06_96.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "0663053dde8e099d32d4f2acde451e2c"
         },
         {
             "name": "al11_64",
@@ -3745,7 +3745,7 @@
             "source_checksum": "d5436682dc95dfe02f76c902ce6d7910",
             "input_file": "am00_44.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "cbeb791f1771f1d0adcfff9a29fe4223"
         },
         {
             "name": "as16_11",
@@ -3801,7 +3801,7 @@
             "source_checksum": "743db775068807269bb9725720adc606",
             "input_file": "am02_48.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "41045aa7d349d9fe233869793d48f322"
         },
         {
             "name": "al03_11",
@@ -3865,7 +3865,7 @@
             "source_checksum": "166bc87d9c433afa1c0b01a184469e5b",
             "input_file": "am02_96.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "000afc3c95e38a98e52cfd70568967ab"
         },
         {
             "name": "as09_48",
@@ -3881,7 +3881,7 @@
             "source_checksum": "bdd2aa77cc5c82b1923c7d7fff1f887d",
             "input_file": "am06_16.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "f8c39576e0e2d17d1d5f14726bb1cafb"
         },
         {
             "name": "as00_12",
@@ -3905,7 +3905,7 @@
             "source_checksum": "be0d7cc4444f4950758da784ff278f90",
             "input_file": "am01_32.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "1bcf994fb90b2f3eb5f15420a869f823"
         },
         {
             "name": "as12_44",

--- a/test_suites/aac/MPEG2_AAC-ADIF.json
+++ b/test_suites/aac/MPEG2_AAC-ADIF.json
@@ -9,7 +9,7 @@
             "source_checksum": "973113459f08d1bee9aea20c222385e0",
             "input_file": "as15_22.adif",
             "output_format": "Unknown",
-            "result": "2c33d7da969504c043578b0c5e515490"
+            "result": "3845021412db78720068ec2dcd901fc3"
         },
         {
             "name": "as17_24",
@@ -17,7 +17,7 @@
             "source_checksum": "3c9a034a4477d2cb8d1b80cb6a8ce63d",
             "input_file": "as17_24.adif",
             "output_format": "Unknown",
-            "result": "8dbd89069364c6e9868f41cb062aa4e9"
+            "result": "5ec07fb1254f038776533d41dd00e67e"
         },
         {
             "name": "al05_96",
@@ -25,7 +25,7 @@
             "source_checksum": "de5c0fc8b7a4bf7e8ea62186016e8979",
             "input_file": "al05_96.adif",
             "output_format": "Unknown",
-            "result": "d48ebd56d96ce7d1fae298d2115e2fa1"
+            "result": "d4dfff5dbf498aabb7ab71ebf71fc6de"
         },
         {
             "name": "al14_44",
@@ -33,7 +33,7 @@
             "source_checksum": "22a44701fb7e519fa229a0d6b2b573b1",
             "input_file": "al14_44.adif",
             "output_format": "Unknown",
-            "result": "ae97172ba9c8b109bb0f01add2b43be8"
+            "result": "1ea3fc56401dc70963f7a6d7897a7377"
         },
         {
             "name": "al16_88",
@@ -41,7 +41,7 @@
             "source_checksum": "0c9e5ff43b8627e55cc30eabf7e59cd8",
             "input_file": "al16_88.adif",
             "output_format": "Unknown",
-            "result": "fb2efedb23b7e2e0ddcb78e370d66ecd"
+            "result": "55c563d8df797e4c8d308796fb511311"
         },
         {
             "name": "as12_88",
@@ -49,7 +49,7 @@
             "source_checksum": "29212b6f98abeb491e26f8b84c4fd835",
             "input_file": "as12_88.adif",
             "output_format": "Unknown",
-            "result": "3b0c7a9fb8cfebec9a2922254d7ef588"
+            "result": "ed0edb7557b7ddea6e180555346c8fa4"
         },
         {
             "name": "am07_12",
@@ -57,7 +57,7 @@
             "source_checksum": "4c278383fa9edb672dc4791937a88594",
             "input_file": "am07_12.adif",
             "output_format": "Unknown",
-            "result": "97ebb8e64754d2f61049ae3a3ba14ff7"
+            "result": ""
         },
         {
             "name": "as17_16",
@@ -65,7 +65,7 @@
             "source_checksum": "07c341c77150a9550d133b9ef0a86674",
             "input_file": "as17_16.adif",
             "output_format": "Unknown",
-            "result": "4cc6adb04199d5d0a9d8458b241556bf"
+            "result": "1aeb35eba5cdc0541e08964402f9b281"
         },
         {
             "name": "al08_88",
@@ -73,7 +73,7 @@
             "source_checksum": "760d1e584d7ef6616e51414ebc98ed7b",
             "input_file": "al08_88.adif",
             "output_format": "Unknown",
-            "result": "49969ec0a8171e12b69a2c22fbf2dcea"
+            "result": "c7f958f10a167fb8fdc45b83b0777386"
         },
         {
             "name": "am07_48",
@@ -81,7 +81,7 @@
             "source_checksum": "0705453d99447b89ca3aa8c63dd50fa6",
             "input_file": "am07_48.adif",
             "output_format": "Unknown",
-            "result": "54302653e935ea1e520f559cbff17498"
+            "result": ""
         },
         {
             "name": "as15_08",
@@ -89,7 +89,7 @@
             "source_checksum": "d714e621e508696f7cfd72e51c742a54",
             "input_file": "as15_08.adif",
             "output_format": "Unknown",
-            "result": "4c96313bbcbf61ea6c5220828c9c0794"
+            "result": "f48ab7fc21542d1d0caf92eacb51eee3"
         },
         {
             "name": "as11_16",
@@ -97,7 +97,7 @@
             "source_checksum": "b085503eb7499f4a7235c753f27dd099",
             "input_file": "as11_16.adif",
             "output_format": "Unknown",
-            "result": "c157dabd5f15f74f5358371766e197dc"
+            "result": "d704c48a8c7a7aadbeb0ff2cd664b065"
         },
         {
             "name": "al06_88",
@@ -105,7 +105,7 @@
             "source_checksum": "2ed28cfe746636e188a633eeb413470b",
             "input_file": "al06_88.adif",
             "output_format": "Unknown",
-            "result": "023e3e66b97d4e25975d9ed960feff53"
+            "result": "4f1c2fd36e30363132d8ed96360e3b29"
         },
         {
             "name": "am03_64",
@@ -121,7 +121,7 @@
             "source_checksum": "2c2fb6a58c972c1458a88c59b7ae237b",
             "input_file": "as09_08.adif",
             "output_format": "Unknown",
-            "result": "75bbedc1baac60a7ae07ab7908e0946e"
+            "result": "c90abb148c09f3fe5eb768fcd283213b"
         },
         {
             "name": "al06_96",
@@ -129,7 +129,7 @@
             "source_checksum": "84662ab811bfb9aacce7fe18b963ca1d",
             "input_file": "al06_96.adif",
             "output_format": "Unknown",
-            "result": "23d429982f9dc63dad91c02112f5f382"
+            "result": "907f07b128d154b6eedd113c495a0473"
         },
         {
             "name": "as11_08",
@@ -137,7 +137,7 @@
             "source_checksum": "540ada16b29d3e0b4a87a9c10d1ed2ec",
             "input_file": "as11_08.adif",
             "output_format": "Unknown",
-            "result": "9c3c12faf5376b9c805c125480d19c8c"
+            "result": "c956ff0d8d65f1157da8db8704a1aa0f"
         },
         {
             "name": "as15_96",
@@ -145,7 +145,7 @@
             "source_checksum": "3ec8c4c9415b1830a5d804db4aa81e8c",
             "input_file": "as15_96.adif",
             "output_format": "Unknown",
-            "result": "41d2a9ff10aa4a4727a14aed3754a200"
+            "result": "4b65363c85dedf3aaf68e78c97abb2a4"
         },
         {
             "name": "as01_11",
@@ -153,7 +153,7 @@
             "source_checksum": "e552aa00b1800eee26b7372c62b4103c",
             "input_file": "as01_11.adif",
             "output_format": "Unknown",
-            "result": "75d31006db49af4a39739589b4da40bb"
+            "result": "bcdc702495729e0034fbb65cfea176ec"
         },
         {
             "name": "am06_32",
@@ -161,7 +161,7 @@
             "source_checksum": "1475e6cd49ed90c4c5d05e4ad5e1da7d",
             "input_file": "am06_32.adif",
             "output_format": "Unknown",
-            "result": "28f66eff1fb1e23a8194213eabac5829"
+            "result": ""
         },
         {
             "name": "as01_44",
@@ -169,7 +169,7 @@
             "source_checksum": "af6d7e3f66bd1f435c541858c3a6ace6",
             "input_file": "as01_44.adif",
             "output_format": "Unknown",
-            "result": "cadcc026ece1cd0bd1a2b4d7909e0bd0"
+            "result": "341a1c0cbe9cfb820c5b8ac6ffba3504"
         },
         {
             "name": "al14_12",
@@ -177,7 +177,7 @@
             "source_checksum": "3870df37b1489d659e1195f6ce6a9ac1",
             "input_file": "al14_12.adif",
             "output_format": "Unknown",
-            "result": "0e4ca06e6c93f5d81bfcb4a6072a3c03"
+            "result": "0838992422e28225ee77bd8f50505d0a"
         },
         {
             "name": "al04_16",
@@ -185,7 +185,7 @@
             "source_checksum": "628e504848bec348ffafa530c139ae1e",
             "input_file": "al04_16.adif",
             "output_format": "Unknown",
-            "result": "0d8c30c389ad6f7805c7795ea804e093"
+            "result": "e9a74efa429e0d6ca38b2c59bdf61652"
         },
         {
             "name": "al16_08",
@@ -193,7 +193,7 @@
             "source_checksum": "983e7b809b6080843cd953d755540eb3",
             "input_file": "al16_08.adif",
             "output_format": "Unknown",
-            "result": "d57c5336122769509cd6e9136b90f165"
+            "result": "830d1866388b7301c96146e0e0614397"
         },
         {
             "name": "as15_32",
@@ -201,7 +201,7 @@
             "source_checksum": "44c2bebaa5c276c1f636f09997e42a2b",
             "input_file": "as15_32.adif",
             "output_format": "Unknown",
-            "result": "9fbbe5304c080a931a578d290d7c3e25"
+            "result": "b68d6ea8dd4223af7d1e57497aaea2e8"
         },
         {
             "name": "as12_32",
@@ -209,7 +209,7 @@
             "source_checksum": "1b73f5a5b52b0df9e11d1307170781b5",
             "input_file": "as12_32.adif",
             "output_format": "Unknown",
-            "result": "75cbf75b95587c51f3fc98d0ec76c418"
+            "result": "473779bf860222b0f5ba126f140ae89f"
         },
         {
             "name": "as08_48",
@@ -217,7 +217,7 @@
             "source_checksum": "0de5d45e2751d8ba2099c03d2f5897ea",
             "input_file": "as08_48.adif",
             "output_format": "Unknown",
-            "result": "1c843a9e8008520a3a85ede6e3ec2bb7"
+            "result": "a9e35a70084e01070ce82663131c4b97"
         },
         {
             "name": "al01_08",
@@ -225,7 +225,7 @@
             "source_checksum": "72d93896b76dcc73fc22d7b02ccda49f",
             "input_file": "al01_08.adif",
             "output_format": "Unknown",
-            "result": "3efe4c0ede751a8212dad3ab7c557d65"
+            "result": "341ba3ace921eb3a805d31cb5c69852a"
         },
         {
             "name": "as16_32",
@@ -233,7 +233,7 @@
             "source_checksum": "d7990e721618f56105cf013952d4ed96",
             "input_file": "as16_32.adif",
             "output_format": "Unknown",
-            "result": "f124b82a5e8dd53cf40d93acbe45ffdf"
+            "result": "b4b3c045e136191c6d42df8fc352d3cf"
         },
         {
             "name": "am01_08",
@@ -241,7 +241,7 @@
             "source_checksum": "c98dff5e8b6e432e4b760c3dbaf4e4a8",
             "input_file": "am01_08.adif",
             "output_format": "Unknown",
-            "result": "b4f2c527b6adc44a166a76a103ed2c77"
+            "result": ""
         },
         {
             "name": "as11_96",
@@ -249,7 +249,7 @@
             "source_checksum": "48b97673168a5c5e963b4f1594df7e13",
             "input_file": "as11_96.adif",
             "output_format": "Unknown",
-            "result": "84330ee7df9052ff8c0de40231d5cf11"
+            "result": "3877801e23700673823b2678c93c8e3e"
         },
         {
             "name": "as01_22",
@@ -257,7 +257,7 @@
             "source_checksum": "374ecfe83db057a962ee023a55b6b5cb",
             "input_file": "as01_22.adif",
             "output_format": "Unknown",
-            "result": "06ac66ecef9a69db87449d8c256aa9eb"
+            "result": "575bde090656bf44b9b7d1031cc7b4ac"
         },
         {
             "name": "as03_44",
@@ -265,7 +265,7 @@
             "source_checksum": "be1fe7e9a26df9824c89d5daae7d3599",
             "input_file": "as03_44.adif",
             "output_format": "Unknown",
-            "result": "4e9ae8d0f09fbb076df06de717644d2a"
+            "result": "b9d7b1fcf7a918ddf1cd51ef97314043"
         },
         {
             "name": "al02_88",
@@ -273,7 +273,7 @@
             "source_checksum": "5e128b64b5af63935a40301ca6b1113f",
             "input_file": "al02_88.adif",
             "output_format": "Unknown",
-            "result": "5f08e589cce07253c9f85cae6c179f7c"
+            "result": "ea940a21c761f8e87cb3b2b8ceb91ebd"
         },
         {
             "name": "am00_64",
@@ -281,7 +281,7 @@
             "source_checksum": "9e9c153d09af52d1488d2dfd5c653b6d",
             "input_file": "am00_64.adif",
             "output_format": "Unknown",
-            "result": "ced4a01389676291c0b8a72b942f60f3"
+            "result": ""
         },
         {
             "name": "al15_96",
@@ -289,7 +289,7 @@
             "source_checksum": "8503ac2de5f3c2b0f9bc946dd8ef5fae",
             "input_file": "al15_96.adif",
             "output_format": "Unknown",
-            "result": "5b824fe89dff41fc13cc0a13f65d2e79"
+            "result": "ae85130efd90f5418c3c36fee8189e00"
         },
         {
             "name": "al08_24",
@@ -297,7 +297,7 @@
             "source_checksum": "1c78301297eed8088e1218c2c3e83660",
             "input_file": "al08_24.adif",
             "output_format": "Unknown",
-            "result": "26aaadd26fea6a7e3499699962fa876b"
+            "result": "25e9f186f207c855879a5f4a18686110"
         },
         {
             "name": "as07_11",
@@ -305,7 +305,7 @@
             "source_checksum": "07def67b46e1779313933a3baa1635ad",
             "input_file": "as07_11.adif",
             "output_format": "Unknown",
-            "result": "9ba87788e5159a4da2eab1b83926349d"
+            "result": "e88a0c08a34fdcce2f9f917b871240e0"
         },
         {
             "name": "am02_12",
@@ -313,7 +313,7 @@
             "source_checksum": "724abd826d9714603bdeacd89297c8a3",
             "input_file": "am02_12.adif",
             "output_format": "Unknown",
-            "result": "8b4b95a3e7848157de9e85922b0dd2df"
+            "result": ""
         },
         {
             "name": "am00_32",
@@ -321,7 +321,7 @@
             "source_checksum": "3be458cd387a67ad17f593fd3d00f87b",
             "input_file": "am00_32.adif",
             "output_format": "Unknown",
-            "result": "6a9e8658270ddc3d3dc4bc52c7f9b4e4"
+            "result": ""
         },
         {
             "name": "as11_12",
@@ -329,7 +329,7 @@
             "source_checksum": "0d1a809e365766873b35878f326f0cda",
             "input_file": "as11_12.adif",
             "output_format": "Unknown",
-            "result": "247c35d301f65c238b453104f7340f94"
+            "result": "3ce237e2c0b6e10f47d7c50c8938148b"
         },
         {
             "name": "al07_11",
@@ -337,7 +337,7 @@
             "source_checksum": "fc8d76f27f177dfaed08cc3c734cd5c2",
             "input_file": "al07_11.adif",
             "output_format": "Unknown",
-            "result": "c7987f0692278a0ce613740d95149229"
+            "result": "d4de30fb19a0873a2357523a21a7c11f"
         },
         {
             "name": "al01_22",
@@ -345,7 +345,7 @@
             "source_checksum": "a74c1ab5ebe080e351f72f41c8ffda50",
             "input_file": "al01_22.adif",
             "output_format": "Unknown",
-            "result": "18c5df5f5f731ae67c762a5a8e41a28e"
+            "result": "bac71f1c4723760f6c595287d8e8f7a1"
         },
         {
             "name": "as11_11",
@@ -353,7 +353,7 @@
             "source_checksum": "8d931fbfbee067cc9952433b43dd3357",
             "input_file": "as11_11.adif",
             "output_format": "Unknown",
-            "result": "7b8fa0337e54c3f883b3f6b61cfcb7fe"
+            "result": "e9ffff20d1b7741befe645289ad0a79d"
         },
         {
             "name": "al16_32",
@@ -361,7 +361,7 @@
             "source_checksum": "404a70a483710c0c1a2f7b4e9ae9e125",
             "input_file": "al16_32.adif",
             "output_format": "Unknown",
-            "result": "e555f2a94076195cddbe9edd2131e3f8"
+            "result": "d5a7bb819c3da7edb65c802b1f06dd8d"
         },
         {
             "name": "am03_32",
@@ -377,7 +377,7 @@
             "source_checksum": "74ab3c39ab5d61042f38365f56abaa1f",
             "input_file": "as06_88.adif",
             "output_format": "Unknown",
-            "result": "77ce70792a1bfd598aef1b0810911af3"
+            "result": "d9fcaa849e98d43d5c9e1272cb45ed5a"
         },
         {
             "name": "al16_11",
@@ -385,7 +385,7 @@
             "source_checksum": "d94fedfab1c1cf7c0e28b531be376601",
             "input_file": "al16_11.adif",
             "output_format": "Unknown",
-            "result": "b6f08a6da5e3ccf7ea8b4cd9db4cef2f"
+            "result": "db12a7bd65b38be3c2483a85f38e2247"
         },
         {
             "name": "as04_48",
@@ -393,7 +393,7 @@
             "source_checksum": "36c9d2324a728561b4e4e05c2a06e496",
             "input_file": "as04_48.adif",
             "output_format": "Unknown",
-            "result": "206a7362d7ed5b39604015ea2d3729f5"
+            "result": "7ccf38ad07dce3b25b59283013770709"
         },
         {
             "name": "as15_88",
@@ -401,7 +401,7 @@
             "source_checksum": "63c123936bef41ff3090a6df4ce35382",
             "input_file": "as15_88.adif",
             "output_format": "Unknown",
-            "result": "4177e5eaed045d07da0cb5953d0a4898"
+            "result": "6b658a186b7b45033d2ec0fce12379cd"
         },
         {
             "name": "al02_16",
@@ -409,7 +409,7 @@
             "source_checksum": "8d0403006c3925ba2737c1ceaf75c563",
             "input_file": "al02_16.adif",
             "output_format": "Unknown",
-            "result": "747cd239982bbf89c906d2a39fc88ad3"
+            "result": "3895a8eb4c3f795f621c0591dac9e076"
         },
         {
             "name": "as07_96",
@@ -417,7 +417,7 @@
             "source_checksum": "26d0d2dbb0c155880d21f70b7a2c7c7a",
             "input_file": "as07_96.adif",
             "output_format": "Unknown",
-            "result": "f9f3a137aff2dafd6e54fc5244e8b277"
+            "result": "a0e96752daf6523ef7b97ee65781e4a6"
         },
         {
             "name": "as04_32",
@@ -425,7 +425,7 @@
             "source_checksum": "43f68a48e10577c3bb17c138ad65430a",
             "input_file": "as04_32.adif",
             "output_format": "Unknown",
-            "result": "f48a1399ca4921ee2ec399daaa9a080b"
+            "result": "5d727123f8f9b07c5e0eae9bf445b72e"
         },
         {
             "name": "as11_88",
@@ -433,7 +433,7 @@
             "source_checksum": "2ce47d17798cdbfa92e68906d4f6973a",
             "input_file": "as11_88.adif",
             "output_format": "Unknown",
-            "result": "18b0882f034fd2fd8519eef52d03071d"
+            "result": "77b571d0663181c946c4707c98dda8fd"
         },
         {
             "name": "as14_96",
@@ -441,7 +441,7 @@
             "source_checksum": "2f696bac95f54675704cbdc03f6af605",
             "input_file": "as14_96.adif",
             "output_format": "Unknown",
-            "result": "a90d3587856469a5fbd58266b7c4f448"
+            "result": "cb972cdb4e5c63d467f7776fa3828699"
         },
         {
             "name": "am05_16",
@@ -449,7 +449,7 @@
             "source_checksum": "c179ce68743ccbe32eb9c0525604cfde",
             "input_file": "am05_16.adif",
             "output_format": "Unknown",
-            "result": "ede190add5ed7fabdca40105b716a244"
+            "result": ""
         },
         {
             "name": "as03_48",
@@ -457,7 +457,7 @@
             "source_checksum": "2ba4cf06b57bd65700ed1d147319c0c7",
             "input_file": "as03_48.adif",
             "output_format": "Unknown",
-            "result": "cb6b7ff7f4d1342fb2233fe41a8c430c"
+            "result": "340d9fe3dc66b3a18d59d62df1d71954"
         },
         {
             "name": "al08_11",
@@ -465,7 +465,7 @@
             "source_checksum": "29221d97459370932770c22b16be666e",
             "input_file": "al08_11.adif",
             "output_format": "Unknown",
-            "result": "76b483d32b37f21b115c7b2528290727"
+            "result": "8f15c703a727432ceb9102ba19accc12"
         },
         {
             "name": "as08_08",
@@ -473,7 +473,7 @@
             "source_checksum": "2032ffba5befa139640339f924d37c77",
             "input_file": "as08_08.adif",
             "output_format": "Unknown",
-            "result": "2cfcb2bbe2efe68a484297f89a855ab3"
+            "result": "e62bcd4999610e37ee6b257bc01542d9"
         },
         {
             "name": "am00_88",
@@ -481,7 +481,7 @@
             "source_checksum": "55be33373a7bc4505b919a0e1caef076",
             "input_file": "am00_88.adif",
             "output_format": "Unknown",
-            "result": "4eb776d8feceb2839cc10c09e083eb25"
+            "result": ""
         },
         {
             "name": "al01_16",
@@ -489,7 +489,7 @@
             "source_checksum": "9392bf9c67380e4aa788d620c6d78b1e",
             "input_file": "al01_16.adif",
             "output_format": "Unknown",
-            "result": "f672442a5ade20a435d8ab1045bb6531"
+            "result": "e2f030fc972340b05f2519b282cdbac3"
         },
         {
             "name": "al10_48",
@@ -497,7 +497,7 @@
             "source_checksum": "ef077bb618b412335f7373f1850b22aa",
             "input_file": "al10_48.adif",
             "output_format": "Unknown",
-            "result": "7a67d156fab668da5d221e98bc7abee2"
+            "result": "2f2c3edf206e466526c1a6f3bc2a41dd"
         },
         {
             "name": "as17_96",
@@ -505,7 +505,7 @@
             "source_checksum": "7e193c8fee053788e4142d4494c122cc",
             "input_file": "as17_96.adif",
             "output_format": "Unknown",
-            "result": "184b56d0315d871aa0df08933fedb1f5"
+            "result": "e5b7d4506a2a7e476c5e173afcf19226"
         },
         {
             "name": "al04_22",
@@ -513,7 +513,7 @@
             "source_checksum": "21192bb9ae3f4670183b53c7882cd9e3",
             "input_file": "al04_22.adif",
             "output_format": "Unknown",
-            "result": "5e07f73fbab97948d0f24f503b44243c"
+            "result": "4fc2b48d87982cf7a70e12d167d3c1dd"
         },
         {
             "name": "as10_08",
@@ -521,7 +521,7 @@
             "source_checksum": "70cba3170e4e72dcdc7ef441e1988ee0",
             "input_file": "as10_08.adif",
             "output_format": "Unknown",
-            "result": "ea68d95c021fdb6638476916da97f68d"
+            "result": "4e6e445af75a79b600f4759c45dca3c8"
         },
         {
             "name": "as14_16",
@@ -529,7 +529,7 @@
             "source_checksum": "a7a0808170a07b1bf6d80c0143da9ec2",
             "input_file": "as14_16.adif",
             "output_format": "Unknown",
-            "result": "9ecdc7e2371cbe431ac0422d36a5eee3"
+            "result": "481c7a271bd4621dac6475e038a66998"
         },
         {
             "name": "as13_16",
@@ -537,7 +537,7 @@
             "source_checksum": "2efff7c432e06a50d8802d0fcb9e9a81",
             "input_file": "as13_16.adif",
             "output_format": "Unknown",
-            "result": "d15df0c7c60656b02d44beccb0ffa32a"
+            "result": "a4c66f7b5287477f02e2e46482b93fd2"
         },
         {
             "name": "al14_32",
@@ -545,7 +545,7 @@
             "source_checksum": "2e21528599362b81050e11a6466080b4",
             "input_file": "al14_32.adif",
             "output_format": "Unknown",
-            "result": "c694cf429bd6b44ac042cda86610d9a1"
+            "result": "72f133b209330a1f080383a4023dd753"
         },
         {
             "name": "as16_22",
@@ -553,7 +553,7 @@
             "source_checksum": "edb4039d3bf55825ae8630a97270e398",
             "input_file": "as16_22.adif",
             "output_format": "Unknown",
-            "result": "dba83f907efc0412078d9292f8be8209"
+            "result": "02856cceb12e9637bb98fc210daf193b"
         },
         {
             "name": "am06_48",
@@ -561,7 +561,7 @@
             "source_checksum": "1cc2e1231962e87ab3f04461fb352cb7",
             "input_file": "am06_48.adif",
             "output_format": "Unknown",
-            "result": "390b741d1eb0c883d7fa8774bd335c91"
+            "result": ""
         },
         {
             "name": "al07_48",
@@ -569,7 +569,7 @@
             "source_checksum": "81f4775c6ee2bde4c826de960087b415",
             "input_file": "al07_48.adif",
             "output_format": "Unknown",
-            "result": "6f918bc625110fadd8474ea296ed9bc9"
+            "result": "70d924177e92b84d441cc00df378b2c0"
         },
         {
             "name": "am06_08",
@@ -577,7 +577,7 @@
             "source_checksum": "338dcd98cded8c3f528d369a5479aaf3",
             "input_file": "am06_08.adif",
             "output_format": "Unknown",
-            "result": "d18699c6289b982368a766654cae0327"
+            "result": ""
         },
         {
             "name": "as13_44",
@@ -585,7 +585,7 @@
             "source_checksum": "0ccd6dafe771f131a0d30a96d124511d",
             "input_file": "as13_44.adif",
             "output_format": "Unknown",
-            "result": "987eb5cf43bda1657763356efd2b1bb5"
+            "result": "14888c909d35b55e76edfb2696f5c0d9"
         },
         {
             "name": "as17_88",
@@ -593,7 +593,7 @@
             "source_checksum": "c69ef051f916a2c1c131881b00c01832",
             "input_file": "as17_88.adif",
             "output_format": "Unknown",
-            "result": "bb00aeafcbcd866473686486c5df641c"
+            "result": "3bf98e171d2dec7242e96170d718c2f7"
         },
         {
             "name": "as13_96",
@@ -601,7 +601,7 @@
             "source_checksum": "d25700c8344a570cfd7be6bf220b6a93",
             "input_file": "as13_96.adif",
             "output_format": "Unknown",
-            "result": "bbe4ebf6a37a75b2dc2f7ef545f825c9"
+            "result": "4b65363c85dedf3aaf68e78c97abb2a4"
         },
         {
             "name": "as13_11",
@@ -609,7 +609,7 @@
             "source_checksum": "cff2c379277e92d2799d8eeb76f77578",
             "input_file": "as13_11.adif",
             "output_format": "Unknown",
-            "result": "cb2eb8c164cdb4531c4f9bee57bcff77"
+            "result": "6c6115066d647d5409a2c2fa9d6f6329"
         },
         {
             "name": "al10_11",
@@ -617,7 +617,7 @@
             "source_checksum": "a7a47614df6c54beec2d743a049a3277",
             "input_file": "al10_11.adif",
             "output_format": "Unknown",
-            "result": "2d3fc0ea32ef7ae7281f18989921337e"
+            "result": "84a10f63ba5870201172712e9284702a"
         },
         {
             "name": "as03_64",
@@ -625,7 +625,7 @@
             "source_checksum": "4630f9e041b11a0f6a39249f90860ce4",
             "input_file": "as03_64.adif",
             "output_format": "Unknown",
-            "result": "509c7c28f6aabfaafae21e9c52292167"
+            "result": "4309816d3606d6c508746f843df54599"
         },
         {
             "name": "al07_88",
@@ -633,7 +633,7 @@
             "source_checksum": "d141d21c99cafc3b72005b7773a96aa5",
             "input_file": "al07_88.adif",
             "output_format": "Unknown",
-            "result": "b321390b3c6d5f756b2f4db146705af1"
+            "result": "dfe19829b88062d92c52c209e41153c3"
         },
         {
             "name": "al05_44",
@@ -641,7 +641,7 @@
             "source_checksum": "a165e5273bb7eb719089fe8ddfd820f2",
             "input_file": "al05_44.adif",
             "output_format": "Unknown",
-            "result": "974c68dff7cd253c3b03afdd25312b3d"
+            "result": "33f981c92cde037b3941040e2ae8bafa"
         },
         {
             "name": "as00_16",
@@ -649,7 +649,7 @@
             "source_checksum": "21eb98b691addda9edcfccd10a17c94b",
             "input_file": "as00_16.adif",
             "output_format": "Unknown",
-            "result": "141ec48eef7ac3babc386074e321d2f2"
+            "result": "3fca6788dceea0bfdb8629150d30a0a4"
         },
         {
             "name": "am01_11",
@@ -657,7 +657,7 @@
             "source_checksum": "6bfcef3f5ce0f22232fc28520e43f516",
             "input_file": "am01_11.adif",
             "output_format": "Unknown",
-            "result": "fd1acc7277a3e121693ccbd422fa9b54"
+            "result": ""
         },
         {
             "name": "as17_08",
@@ -665,7 +665,7 @@
             "source_checksum": "059782358d221faac763a6c270d2da94",
             "input_file": "as17_08.adif",
             "output_format": "Unknown",
-            "result": "91e7370141a87c9bd3859cb1e8a90eaa"
+            "result": "43e5ba87c26f08d32b8b89469c9a3d7e"
         },
         {
             "name": "am04_44",
@@ -673,7 +673,7 @@
             "source_checksum": "2cd0217b1e1ea822e7894ea67efd111b",
             "input_file": "am04_44.adif",
             "output_format": "Unknown",
-            "result": "aed190e2f215781f3ce5d6b7f049d01f"
+            "result": ""
         },
         {
             "name": "as13_24",
@@ -681,7 +681,7 @@
             "source_checksum": "c04efbbd3ab66080b2a06f5f77dfc067",
             "input_file": "as13_24.adif",
             "output_format": "Unknown",
-            "result": "4d58a8c95fe5b572064e61c765a51dcc"
+            "result": "02bfc42a74201206630237e4c7ad381e"
         },
         {
             "name": "al07_08",
@@ -689,7 +689,7 @@
             "source_checksum": "20bcf96171efdc4a554133336b65f3ed",
             "input_file": "al07_08.adif",
             "output_format": "Unknown",
-            "result": "57119ad0fe1c7ebec51ded7e505bc08c"
+            "result": "eaac5252e1c57e7572110d69f4256a22"
         },
         {
             "name": "as10_32",
@@ -697,7 +697,7 @@
             "source_checksum": "fcbfa2eeba126394b35f1ad96c0232c4",
             "input_file": "as10_32.adif",
             "output_format": "Unknown",
-            "result": "ac3c8de68995eaac650d2cb068f9d276"
+            "result": "ab0ddce25aaa8554c5eec91b10c0c546"
         },
         {
             "name": "al00_12",
@@ -705,7 +705,7 @@
             "source_checksum": "27ba3b8d0d1be447640d018c5b2fd147",
             "input_file": "al00_12.adif",
             "output_format": "Unknown",
-            "result": "d8785aa25e03586f25d30f8627ebea42"
+            "result": "1003860d480d488f2093171008643ca2"
         },
         {
             "name": "as03_12",
@@ -713,7 +713,7 @@
             "source_checksum": "a3d86163d27462157df0f2b25e648c29",
             "input_file": "as03_12.adif",
             "output_format": "Unknown",
-            "result": "13dbad3479529b56ef73f1b81b7ec5ef"
+            "result": "abe28e655b5db49b04de9ea99b431e4e"
         },
         {
             "name": "as03_88",
@@ -721,7 +721,7 @@
             "source_checksum": "b230fa4c0be87fb2b3f14b9bb6635b8f",
             "input_file": "as03_88.adif",
             "output_format": "Unknown",
-            "result": "eaf9ef96551243996e32edd057ee982c"
+            "result": "7c1d95a7d4e0291f22079effbf894a78"
         },
         {
             "name": "am01_96",
@@ -729,7 +729,7 @@
             "source_checksum": "f8a86e9fc00e991edc14d197b53b1474",
             "input_file": "am01_96.adif",
             "output_format": "Unknown",
-            "result": "973f40dc7d464c8b4b68db9455e23b82"
+            "result": ""
         },
         {
             "name": "as14_24",
@@ -737,7 +737,7 @@
             "source_checksum": "b7e1f50d540403a71153a3b5d2c02674",
             "input_file": "as14_24.adif",
             "output_format": "Unknown",
-            "result": "388dce7e34dd6a069a9744424344803f"
+            "result": "9576e0ff192755ea369507485c58279e"
         },
         {
             "name": "am04_64",
@@ -745,7 +745,7 @@
             "source_checksum": "cec91a4c806b6b73dfc3241f62e840e9",
             "input_file": "am04_64.adif",
             "output_format": "Unknown",
-            "result": "4c5cea2946487d0c1d6037a6c640ab6d"
+            "result": ""
         },
         {
             "name": "al07_44",
@@ -753,7 +753,7 @@
             "source_checksum": "8fb33e40c8ef874454fd515dd7d5f183",
             "input_file": "al07_44.adif",
             "output_format": "Unknown",
-            "result": "26fb3f4baea7f970b9883054c6bc9869"
+            "result": "70d924177e92b84d441cc00df378b2c0"
         },
         {
             "name": "as13_32",
@@ -761,7 +761,7 @@
             "source_checksum": "77b537b1e3a2c9fca87f0b61b72d7933",
             "input_file": "as13_32.adif",
             "output_format": "Unknown",
-            "result": "bb7034cc7007eddb6c27d84c78feb421"
+            "result": "b68d6ea8dd4223af7d1e57497aaea2e8"
         },
         {
             "name": "am02_88",
@@ -769,7 +769,7 @@
             "source_checksum": "ea11c15002bc0ce36cbd25a61c6a5993",
             "input_file": "am02_88.adif",
             "output_format": "Unknown",
-            "result": "d1654244608e1e9470604439a2b56312"
+            "result": ""
         },
         {
             "name": "al14_96",
@@ -777,7 +777,7 @@
             "source_checksum": "792dc57b8b5017a7cb53610c38133d1e",
             "input_file": "al14_96.adif",
             "output_format": "Unknown",
-            "result": "4dbb7a5874ed45d529d010975c649a36"
+            "result": "ab6c0c02ab8224bc5f126264ee403a42"
         },
         {
             "name": "am03_44",
@@ -793,7 +793,7 @@
             "source_checksum": "0ea2cad65977cceb8ed6e21addb15ded",
             "input_file": "al01_44.adif",
             "output_format": "Unknown",
-            "result": "9db3f0a6df8d64b3addb14cd64401ea9"
+            "result": "0ac8f10d9023e838fd99b79fbd158eab"
         },
         {
             "name": "am03_12",
@@ -809,7 +809,7 @@
             "source_checksum": "fab782be3635222fdacc2c1d6b7ffb04",
             "input_file": "as15_64.adif",
             "output_format": "Unknown",
-            "result": "4288b05bdd8d06b29fbb09c30ddb299d"
+            "result": "9f960c8f0636c7a90bba45ca0cb95de0"
         },
         {
             "name": "al00_88",
@@ -817,7 +817,7 @@
             "source_checksum": "f1b80753bffbc0cb90800cb5ae7a30d6",
             "input_file": "al00_88.adif",
             "output_format": "Unknown",
-            "result": "6f847cba9dc576fac85411e5f7e82a4f"
+            "result": "70118d5e3c508f4709d4944e098c1c9b"
         },
         {
             "name": "al16_22",
@@ -825,7 +825,7 @@
             "source_checksum": "eaf6160cd413973ba94a6c3c2698c92d",
             "input_file": "al16_22.adif",
             "output_format": "Unknown",
-            "result": "ce0d45c137586152931c1e6790d8e99a"
+            "result": "d764858d2fa96357a3214bbb34d75224"
         },
         {
             "name": "as01_96",
@@ -833,7 +833,7 @@
             "source_checksum": "1b379e22176737c08a7247f1df30f31b",
             "input_file": "as01_96.adif",
             "output_format": "Unknown",
-            "result": "5c7a1c940495f5fee0bf5f5c86c85201"
+            "result": "27786e9b7d83abafd8c0bff805d429b9"
         },
         {
             "name": "al10_96",
@@ -841,7 +841,7 @@
             "source_checksum": "b9b90fc331eb062e8a58dcf4d138c48c",
             "input_file": "al10_96.adif",
             "output_format": "Unknown",
-            "result": "626607123a75fd0618eda166afe941e1"
+            "result": "683fbd00d9dcf296f014bb62fd180f1d"
         },
         {
             "name": "al10_08",
@@ -849,7 +849,7 @@
             "source_checksum": "091edfc078279bd603cd271ee2701206",
             "input_file": "al10_08.adif",
             "output_format": "Unknown",
-            "result": "78f7ebac11c9bc22eb7976e67d538300"
+            "result": "667e14ac5c9fd1183f1f243e23947939"
         },
         {
             "name": "am00_96",
@@ -857,7 +857,7 @@
             "source_checksum": "88ac1a9710fff86f8b8e2a2d63d28b35",
             "input_file": "am00_96.adif",
             "output_format": "Unknown",
-            "result": "c2f56da4276be44056df2099fe844862"
+            "result": ""
         },
         {
             "name": "as06_12",
@@ -865,7 +865,7 @@
             "source_checksum": "2ab530176b6ddbe5ece2bbf80fad0e0f",
             "input_file": "as06_12.adif",
             "output_format": "Unknown",
-            "result": "dd12c849b1c5ecdf84b34199f579d116"
+            "result": "adaa0667e7581ff3d6f56ba40bb1c457"
         },
         {
             "name": "am06_88",
@@ -873,7 +873,7 @@
             "source_checksum": "7194a61412f153fc0582ba81d817da1d",
             "input_file": "am06_88.adif",
             "output_format": "Unknown",
-            "result": "a14e628165c352143d14b0b554971e48"
+            "result": ""
         },
         {
             "name": "al05_64",
@@ -881,7 +881,7 @@
             "source_checksum": "62b9321e187a67c0fcb79c38d6fac2df",
             "input_file": "al05_64.adif",
             "output_format": "Unknown",
-            "result": "b531ea7a5beeea84ee18e4c6c3176a1d"
+            "result": "fd32fac5c93040674baf30e5ebf57c52"
         },
         {
             "name": "as12_24",
@@ -889,7 +889,7 @@
             "source_checksum": "d3df57fdd36a9a36ab85baba1b8132c5",
             "input_file": "as12_24.adif",
             "output_format": "Unknown",
-            "result": "038b62b9acda723c5c716bd1b06492ee"
+            "result": "cfabdc64e2e652806354ed8b821690c5"
         },
         {
             "name": "as07_32",
@@ -897,7 +897,7 @@
             "source_checksum": "471ecadda7593e19e078c126a7ab3b82",
             "input_file": "as07_32.adif",
             "output_format": "Unknown",
-            "result": "b5421d371b9f7e3e0d746f0e1f8ad809"
+            "result": "0915e1fbc77e87737d528a0c43051124"
         },
         {
             "name": "am05_24",
@@ -905,7 +905,7 @@
             "source_checksum": "cd8ea7bbdb10df386596da86d68a2f6d",
             "input_file": "am05_24.adif",
             "output_format": "Unknown",
-            "result": "d05aeabaf1ead030a43b70110df7e59a"
+            "result": ""
         },
         {
             "name": "as02_44",
@@ -913,7 +913,7 @@
             "source_checksum": "6333226b0730d35be6fa587ee77be123",
             "input_file": "as02_44.adif",
             "output_format": "Unknown",
-            "result": "bed73699c79288e37ac3ea8f8dce1814"
+            "result": "1d3d1e73b19feeb4ecbe4a702a4361dc"
         },
         {
             "name": "am03_16",
@@ -929,7 +929,7 @@
             "source_checksum": "4bcafc3db934eea2555383c7cdb575bc",
             "input_file": "am00_12.adif",
             "output_format": "Unknown",
-            "result": "ed6315a5d24d5bd43f42c31f38653ea5"
+            "result": ""
         },
         {
             "name": "al17_08",
@@ -937,7 +937,7 @@
             "source_checksum": "d88c04ad6a3140a58c2bd66c9f95f28c",
             "input_file": "al17_08.adif",
             "output_format": "Unknown",
-            "result": "ad8fce15ba0e33cf63663c2d9f13ce7b"
+            "result": "9ce0c79e5a3b97ba1cd7f9051b9cb813"
         },
         {
             "name": "al01_12",
@@ -945,7 +945,7 @@
             "source_checksum": "6e999ac94a3dd9ec0a3c6895fc484bac",
             "input_file": "al01_12.adif",
             "output_format": "Unknown",
-            "result": "af228e4d3dd45d1cbdea619de81b232a"
+            "result": "1bf3c602a298c1b7b2f65080c83d4b49"
         },
         {
             "name": "as01_64",
@@ -953,7 +953,7 @@
             "source_checksum": "aa4924767047ea38ad277c5b8c0346db",
             "input_file": "as01_64.adif",
             "output_format": "Unknown",
-            "result": "8b2609d8c43c34024f0b895431a599de"
+            "result": "a94e930b4474e51dffb012d46af338d5"
         },
         {
             "name": "al11_08",
@@ -961,7 +961,7 @@
             "source_checksum": "5d0a4f363fcac705522c185fdc7ef9ad",
             "input_file": "al11_08.adif",
             "output_format": "Unknown",
-            "result": "3fce9a2bc86c286dfeecc07abe410c73"
+            "result": "ccea2c92561ddbf2e798fbfa14dc46bb"
         },
         {
             "name": "as02_08",
@@ -969,7 +969,7 @@
             "source_checksum": "51b7a069765a38b8ba1a32d12c9adb3a",
             "input_file": "as02_08.adif",
             "output_format": "Unknown",
-            "result": "1c79e9b11ed47cdab8e16be4fe3b152a"
+            "result": "19b5d8f467aac0f0f9c3cd5b841f392e"
         },
         {
             "name": "al08_12",
@@ -977,7 +977,7 @@
             "source_checksum": "64a84baa2e725cb9393a4c487a9b49aa",
             "input_file": "al08_12.adif",
             "output_format": "Unknown",
-            "result": "e19d47280c7782a073017454c21b9e7d"
+            "result": "85695b2defca606c821ed77f12a3d491"
         },
         {
             "name": "am02_64",
@@ -985,7 +985,7 @@
             "source_checksum": "0bda098d9898033a46f48e2720c78ccf",
             "input_file": "am02_64.adif",
             "output_format": "Unknown",
-            "result": "66d2d78003904501367c8814dd051705"
+            "result": ""
         },
         {
             "name": "al05_08",
@@ -993,7 +993,7 @@
             "source_checksum": "44dfe04e6ae3afc18cbfbf20816e626f",
             "input_file": "al05_08.adif",
             "output_format": "Unknown",
-            "result": "757c439182686c058aae637381af759c"
+            "result": "0af6ed73f0e59937b0ffff6da27a9bc8"
         },
         {
             "name": "as01_88",
@@ -1001,7 +1001,7 @@
             "source_checksum": "4229e961f46e211815254a2c7a96fde6",
             "input_file": "as01_88.adif",
             "output_format": "Unknown",
-            "result": "33a3a694ee3fa2c681505ba19d83e6f1"
+            "result": "537a0a3189c650bc1d9e06011f636b26"
         },
         {
             "name": "as06_08",
@@ -1009,7 +1009,7 @@
             "source_checksum": "a90338f833cbe20bc93b646d9f960f55",
             "input_file": "as06_08.adif",
             "output_format": "Unknown",
-            "result": "9442529462fbfd81bb64fdc95ddb81f9"
+            "result": "555df93edaf95cbe5197e493659311f0"
         },
         {
             "name": "as10_44",
@@ -1017,7 +1017,7 @@
             "source_checksum": "3a3bd577479896764e5846773b0d12b4",
             "input_file": "as10_44.adif",
             "output_format": "Unknown",
-            "result": "1eec35f21ed88e2c93ca8e7f515f89f7"
+            "result": "66442b358ffc0b17ff458ebcb910a78d"
         },
         {
             "name": "am02_44",
@@ -1025,7 +1025,7 @@
             "source_checksum": "65e81cad01a0e6af123a9bef9799a280",
             "input_file": "am02_44.adif",
             "output_format": "Unknown",
-            "result": "c4b11daafb3e163bcca28cb49051ac21"
+            "result": ""
         },
         {
             "name": "al14_11",
@@ -1033,7 +1033,7 @@
             "source_checksum": "cbebdea1e1fb02303ef6a49b039ee77f",
             "input_file": "al14_11.adif",
             "output_format": "Unknown",
-            "result": "95d4a0329a616c98ea463667849184e1"
+            "result": "e0f68df4182839866feb36ec0dfa23a2"
         },
         {
             "name": "al17_64",
@@ -1041,7 +1041,7 @@
             "source_checksum": "d7ac48c5e94a457802956ad7843de4aa",
             "input_file": "al17_64.adif",
             "output_format": "Unknown",
-            "result": "8772d2ca9b0ba7a1791efbdaa0164ef4"
+            "result": "9c3bc834d40d27a441ab80ae72eda8c4"
         },
         {
             "name": "as07_08",
@@ -1049,7 +1049,7 @@
             "source_checksum": "7da1536b27398aeb95abea0b07356574",
             "input_file": "as07_08.adif",
             "output_format": "Unknown",
-            "result": "a2f069bb2d4c2fc559b087ceaf2611a9"
+            "result": "4374f44fca297d68a85e64e1c2ad591d"
         },
         {
             "name": "as06_64",
@@ -1057,7 +1057,7 @@
             "source_checksum": "d135dafc5671184c6209da8d6762c7b0",
             "input_file": "as06_64.adif",
             "output_format": "Unknown",
-            "result": "170c0c8d49a9c865e0f18b00694e2449"
+            "result": "b269ccbec78278261e9f9d829366b686"
         },
         {
             "name": "as13_64",
@@ -1065,7 +1065,7 @@
             "source_checksum": "332cef51a6bd356e0543c787170e2a01",
             "input_file": "as13_64.adif",
             "output_format": "Unknown",
-            "result": "5f6cacc81f005fbea09b6f5c550fbc1e"
+            "result": "9f960c8f0636c7a90bba45ca0cb95de0"
         },
         {
             "name": "al14_08",
@@ -1073,7 +1073,7 @@
             "source_checksum": "23ff9b844b6e74c3403376c3db1399f3",
             "input_file": "al14_08.adif",
             "output_format": "Unknown",
-            "result": "b83a3dc231f8dc197cf80a9661b9f565"
+            "result": "c25a053760f16d8340be000648f0a426"
         },
         {
             "name": "as15_12",
@@ -1081,7 +1081,7 @@
             "source_checksum": "d0b0206d412294f9213da07403d85e26",
             "input_file": "as15_12.adif",
             "output_format": "Unknown",
-            "result": "c0122137dfb68395ec79ffaba473aa99"
+            "result": "971a2bff11d06bc3c578efda34aefa4b"
         },
         {
             "name": "as10_11",
@@ -1089,7 +1089,7 @@
             "source_checksum": "9b04af39e3e363be4aefe1fb6283620e",
             "input_file": "as10_11.adif",
             "output_format": "Unknown",
-            "result": "ed444ee237b26cf91d18a572b944929e"
+            "result": "48faf4c4165ff42a3ed86f7102e266f6"
         },
         {
             "name": "al17_32",
@@ -1097,7 +1097,7 @@
             "source_checksum": "e2e7edc8ae817bd03b41757909a39b07",
             "input_file": "al17_32.adif",
             "output_format": "Unknown",
-            "result": "bdfbc1f533af7873b8b27c7f6684d110"
+            "result": "fb0aaa3f83522df7406f67744aa5ac0f"
         },
         {
             "name": "as09_24",
@@ -1105,7 +1105,7 @@
             "source_checksum": "ecde57ece173d963040f160088f9826d",
             "input_file": "as09_24.adif",
             "output_format": "Unknown",
-            "result": "aee0f2fa7904afa5b67f4a3b8b4dbe25"
+            "result": "851b0946a36ffb0d4d309c2a4010ec9b"
         },
         {
             "name": "as00_11",
@@ -1113,7 +1113,7 @@
             "source_checksum": "d72dc24367e405b6709ea7b8875b4f2c",
             "input_file": "as00_11.adif",
             "output_format": "Unknown",
-            "result": "268ba205e55182e6a5155ff82c90bccc"
+            "result": "3629580db303963cdea8dc8d3ecc28e1"
         },
         {
             "name": "as10_12",
@@ -1121,7 +1121,7 @@
             "source_checksum": "61b5be53000e5a6cf676481ced6ede24",
             "input_file": "as10_12.adif",
             "output_format": "Unknown",
-            "result": "177f813fdec5c9ca774c2dc3f746cf98"
+            "result": "f057d8a0ad40f59015672c8d713d44ee"
         },
         {
             "name": "as09_12",
@@ -1129,7 +1129,7 @@
             "source_checksum": "8122b895d9fa0577ad3eef9b62697b96",
             "input_file": "as09_12.adif",
             "output_format": "Unknown",
-            "result": "10fe39f2a317aad193c7771794c24095"
+            "result": "ec6dc14c20693f61c10844ed800a375d"
         },
         {
             "name": "as12_12",
@@ -1137,7 +1137,7 @@
             "source_checksum": "25ff13144c947506b4ef6bd01e7a0372",
             "input_file": "as12_12.adif",
             "output_format": "Unknown",
-            "result": "22a434792056b77731c86d46d3f726e7"
+            "result": "bda16028a6bf0f84d2466e3689bf73bb"
         },
         {
             "name": "am05_96",
@@ -1145,7 +1145,7 @@
             "source_checksum": "a07b6a477935908696a1a8754435dd7b",
             "input_file": "am05_96.adif",
             "output_format": "Unknown",
-            "result": "4b1f764f8a1e1c3656fe5ef38e1d1295"
+            "result": ""
         },
         {
             "name": "as17_11",
@@ -1153,7 +1153,7 @@
             "source_checksum": "e5ef54402a2fe8ca131381d219379ab7",
             "input_file": "as17_11.adif",
             "output_format": "Unknown",
-            "result": "81ecf3f13d8c14ae1935f1ef030a65f2"
+            "result": "300e847b3b81826305e6b4c6dc611235"
         },
         {
             "name": "al11_12",
@@ -1161,7 +1161,7 @@
             "source_checksum": "5ea6c0b20b0fc60d2c61c1333732253e",
             "input_file": "al11_12.adif",
             "output_format": "Unknown",
-            "result": "500e856f36ffbfcad2f7bffacbf36b12"
+            "result": "7ab9935dd1adae5fb5b921c51fb6e3a7"
         },
         {
             "name": "al02_64",
@@ -1169,7 +1169,7 @@
             "source_checksum": "543417e6aac553a482581ed015b60835",
             "input_file": "al02_64.adif",
             "output_format": "Unknown",
-            "result": "3520681a5c7c86c0689431451fcaaaba"
+            "result": "5a1b7aaee8c3e44254fb010268cdcabe"
         },
         {
             "name": "al04_11",
@@ -1177,7 +1177,7 @@
             "source_checksum": "6bbe5612cbafcda2b91cb58b9536731e",
             "input_file": "al04_11.adif",
             "output_format": "Unknown",
-            "result": "cd454ac8cac183ec37a8958349694539"
+            "result": "ce01170c4b3bbadfb22580879745bb79"
         },
         {
             "name": "as01_48",
@@ -1185,7 +1185,7 @@
             "source_checksum": "5779062d3f406e97375920aaad8b4b81",
             "input_file": "as01_48.adif",
             "output_format": "Unknown",
-            "result": "e233e43cc9af5456ddea2649e73fdf10"
+            "result": "39601f6c36e9bed60b5e2b1d700a9acf"
         },
         {
             "name": "am07_32",
@@ -1193,7 +1193,7 @@
             "source_checksum": "6e16189535ee42a3b74f9b9e79907a1f",
             "input_file": "am07_32.adif",
             "output_format": "Unknown",
-            "result": "aefb6f3ee8f563a1fc867b460ce7fb7e"
+            "result": ""
         },
         {
             "name": "am01_24",
@@ -1201,7 +1201,7 @@
             "source_checksum": "806d34a4e2cbe4e73a249e51d5dbe0fc",
             "input_file": "am01_24.adif",
             "output_format": "Unknown",
-            "result": "f9f1e2f962c273fa6ac41d39b97908b1"
+            "result": ""
         },
         {
             "name": "as02_11",
@@ -1209,7 +1209,7 @@
             "source_checksum": "f489f54829abcffad471f7cae943006e",
             "input_file": "as02_11.adif",
             "output_format": "Unknown",
-            "result": "38ef40de9b789c408f09b4bfb8ed0276"
+            "result": "a9dbc7369832bc9ce70391719891fb98"
         },
         {
             "name": "al11_11",
@@ -1217,7 +1217,7 @@
             "source_checksum": "e8998fbbf779d630b9bc8c52587a809f",
             "input_file": "al11_11.adif",
             "output_format": "Unknown",
-            "result": "6c58d72c4d61bfaade9d024befc6720d"
+            "result": "7ab9935dd1adae5fb5b921c51fb6e3a7"
         },
         {
             "name": "al07_32",
@@ -1225,7 +1225,7 @@
             "source_checksum": "1951b2cdc62f469aff0c33e6238ec6ed",
             "input_file": "al07_32.adif",
             "output_format": "Unknown",
-            "result": "b3e7f7a56194cee885f27fdb6bcde0ef"
+            "result": "70d924177e92b84d441cc00df378b2c0"
         },
         {
             "name": "as14_44",
@@ -1233,7 +1233,7 @@
             "source_checksum": "d34b6e847823670133a78409150bd4d6",
             "input_file": "as14_44.adif",
             "output_format": "Unknown",
-            "result": "eea8952903287bbb55f09062b1952f7e"
+            "result": "e9ede9a5a4dad2a4c35d239aec4889fc"
         },
         {
             "name": "al10_32",
@@ -1241,7 +1241,7 @@
             "source_checksum": "714ce237510281f9f26399249400c051",
             "input_file": "al10_32.adif",
             "output_format": "Unknown",
-            "result": "56625ea03c1904f9002987ec322b791f"
+            "result": "64c7e981f255cb6317c361c93e8df348"
         },
         {
             "name": "am05_11",
@@ -1249,7 +1249,7 @@
             "source_checksum": "f9cb1b11e8571ab7b8c5c0e713cc2666",
             "input_file": "am05_11.adif",
             "output_format": "Unknown",
-            "result": "8c50713c2b4441b86eb6cdf337790a63"
+            "result": ""
         },
         {
             "name": "al11_96",
@@ -1257,7 +1257,7 @@
             "source_checksum": "935e4d6703ce671da87bce96b98675ca",
             "input_file": "al11_96.adif",
             "output_format": "Unknown",
-            "result": "2dcbaa1a0cc55268446084ade89792d2"
+            "result": "b8c525add273b5c290f71a807a1c4b69"
         },
         {
             "name": "as03_24",
@@ -1265,7 +1265,7 @@
             "source_checksum": "414c5378d08014af10eb7afddc01e5f6",
             "input_file": "as03_24.adif",
             "output_format": "Unknown",
-            "result": "d48c085a48f78fdc40260e4473355645"
+            "result": "7824e57e3964d56457224f67a9383e7b"
         },
         {
             "name": "as00_96",
@@ -1273,7 +1273,7 @@
             "source_checksum": "edb7e3e997dd0683016f66f49f66b307",
             "input_file": "as00_96.adif",
             "output_format": "Unknown",
-            "result": "25874ef62a64c7dd56ade35eee089f70"
+            "result": "44ea7c5eec39221a7d480380ff7a3ce9"
         },
         {
             "name": "as09_32",
@@ -1281,7 +1281,7 @@
             "source_checksum": "370de848773760e4864fb4d46e482890",
             "input_file": "as09_32.adif",
             "output_format": "Unknown",
-            "result": "3269f2464a6fc84be10e170a910cf5cd"
+            "result": "c30c42a679a63bb4764920eb82e34101"
         },
         {
             "name": "as16_88",
@@ -1289,7 +1289,7 @@
             "source_checksum": "f0ef214db637a349e87c6a37a751083d",
             "input_file": "as16_88.adif",
             "output_format": "Unknown",
-            "result": "98ec633740ffb7311cf063643698c608"
+            "result": "28e85247ea8004cd8253429f6c1e7248"
         },
         {
             "name": "as05_11",
@@ -1297,7 +1297,7 @@
             "source_checksum": "51f5815f7309678cbe33afb7007dc810",
             "input_file": "as05_11.adif",
             "output_format": "Unknown",
-            "result": "b80df7933e4b0de42644f3ca2ab4af26"
+            "result": "4304c8ed55dac9a12a96e88528ce97b7"
         },
         {
             "name": "am05_12",
@@ -1305,7 +1305,7 @@
             "source_checksum": "bf4a83b0b6c3b94746b3462d68f654c4",
             "input_file": "am05_12.adif",
             "output_format": "Unknown",
-            "result": "c0acc317ad68ea35202e995e36934aeb"
+            "result": ""
         },
         {
             "name": "al15_22",
@@ -1313,7 +1313,7 @@
             "source_checksum": "9f6aca5fb1fd3603cee3ef0bc9196f09",
             "input_file": "al15_22.adif",
             "output_format": "Unknown",
-            "result": "5102bc34434a6afa02035c4327070a27"
+            "result": "16e1e7aa3336dd99203ce7b16087719d"
         },
         {
             "name": "al06_12",
@@ -1321,7 +1321,7 @@
             "source_checksum": "983d2fe5e350df1ce724163046115786",
             "input_file": "al06_12.adif",
             "output_format": "Unknown",
-            "result": "c5ad46d44a8aa2f9b722e86724e78533"
+            "result": "0478cbd3efa8e014ca82954e31084f20"
         },
         {
             "name": "am06_24",
@@ -1329,7 +1329,7 @@
             "source_checksum": "a9421c6811dafd836da05d037f9fcbf4",
             "input_file": "am06_24.adif",
             "output_format": "Unknown",
-            "result": "91499d27cccdf5dff7464ade88d7a0f4"
+            "result": ""
         },
         {
             "name": "as16_12",
@@ -1337,7 +1337,7 @@
             "source_checksum": "537e63ad7170042b4de8638e9f99fbf2",
             "input_file": "as16_12.adif",
             "output_format": "Unknown",
-            "result": "cf6c3d855e7948d6f9ea8153ce99c835"
+            "result": "cb0d5dbdfddc30ad05585e911fc73d59"
         },
         {
             "name": "al05_32",
@@ -1345,7 +1345,7 @@
             "source_checksum": "c9dc7ea87bb8c2138accb373ecb93f6b",
             "input_file": "al05_32.adif",
             "output_format": "Unknown",
-            "result": "70a77b7ff81977996d2f8e2eb976731c"
+            "result": "d8fd8cbd4707458c7dbc2331ad792e67"
         },
         {
             "name": "al06_08",
@@ -1353,7 +1353,7 @@
             "source_checksum": "b6c41f3ddf3d1d84aeab46be9672b810",
             "input_file": "al06_08.adif",
             "output_format": "Unknown",
-            "result": "908178c6c11aba81d8807c887eff080f"
+            "result": "0e0cc8a25f7eb161f66ee3bc65199d04"
         },
         {
             "name": "am04_48",
@@ -1361,7 +1361,7 @@
             "source_checksum": "3aff314027f3b08129ba3cfedca95011",
             "input_file": "am04_48.adif",
             "output_format": "Unknown",
-            "result": "c82d341d09df47d7cd95980103a5047b"
+            "result": ""
         },
         {
             "name": "am01_16",
@@ -1369,7 +1369,7 @@
             "source_checksum": "60fe7b6600282ba2932e052916358e20",
             "input_file": "am01_16.adif",
             "output_format": "Unknown",
-            "result": "fd2786d9f25f1dcbba7e0c69b4e6e852"
+            "result": ""
         },
         {
             "name": "as03_16",
@@ -1377,7 +1377,7 @@
             "source_checksum": "54b0faf23d3f08535cfaec672e32c3fe",
             "input_file": "as03_16.adif",
             "output_format": "Unknown",
-            "result": "ab10d711cc205cfba6b4ab3acf786659"
+            "result": "0298779243f1f989e4aea5aa255f57ea"
         },
         {
             "name": "as02_96",
@@ -1385,7 +1385,7 @@
             "source_checksum": "0910681bd4c31d8dacd8f5d4cb5e35bc",
             "input_file": "as02_96.adif",
             "output_format": "Unknown",
-            "result": "0015c9bd4f31478189693a9a02f0ce4c"
+            "result": "d5c8999daac06c904e5327603f51f0cb"
         },
         {
             "name": "as14_48",
@@ -1393,7 +1393,7 @@
             "source_checksum": "9fc154f89b929e81b04981ddb8d05cc6",
             "input_file": "as14_48.adif",
             "output_format": "Unknown",
-            "result": "ca2372c941696bc6f2a832955a731f02"
+            "result": "58f3a2a2c3bb76ddcdecb80e54e32cda"
         },
         {
             "name": "am01_48",
@@ -1401,7 +1401,7 @@
             "source_checksum": "75268f551cca8f1cf69755a80ca59243",
             "input_file": "am01_48.adif",
             "output_format": "Unknown",
-            "result": "4a8e8fda92a0a62b6223ff70dc01a85d"
+            "result": ""
         },
         {
             "name": "al10_64",
@@ -1409,7 +1409,7 @@
             "source_checksum": "66854739b84336de79d86148bb43bbce",
             "input_file": "al10_64.adif",
             "output_format": "Unknown",
-            "result": "385bc8facd3a65085b097ec6e8456e8f"
+            "result": "60353cbfdf32fc2539dab16995aef0f2"
         },
         {
             "name": "as10_64",
@@ -1417,7 +1417,7 @@
             "source_checksum": "531de5e77171cca0bb4c8233616c2fd7",
             "input_file": "as10_64.adif",
             "output_format": "Unknown",
-            "result": "3f048234a7cb626e3721c4897396888d"
+            "result": "f098fc1ece5df2f3e5ae72b49f7801ec"
         },
         {
             "name": "al11_24",
@@ -1425,7 +1425,7 @@
             "source_checksum": "484f7a6979741a3d5d307c2951bc49a8",
             "input_file": "al11_24.adif",
             "output_format": "Unknown",
-            "result": "3d0818a89b925321723f3d94f240313e"
+            "result": "e6c07de6c6cbf92bd9c53308443f8c35"
         },
         {
             "name": "al08_48",
@@ -1433,7 +1433,7 @@
             "source_checksum": "ae2dfe8516355a4902a9cceb3dc4e1fc",
             "input_file": "al08_48.adif",
             "output_format": "Unknown",
-            "result": "3e6aed72a9f8a512abfb3910ce659875"
+            "result": "97e049c5ca237411214a5ba9f0733dbc"
         },
         {
             "name": "as02_24",
@@ -1441,7 +1441,7 @@
             "source_checksum": "3fdfad2cc900055aa3e08b0d4518f7dc",
             "input_file": "as02_24.adif",
             "output_format": "Unknown",
-            "result": "8c5a5f68d0f34a31fbdbcb6431d95ce1"
+            "result": "90ebe7c4b7924fd5bd0c8a26d904ac79"
         },
         {
             "name": "as02_32",
@@ -1449,7 +1449,7 @@
             "source_checksum": "6f969fe3439f169794b257227a908373",
             "input_file": "as02_32.adif",
             "output_format": "Unknown",
-            "result": "5194631454e943a0cfe1fcca55e35caa"
+            "result": "f3ee637a48cf6737058daef20576406c"
         },
         {
             "name": "as03_32",
@@ -1457,7 +1457,7 @@
             "source_checksum": "a709f78ed8075fc43ecf64e7aae2f0b4",
             "input_file": "as03_32.adif",
             "output_format": "Unknown",
-            "result": "ef99583781d0ed96cd3ffe95edf603c1"
+            "result": "920794a07f55ca188bb2fdcc09dd990a"
         },
         {
             "name": "as02_88",
@@ -1465,7 +1465,7 @@
             "source_checksum": "06d90c71bc5d7d65be25d6ac9d87471d",
             "input_file": "as02_88.adif",
             "output_format": "Unknown",
-            "result": "743720b5a196e871221a697c54d077a4"
+            "result": "f669b471bf5bfd82e5a24f6715ca5e8b"
         },
         {
             "name": "as13_88",
@@ -1473,7 +1473,7 @@
             "source_checksum": "265d5ba6dd9aa495a72be1218ca582cd",
             "input_file": "as13_88.adif",
             "output_format": "Unknown",
-            "result": "c179c48d2ec68eac7daeb9d192315324"
+            "result": "6b658a186b7b45033d2ec0fce12379cd"
         },
         {
             "name": "al00_64",
@@ -1481,7 +1481,7 @@
             "source_checksum": "5265ac7d2779a6c8935a8a7ba0df7ef0",
             "input_file": "al00_64.adif",
             "output_format": "Unknown",
-            "result": "ed617a3380649158fcad8a884cd2c7da"
+            "result": "0acee3957588ecf625efa56540f02f6a"
         },
         {
             "name": "al07_16",
@@ -1489,7 +1489,7 @@
             "source_checksum": "fd94710d05ccaf37a1460aae76573a2e",
             "input_file": "al07_16.adif",
             "output_format": "Unknown",
-            "result": "44116b59a1e5a2326e0b4adb6a54e425"
+            "result": "d4de30fb19a0873a2357523a21a7c11f"
         },
         {
             "name": "al15_44",
@@ -1497,7 +1497,7 @@
             "source_checksum": "dda8f7dd23a5a91459e83734dceb189c",
             "input_file": "al15_44.adif",
             "output_format": "Unknown",
-            "result": "f92dbbf81850e6c41624e2f374bd21dd"
+            "result": "2767d1b2de38d169cc1928312efc95a0"
         },
         {
             "name": "al02_48",
@@ -1505,7 +1505,7 @@
             "source_checksum": "78308842a6a9f66cf1856a21c2015478",
             "input_file": "al02_48.adif",
             "output_format": "Unknown",
-            "result": "12123a0f5029080c1d77cdea15e7eb5a"
+            "result": "efce3a472bba51ef2c22a68981f7bd40"
         },
         {
             "name": "as07_24",
@@ -1513,7 +1513,7 @@
             "source_checksum": "4404503a3bb2d603d8b7094e121b2c16",
             "input_file": "as07_24.adif",
             "output_format": "Unknown",
-            "result": "d6387bdff258fb143649563a56142f11"
+            "result": "8a6f5b90e5fdd48feb04a0d7bbe10b73"
         },
         {
             "name": "al15_12",
@@ -1521,7 +1521,7 @@
             "source_checksum": "cf936789f590c3de434da91bcb1fd47f",
             "input_file": "al15_12.adif",
             "output_format": "Unknown",
-            "result": "7d69b6b24db914cc897d3041d9c31004"
+            "result": "613e8b751fe47328154d1459b0675880"
         },
         {
             "name": "as03_08",
@@ -1529,7 +1529,7 @@
             "source_checksum": "c20766117feabf1ad20c3a6de239229d",
             "input_file": "as03_08.adif",
             "output_format": "Unknown",
-            "result": "a9757b75e9714b4a1402defbae821c71"
+            "result": "873c6825dee58dba747bb0d1713c9876"
         },
         {
             "name": "al15_16",
@@ -1537,7 +1537,7 @@
             "source_checksum": "6f208714b73294baa6ab96150f1b6585",
             "input_file": "al15_16.adif",
             "output_format": "Unknown",
-            "result": "d4f437e1a2355bc251ed6b1bc5cb5abb"
+            "result": "84a8b1a037c4c3385c37aa6b106ed4e8"
         },
         {
             "name": "as16_44",
@@ -1545,7 +1545,7 @@
             "source_checksum": "b3c46830c7b4dc0ed6ef969536b3b682",
             "input_file": "as16_44.adif",
             "output_format": "Unknown",
-            "result": "6c8662690fb978351069c907bb551967"
+            "result": "e9ede9a5a4dad2a4c35d239aec4889fc"
         },
         {
             "name": "as05_48",
@@ -1553,7 +1553,7 @@
             "source_checksum": "37f4af2d7fca05fbfc0ce8c01dbe0bd8",
             "input_file": "as05_48.adif",
             "output_format": "Unknown",
-            "result": "0c0a1808388d66236e0610552f0a9a74"
+            "result": "92776cb4dcaa00660145739ac77f3c40"
         },
         {
             "name": "as02_48",
@@ -1561,7 +1561,7 @@
             "source_checksum": "7f430b134f210e7d51f4fc8784cf0031",
             "input_file": "as02_48.adif",
             "output_format": "Unknown",
-            "result": "cad33a05189eec4fa45726ec0f4a37b7"
+            "result": "8f0fec654f8b846b229f8a656c6aca0d"
         },
         {
             "name": "am01_88",
@@ -1569,7 +1569,7 @@
             "source_checksum": "36c3ac9e1cdfaee199fece84578a89e1",
             "input_file": "am01_88.adif",
             "output_format": "Unknown",
-            "result": "da8a298e0336f73be2e6580e9feda34a"
+            "result": ""
         },
         {
             "name": "am06_11",
@@ -1577,7 +1577,7 @@
             "source_checksum": "463fd1a62a3d64b9f0f870c31b18cdc5",
             "input_file": "am06_11.adif",
             "output_format": "Unknown",
-            "result": "afdd70fe093061dfeab43b2f2733eb12"
+            "result": ""
         },
         {
             "name": "al06_16",
@@ -1585,7 +1585,7 @@
             "source_checksum": "53291b8acc28f4263f0257483d566f65",
             "input_file": "al06_16.adif",
             "output_format": "Unknown",
-            "result": "951df0c7979f6ea775f1dd17917ba116"
+            "result": "ae346b6e8f7053883dc823c3f4288ff5"
         },
         {
             "name": "as00_44",
@@ -1593,7 +1593,7 @@
             "source_checksum": "1eb2e2a70405662c2bd2b8e2c3433e92",
             "input_file": "as00_44.adif",
             "output_format": "Unknown",
-            "result": "c33a7e28f410e4a62e222b942f011892"
+            "result": "b54c4156d525170f40cff12eb4f0afd8"
         },
         {
             "name": "as10_22",
@@ -1601,7 +1601,7 @@
             "source_checksum": "185616ba252a1c63f2fb57c62f08d39a",
             "input_file": "as10_22.adif",
             "output_format": "Unknown",
-            "result": "63540df30d23ff3c710face7def42f2f"
+            "result": "bc7e903ad7664ee5e0fbbb655e1e32ee"
         },
         {
             "name": "as00_32",
@@ -1609,7 +1609,7 @@
             "source_checksum": "fa532cc4486c814259b8405a1a28b06b",
             "input_file": "as00_32.adif",
             "output_format": "Unknown",
-            "result": "a586d5e77f69f37f35480fbf684c4c8d"
+            "result": "ba87750cd665c8d17d0515d5162b6899"
         },
         {
             "name": "as12_16",
@@ -1617,7 +1617,7 @@
             "source_checksum": "046c1f0d8fa6f4fff06ca4d3edb84546",
             "input_file": "as12_16.adif",
             "output_format": "Unknown",
-            "result": "053c70d6fae79706c0e52b946dfa187b"
+            "result": "a987f1846c38136e503b386b0eb1bec8"
         },
         {
             "name": "al03_48",
@@ -1625,7 +1625,7 @@
             "source_checksum": "83d96a25a3e3009eee4166523380cf3b",
             "input_file": "al03_48.adif",
             "output_format": "Unknown",
-            "result": "3423a37adda615d49193b754cd4e2b2e"
+            "result": "908d650ff51a6b6f09d22d70ed0eafc3"
         },
         {
             "name": "am00_08",
@@ -1633,7 +1633,7 @@
             "source_checksum": "486014e224f9979e004d171cb6d89301",
             "input_file": "am00_08.adif",
             "output_format": "Unknown",
-            "result": "c083f24c1dbb71fd59b15ee003627a81"
+            "result": ""
         },
         {
             "name": "al15_64",
@@ -1641,7 +1641,7 @@
             "source_checksum": "f7daa778a7429520312a19495a45d7d7",
             "input_file": "al15_64.adif",
             "output_format": "Unknown",
-            "result": "05c5d3379b87fc4d7c667ec7a42fb699"
+            "result": "9a57af3c5a820f0d72cc46a9742b844e"
         },
         {
             "name": "al04_48",
@@ -1649,7 +1649,7 @@
             "source_checksum": "27dfe1f7efaea1d2ef83a33ca8592211",
             "input_file": "al04_48.adif",
             "output_format": "Unknown",
-            "result": "8425a582faa9df2f2f16ed3b29b89db0"
+            "result": "1f04cda750065aad2633d369241e9aed"
         },
         {
             "name": "as02_12",
@@ -1657,7 +1657,7 @@
             "source_checksum": "f2b22f2d40c765306aac63f12a289e85",
             "input_file": "as02_12.adif",
             "output_format": "Unknown",
-            "result": "a344dd9ecf4d768006ad70e923789045"
+            "result": "11af3f565ca36a6ceab18aaabdca4f46"
         },
         {
             "name": "as05_44",
@@ -1665,7 +1665,7 @@
             "source_checksum": "1bf578f4ecc4c8e1f2d32e09f9ec7b50",
             "input_file": "as05_44.adif",
             "output_format": "Unknown",
-            "result": "86dda4d3c8379e28a9daffd13b49de78"
+            "result": "6d52bc409273a725d7d0688d2be08421"
         },
         {
             "name": "as06_22",
@@ -1673,7 +1673,7 @@
             "source_checksum": "102a336da252003df1be050fe530fb47",
             "input_file": "as06_22.adif",
             "output_format": "Unknown",
-            "result": "5ea03bd99aebdb3b7274ee333182502c"
+            "result": "3d1602d419ff72fd988407ac777dc09d"
         },
         {
             "name": "al05_24",
@@ -1681,7 +1681,7 @@
             "source_checksum": "ef7273bef5348e4f25b4f74d06a94149",
             "input_file": "al05_24.adif",
             "output_format": "Unknown",
-            "result": "35fa30e8b391513d7342bd0705f413be"
+            "result": "6420d66039cd4cef3ff15fbbbe94459b"
         },
         {
             "name": "as16_48",
@@ -1689,7 +1689,7 @@
             "source_checksum": "c1d02c5aa5d128dae8f4840957b7e974",
             "input_file": "as16_48.adif",
             "output_format": "Unknown",
-            "result": "006ccb8ff4408ff8a18bee484af26fea"
+            "result": "58f3a2a2c3bb76ddcdecb80e54e32cda"
         },
         {
             "name": "as04_96",
@@ -1697,7 +1697,7 @@
             "source_checksum": "8af7979e2812243b4c8d289998977b5a",
             "input_file": "as04_96.adif",
             "output_format": "Unknown",
-            "result": "0f2f8a81a76aed87b05579ad95b9623e"
+            "result": "427a7b0857a8a9b9e5d10c57c3d7f56d"
         },
         {
             "name": "am04_96",
@@ -1705,7 +1705,7 @@
             "source_checksum": "2f8610445d67d522dfae66c55791844d",
             "input_file": "am04_96.adif",
             "output_format": "Unknown",
-            "result": "a4575d75131980fa419052202d927699"
+            "result": ""
         },
         {
             "name": "al03_22",
@@ -1713,7 +1713,7 @@
             "source_checksum": "5390b6ff9692ceea6c7ffc34e2ef827c",
             "input_file": "al03_22.adif",
             "output_format": "Unknown",
-            "result": "7620d0b5cb72527b254c4c3d04d0da53"
+            "result": "6819ba04cee182d2aa3247ed93b9923d"
         },
         {
             "name": "al02_32",
@@ -1721,7 +1721,7 @@
             "source_checksum": "011f1ba40f43cbcaa21ccaeb7ff1acad",
             "input_file": "al02_32.adif",
             "output_format": "Unknown",
-            "result": "9b8f034d020af012aab28c66d44ed090"
+            "result": "6ba7ac6c9ce17617f2b8e192d64111ca"
         },
         {
             "name": "as02_16",
@@ -1729,7 +1729,7 @@
             "source_checksum": "fcae91f018fae9802f0282b1ef667ef1",
             "input_file": "as02_16.adif",
             "output_format": "Unknown",
-            "result": "a7529483ff57afcac97217182ac3f4e9"
+            "result": "21842cc363c6ba31f829806c76c0d488"
         },
         {
             "name": "as08_64",
@@ -1737,7 +1737,7 @@
             "source_checksum": "42554670387838a1405236f84f9f75e4",
             "input_file": "as08_64.adif",
             "output_format": "Unknown",
-            "result": "b7ea2d7f026ffc0999c3208274dbfa98"
+            "result": "967475be69d08b82e6b150b78a86f44d"
         },
         {
             "name": "al10_22",
@@ -1745,7 +1745,7 @@
             "source_checksum": "8ba01b5432895372cfcd729765bbc661",
             "input_file": "al10_22.adif",
             "output_format": "Unknown",
-            "result": "835a422e74b283a569340e3cb659d294"
+            "result": "4c1f58d8aa0646636fc1b6ffce4aaf20"
         },
         {
             "name": "al00_96",
@@ -1753,7 +1753,7 @@
             "source_checksum": "a4341f186efda6dad24b64577b77c639",
             "input_file": "al00_96.adif",
             "output_format": "Unknown",
-            "result": "d7f35eb2fbc98733d4a11533d515dfca"
+            "result": "7dc7b3c9f121b6afe05020dcd7316f45"
         },
         {
             "name": "am04_12",
@@ -1761,7 +1761,7 @@
             "source_checksum": "2b26096ce17d6e6fc3cfbdb23fb36ee7",
             "input_file": "am04_12.adif",
             "output_format": "Unknown",
-            "result": "471f36c8ae39f7e6223892906910249a"
+            "result": ""
         },
         {
             "name": "as17_64",
@@ -1769,7 +1769,7 @@
             "source_checksum": "82ca1da4cc28179b9b13b96646a724dd",
             "input_file": "as17_64.adif",
             "output_format": "Unknown",
-            "result": "c9d2c3d35d665ee8ec0167eec0ac05ae"
+            "result": "95e70c5865bb22a9b7389af0b3d024fb"
         },
         {
             "name": "al10_44",
@@ -1777,7 +1777,7 @@
             "source_checksum": "6b3b2e83b9812c54d65ba83e6fe94066",
             "input_file": "al10_44.adif",
             "output_format": "Unknown",
-            "result": "6db1640b4644fe0ebd60e683544c243a"
+            "result": "d1d7df79481b20a7cbff0726807bb161"
         },
         {
             "name": "al16_24",
@@ -1785,7 +1785,7 @@
             "source_checksum": "e1600a8935d316a51e84b6e1f464ae30",
             "input_file": "al16_24.adif",
             "output_format": "Unknown",
-            "result": "3b385fdfbcd81f8ca7700f1970e31d69"
+            "result": "504ea25bf408453edb069c8874792863"
         },
         {
             "name": "as09_64",
@@ -1793,7 +1793,7 @@
             "source_checksum": "1d4df190aecd137c2b53ffd97ac7d350",
             "input_file": "as09_64.adif",
             "output_format": "Unknown",
-            "result": "662b8783c15662d06262953a586233c0"
+            "result": "eaf17ab6b54acc45bd1bf4a0c50b99a1"
         },
         {
             "name": "as08_32",
@@ -1801,7 +1801,7 @@
             "source_checksum": "4cbd1a709580c9a4cb3419ee46956c62",
             "input_file": "as08_32.adif",
             "output_format": "Unknown",
-            "result": "8a79ded78a344d98459b8a15d7dc1efd"
+            "result": "11a3cfd97a1fdb82c0a2c46df65514b6"
         },
         {
             "name": "as07_48",
@@ -1809,7 +1809,7 @@
             "source_checksum": "5795d6a65fc76242207fc5730e57b992",
             "input_file": "as07_48.adif",
             "output_format": "Unknown",
-            "result": "c6640a2982cd6cb568e4fecde26d312f"
+            "result": "06baf14e1baa6f403761fb4aff978608"
         },
         {
             "name": "am04_08",
@@ -1817,7 +1817,7 @@
             "source_checksum": "f9d9a02cd9595587cc59a2f05e9b7a58",
             "input_file": "am04_08.adif",
             "output_format": "Unknown",
-            "result": "64204501c5c229574ea019ccf153161c"
+            "result": ""
         },
         {
             "name": "as01_16",
@@ -1825,7 +1825,7 @@
             "source_checksum": "3243787f89da65be6b0fa90b24f90ade",
             "input_file": "as01_16.adif",
             "output_format": "Unknown",
-            "result": "443d8fe9ef999db485118069a3cd368a"
+            "result": "0bda27fe86e947592e92ec47c050621a"
         },
         {
             "name": "as00_88",
@@ -1833,7 +1833,7 @@
             "source_checksum": "c5e93d25747956d8c037cdcfb9681168",
             "input_file": "as00_88.adif",
             "output_format": "Unknown",
-            "result": "7c45a2c5566d18c70385ba6faaeb90c0"
+            "result": "9fad6dc2afb3e4dfe2c48736dc612302"
         },
         {
             "name": "al17_22",
@@ -1841,7 +1841,7 @@
             "source_checksum": "4816ccb2676cf31919106c7b90b9d16e",
             "input_file": "al17_22.adif",
             "output_format": "Unknown",
-            "result": "211a3759a8a15f002d9a513bb953adca"
+            "result": "282a105e716a8a6280f5fd9c162dbbce"
         },
         {
             "name": "al08_22",
@@ -1849,7 +1849,7 @@
             "source_checksum": "831863f51f6305bdfabbd849cec02a7c",
             "input_file": "al08_22.adif",
             "output_format": "Unknown",
-            "result": "0c2cb8f5186564cfcb0e59f0ea33b851"
+            "result": "05c041101be07734c5b7eb4619dea481"
         },
         {
             "name": "al17_24",
@@ -1857,7 +1857,7 @@
             "source_checksum": "eea5321dd06f793a4e26a5f619a8ea09",
             "input_file": "al17_24.adif",
             "output_format": "Unknown",
-            "result": "b71e53adc0fd512863cfef6024dc696e"
+            "result": "81e7f63e34e349fd6138172552c55936"
         },
         {
             "name": "am00_22",
@@ -1865,7 +1865,7 @@
             "source_checksum": "5953a6cf627bab3032706c4f67baa709",
             "input_file": "am00_22.adif",
             "output_format": "Unknown",
-            "result": "eb0b98927548766c4255669f3e3ce9b8"
+            "result": ""
         },
         {
             "name": "al02_96",
@@ -1873,7 +1873,7 @@
             "source_checksum": "4bb6735b2e164cfc1978bc28940eca97",
             "input_file": "al02_96.adif",
             "output_format": "Unknown",
-            "result": "ed6285e0cfb8c550b2706a5fca959e5b"
+            "result": "c91d263e846628e4060cdef6c9b5c81d"
         },
         {
             "name": "as13_08",
@@ -1881,7 +1881,7 @@
             "source_checksum": "f86b772eeb27e2005986a1f47f96b99d",
             "input_file": "as13_08.adif",
             "output_format": "Unknown",
-            "result": "24e076717c1e4d93b2555b8e2577d83c"
+            "result": "f48ab7fc21542d1d0caf92eacb51eee3"
         },
         {
             "name": "as10_88",
@@ -1889,7 +1889,7 @@
             "source_checksum": "a1e82e62f8f3c4b9157f80d8a14f488a",
             "input_file": "as10_88.adif",
             "output_format": "Unknown",
-            "result": "6b703dce85ab645f4c93f93531147ad7"
+            "result": "89d1a1d770e20273220f50c283de459a"
         },
         {
             "name": "am02_16",
@@ -1897,7 +1897,7 @@
             "source_checksum": "fc2f23c3e0018defc658e7ba53285fc3",
             "input_file": "am02_16.adif",
             "output_format": "Unknown",
-            "result": "52524ae6d48844ed21487ca2bbadb4e7"
+            "result": ""
         },
         {
             "name": "as04_64",
@@ -1905,7 +1905,7 @@
             "source_checksum": "c5fd2bf14c328dbe198e5610b4c8bc75",
             "input_file": "as04_64.adif",
             "output_format": "Unknown",
-            "result": "3870cf022763616fb17dfaddaa2164fc"
+            "result": "e8ba5e37c694b3669d197c8ba5f980a1"
         },
         {
             "name": "as06_96",
@@ -1913,7 +1913,7 @@
             "source_checksum": "abd0dd523acc11cef329f3df8b5ef090",
             "input_file": "as06_96.adif",
             "output_format": "Unknown",
-            "result": "bf0ac98555d58abe43989d40c9e4d36a"
+            "result": "186d598b2d6798f3e41cdb3fe57f4469"
         },
         {
             "name": "al05_88",
@@ -1921,7 +1921,7 @@
             "source_checksum": "d23201f4f0d47e8d2434f52c69ee9645",
             "input_file": "al05_88.adif",
             "output_format": "Unknown",
-            "result": "1ae6c2ed656dab100587eec3ce413166"
+            "result": "6b609311bb4090654a70cda3b6df7ee4"
         },
         {
             "name": "am00_24",
@@ -1929,7 +1929,7 @@
             "source_checksum": "7c0c22ed3b15be29afcbc46f179fddf7",
             "input_file": "am00_24.adif",
             "output_format": "Unknown",
-            "result": "fd42f61a2fdc9a35a695373dadc79769"
+            "result": ""
         },
         {
             "name": "al03_32",
@@ -1937,7 +1937,7 @@
             "source_checksum": "edad5b37697ee9b29aad9dd0352ae20a",
             "input_file": "al03_32.adif",
             "output_format": "Unknown",
-            "result": "b1147dcac85d3f49fa33a8fef80b1098"
+            "result": "5262e32342bfac7cfbad37a17fbdaba2"
         },
         {
             "name": "am01_12",
@@ -1945,7 +1945,7 @@
             "source_checksum": "09ac88daefcf469da375592eee3d2d10",
             "input_file": "am01_12.adif",
             "output_format": "Unknown",
-            "result": "74d2561f0d010b57650a96a928f1156d"
+            "result": ""
         },
         {
             "name": "al08_32",
@@ -1953,7 +1953,7 @@
             "source_checksum": "e6f3dbbc3bca93e7360f55e25f0ac168",
             "input_file": "al08_32.adif",
             "output_format": "Unknown",
-            "result": "15802d910ecf295167ef46b452f122f0"
+            "result": "f02dcaed96aa7113f6f34ab33a786383"
         },
         {
             "name": "as17_32",
@@ -1961,7 +1961,7 @@
             "source_checksum": "04794b3fc57432105789f4b896690ff4",
             "input_file": "as17_32.adif",
             "output_format": "Unknown",
-            "result": "bd03c6031c3343160967dad3d8a5e15b"
+            "result": "f905cf951369cd78ff5dbc5fc03b82a7"
         },
         {
             "name": "al00_48",
@@ -1969,7 +1969,7 @@
             "source_checksum": "a8d8c0115b96a1b970bc5706484c250f",
             "input_file": "al00_48.adif",
             "output_format": "Unknown",
-            "result": "abd8313d6637a6ad21b73e0a82c4b1c5"
+            "result": "81aed3ed01060d1453cc96ad6e8e7222"
         },
         {
             "name": "as06_48",
@@ -1977,7 +1977,7 @@
             "source_checksum": "67b3f544eccd37987b4ab7c6edfc0628",
             "input_file": "as06_48.adif",
             "output_format": "Unknown",
-            "result": "aaa204f179951f42e84db63afa5c8235"
+            "result": "b244b4e92cad9813cd100e1dd92ae8a4"
         },
         {
             "name": "as06_16",
@@ -1985,7 +1985,7 @@
             "source_checksum": "0991f82910e3a3ceb7411fa3ecd2579b",
             "input_file": "as06_16.adif",
             "output_format": "Unknown",
-            "result": "39bde639c7675aa8e9691131b0b3d979"
+            "result": "481e95a7bc8864e6b97edb66cc561aaa"
         },
         {
             "name": "am03_11",
@@ -2001,7 +2001,7 @@
             "source_checksum": "c861c83476f57db3d430939222969962",
             "input_file": "as15_11.adif",
             "output_format": "Unknown",
-            "result": "7ecca8e2d8495c76231fdb8c2f8d88f8"
+            "result": "6c6115066d647d5409a2c2fa9d6f6329"
         },
         {
             "name": "al05_12",
@@ -2009,7 +2009,7 @@
             "source_checksum": "8eb62e29a607e52f54fcb83d0dbba9ea",
             "input_file": "al05_12.adif",
             "output_format": "Unknown",
-            "result": "833295e60e339dc95b9cce1bf626c55f"
+            "result": "afbc1483e6a4a6dc56901b63b047969f"
         },
         {
             "name": "as05_32",
@@ -2017,7 +2017,7 @@
             "source_checksum": "786ff25ecfab56e2f8568c5ac4416e71",
             "input_file": "as05_32.adif",
             "output_format": "Unknown",
-            "result": "b230aac0965664b7949b22a561ed083d"
+            "result": "81c8e7279518789f3aca4218330f3dc3"
         },
         {
             "name": "as08_44",
@@ -2025,7 +2025,7 @@
             "source_checksum": "cfc463ff339a0e17451ffac899840f93",
             "input_file": "as08_44.adif",
             "output_format": "Unknown",
-            "result": "676d971358b073017a05da87d8a8cf31"
+            "result": "cf0ed6a192d5677699cdd2d0ed48690e"
         },
         {
             "name": "am05_64",
@@ -2033,7 +2033,7 @@
             "source_checksum": "2be3b02613dd9b680ddc3c1dec538190",
             "input_file": "am05_64.adif",
             "output_format": "Unknown",
-            "result": "c5eaa7025e49b641709a8c962a9fec4f"
+            "result": ""
         },
         {
             "name": "as04_11",
@@ -2041,7 +2041,7 @@
             "source_checksum": "5c413397a5056fa581af6fea2c95eb9a",
             "input_file": "as04_11.adif",
             "output_format": "Unknown",
-            "result": "fd578ca3c2463363498e02df9ff27c2f"
+            "result": "9b1e1cb3d539ac3c605175a667cc426a"
         },
         {
             "name": "al03_12",
@@ -2049,7 +2049,7 @@
             "source_checksum": "f7f1df748e4c5d74add7a46d11191114",
             "input_file": "al03_12.adif",
             "output_format": "Unknown",
-            "result": "a539b569424dd16e33df702f969c2c45"
+            "result": "97c9a4a96818ef0c03dc1c8797aa7279"
         },
         {
             "name": "am05_44",
@@ -2057,7 +2057,7 @@
             "source_checksum": "07592518d2fbc33f5f2e5ba04c72be05",
             "input_file": "am05_44.adif",
             "output_format": "Unknown",
-            "result": "b9808e995c35e7aec73e670f7b09c699"
+            "result": ""
         },
         {
             "name": "al00_11",
@@ -2065,7 +2065,7 @@
             "source_checksum": "29c354ff3674a291e859644d38607c06",
             "input_file": "al00_11.adif",
             "output_format": "Unknown",
-            "result": "564fdffe306018f3beb5a6591bef4916"
+            "result": "6eb23f7d1b322d167f0c075234ad66ec"
         },
         {
             "name": "am04_16",
@@ -2073,7 +2073,7 @@
             "source_checksum": "75cb5ed0631e83714602af7f70c92920",
             "input_file": "am04_16.adif",
             "output_format": "Unknown",
-            "result": "97e01cc29ed85f086b461143650a5929"
+            "result": ""
         },
         {
             "name": "al01_32",
@@ -2081,7 +2081,7 @@
             "source_checksum": "2c7cb9ae862f21c6d979a7ff03da979b",
             "input_file": "al01_32.adif",
             "output_format": "Unknown",
-            "result": "09cc3507d1b246b4282c57480f87f45d"
+            "result": "11be4fd08e53a9ee75abaca22469f6dd"
         },
         {
             "name": "as05_96",
@@ -2089,7 +2089,7 @@
             "source_checksum": "bf3e69ff5e104c80a8562471529f6e2a",
             "input_file": "as05_96.adif",
             "output_format": "Unknown",
-            "result": "c844fc76ba81822b36b4dc653f65d80c"
+            "result": "692a1720c71b0f8ed917ddf21a38f390"
         },
         {
             "name": "as13_22",
@@ -2097,7 +2097,7 @@
             "source_checksum": "393b584638bbd8f3da30bc22387c64e7",
             "input_file": "as13_22.adif",
             "output_format": "Unknown",
-            "result": "b7f5db02beafe48e6c4ab4ee7c3178e1"
+            "result": "3845021412db78720068ec2dcd901fc3"
         },
         {
             "name": "al15_24",
@@ -2105,7 +2105,7 @@
             "source_checksum": "b82c5db2c5e53d83d6ea5c1a5d42d889",
             "input_file": "al15_24.adif",
             "output_format": "Unknown",
-            "result": "2e274ef446e418f012ddaa2e93ef41ee"
+            "result": "938c26465f99f8c49948a749e3549f96"
         },
         {
             "name": "al01_64",
@@ -2113,7 +2113,7 @@
             "source_checksum": "d3d72f21cf951cf4e7a7c1d979773844",
             "input_file": "al01_64.adif",
             "output_format": "Unknown",
-            "result": "d383f2f17e5e483d9ca000d68e32d373"
+            "result": "567affc7a30b2b05804877c986b93849"
         },
         {
             "name": "al11_32",
@@ -2121,7 +2121,7 @@
             "source_checksum": "138c6689f4070dc3a963d3cced8414c9",
             "input_file": "al11_32.adif",
             "output_format": "Unknown",
-            "result": "aece086a2e3a22e86aab68460e393e31"
+            "result": "8d04675fe3c49edc18dd47e0d7a52e8b"
         },
         {
             "name": "al15_88",
@@ -2129,7 +2129,7 @@
             "source_checksum": "a735f7added079fdd22bb561640d3870",
             "input_file": "al15_88.adif",
             "output_format": "Unknown",
-            "result": "5ebea5e79d02a158c37adc0eda56affb"
+            "result": "dab50d4dda248e969302ebf08cc123e1"
         },
         {
             "name": "al04_96",
@@ -2137,7 +2137,7 @@
             "source_checksum": "aa43752745b2184c57d908ca14c39744",
             "input_file": "al04_96.adif",
             "output_format": "Unknown",
-            "result": "d1e04ce10f5f9bc2ef51abe1989bc6da"
+            "result": "edb05b74da0fb44f78dc51c5c8e7369f"
         },
         {
             "name": "as12_11",
@@ -2145,7 +2145,7 @@
             "source_checksum": "fd831aa0b6cb7abab09cb669e8e97da5",
             "input_file": "as12_11.adif",
             "output_format": "Unknown",
-            "result": "4a68be51ef73db9cdbdf3221793bbf4e"
+            "result": "78df5d5b0f389a36d0965568e053b126"
         },
         {
             "name": "al04_08",
@@ -2153,7 +2153,7 @@
             "source_checksum": "9de5dc95fcd431d38085c3fd1b67ceaf",
             "input_file": "al04_08.adif",
             "output_format": "Unknown",
-            "result": "231c9dc383b337bf38563abaaf8f029c"
+            "result": "19d650af57f6baa32202f3100aeb1eda"
         },
         {
             "name": "as07_64",
@@ -2161,7 +2161,7 @@
             "source_checksum": "25590e412968c02af2557a94debe9512",
             "input_file": "as07_64.adif",
             "output_format": "Unknown",
-            "result": "6d6eff939dec0fe13c287d8890a8a652"
+            "result": "c8dccbd7a2c94b812341b369757f2cf6"
         },
         {
             "name": "as02_22",
@@ -2169,7 +2169,7 @@
             "source_checksum": "b406f6beff96dac480270e4bd6ada9ce",
             "input_file": "as02_22.adif",
             "output_format": "Unknown",
-            "result": "5f2f6b6ef41559f7278968a6e9d31c18"
+            "result": "01451e220069c903d77ca277444480c5"
         },
         {
             "name": "al02_22",
@@ -2177,7 +2177,7 @@
             "source_checksum": "bbf19a61465e31c556ffd5e67a273e81",
             "input_file": "al02_22.adif",
             "output_format": "Unknown",
-            "result": "ec7061228793d93b20f5f677e542ca1d"
+            "result": "f17cde07183e4e9e9986248b099d098c"
         },
         {
             "name": "as11_22",
@@ -2185,7 +2185,7 @@
             "source_checksum": "97d485ba1ec66a192aea236bfc194ba1",
             "input_file": "as11_22.adif",
             "output_format": "Unknown",
-            "result": "dd86941c116f3ec5ce8b8cd4975ff3ad"
+            "result": "240d65d4f0e91934c0385d84db957d4a"
         },
         {
             "name": "as08_11",
@@ -2193,7 +2193,7 @@
             "source_checksum": "dd9f3618b2f918404d80ec2984022e8d",
             "input_file": "as08_11.adif",
             "output_format": "Unknown",
-            "result": "db7c7e7e6221255ff19c36a7a8096e47"
+            "result": "ba9b6025a324f400b8974402fc0cb31d"
         },
         {
             "name": "am07_16",
@@ -2201,7 +2201,7 @@
             "source_checksum": "6907839260332d03ab0fe526487f6a2e",
             "input_file": "am07_16.adif",
             "output_format": "Unknown",
-            "result": "67631d8560a5110815639b122a371003"
+            "result": ""
         },
         {
             "name": "al07_64",
@@ -2209,7 +2209,7 @@
             "source_checksum": "7c39cf45af0ffbf4f2e333fc720b594a",
             "input_file": "al07_64.adif",
             "output_format": "Unknown",
-            "result": "d9ffa48ad4094cdcdd9ddd423addb04c"
+            "result": "45fc46d86e78b09f6277591a34fc2793"
         },
         {
             "name": "al05_16",
@@ -2217,7 +2217,7 @@
             "source_checksum": "46466377ece9f768efd423836a600bd2",
             "input_file": "al05_16.adif",
             "output_format": "Unknown",
-            "result": "22b2f611f3a41c54f7837af9c1b4dd7b"
+            "result": "3e17aa815d1dfbb8228c0723179d9840"
         },
         {
             "name": "al17_88",
@@ -2225,7 +2225,7 @@
             "source_checksum": "e7087dd37dd943ed8c718916472bd34f",
             "input_file": "al17_88.adif",
             "output_format": "Unknown",
-            "result": "2219bd5815a46dfcf774a271e35e525f"
+            "result": "ad70e0b02635cfcb30c928dc70b4ef05"
         },
         {
             "name": "al11_16",
@@ -2233,7 +2233,7 @@
             "source_checksum": "48c617c21b8f39d49539cf70864e37b3",
             "input_file": "al11_16.adif",
             "output_format": "Unknown",
-            "result": "744d618e1e12d1e19f566c74b00a299b"
+            "result": "56c62176823bf381fb8544ab7afac53f"
         },
         {
             "name": "as14_88",
@@ -2241,7 +2241,7 @@
             "source_checksum": "162557a17004be6e524cff529b5c9f81",
             "input_file": "as14_88.adif",
             "output_format": "Unknown",
-            "result": "a1bcc3f34ea750cc0ff1017f058702f7"
+            "result": "28e85247ea8004cd8253429f6c1e7248"
         },
         {
             "name": "al17_16",
@@ -2249,7 +2249,7 @@
             "source_checksum": "27123fef4142e7839d94297ddafe3635",
             "input_file": "al17_16.adif",
             "output_format": "Unknown",
-            "result": "1cdb187a479e006c240bcb15aa58c923"
+            "result": "578f691643c105bc6e12665c4f595a0a"
         },
         {
             "name": "am01_64",
@@ -2257,7 +2257,7 @@
             "source_checksum": "c700995285943645467e0bca4be4203b",
             "input_file": "am01_64.adif",
             "output_format": "Unknown",
-            "result": "b122693c58ec1f26785bf0fdc54a60b6"
+            "result": ""
         },
         {
             "name": "as09_96",
@@ -2265,7 +2265,7 @@
             "source_checksum": "469b6a7aaf50fa2b8a346f19b70fe7d7",
             "input_file": "as09_96.adif",
             "output_format": "Unknown",
-            "result": "7bc2688eec734b01ec2583f86d2135d8"
+            "result": "dacba353af93ca1befcabcc4e4d28e0a"
         },
         {
             "name": "as11_44",
@@ -2273,7 +2273,7 @@
             "source_checksum": "2a4da877c3efba23e6b17a97fde04ef7",
             "input_file": "as11_44.adif",
             "output_format": "Unknown",
-            "result": "9d8a4f38e4275fcc36646642ee6a5d92"
+            "result": "6faa8f6cad155d54f232fdfcc1c1a001"
         },
         {
             "name": "al00_08",
@@ -2281,7 +2281,7 @@
             "source_checksum": "28f92ffac6e9d6902d48b5deabc5f19c",
             "input_file": "al00_08.adif",
             "output_format": "Unknown",
-            "result": "f51bc915327ba92651210a086a9fc0ca"
+            "result": "974fc5db0dd85a5240956a8a5e593469"
         },
         {
             "name": "as12_64",
@@ -2289,7 +2289,7 @@
             "source_checksum": "fda3af28f356a0d24ba9afc2f46ec6bd",
             "input_file": "as12_64.adif",
             "output_format": "Unknown",
-            "result": "416bfd4370daabaf668bd30fd7997474"
+            "result": "8839665fc97bff6a189aff3bc2d914e9"
         },
         {
             "name": "am04_32",
@@ -2297,7 +2297,7 @@
             "source_checksum": "651df35d42e4ff5c2de6012778578a56",
             "input_file": "am04_32.adif",
             "output_format": "Unknown",
-            "result": "8c6c38c3e9fac6b328857621350c90a6"
+            "result": ""
         },
         {
             "name": "as06_32",
@@ -2305,7 +2305,7 @@
             "source_checksum": "d1604f527022a000c07ee30e9fad75bf",
             "input_file": "as06_32.adif",
             "output_format": "Unknown",
-            "result": "27826f37e38556d630c64bd4542e8da9"
+            "result": "fcf22800a2bd08404106ba73071589e9"
         },
         {
             "name": "as12_48",
@@ -2313,7 +2313,7 @@
             "source_checksum": "e0ace25c053ce4e8af121375d7b1a5a6",
             "input_file": "as12_48.adif",
             "output_format": "Unknown",
-            "result": "e2b742a62f77206620cbd8ac3e359172"
+            "result": "4dc47947189b4cf08e4f5feee6b2ea48"
         },
         {
             "name": "al03_16",
@@ -2321,7 +2321,7 @@
             "source_checksum": "d8409e2181a0afe5a23bfebd466f663e",
             "input_file": "al03_16.adif",
             "output_format": "Unknown",
-            "result": "9e22fd8dfc8b6cd393605b8057fa9cb2"
+            "result": "98b5f0df41b303b02037224f09cf45ea"
         },
         {
             "name": "al04_12",
@@ -2329,7 +2329,7 @@
             "source_checksum": "e431501fbb8f33b65a4662dd7e9218f7",
             "input_file": "al04_12.adif",
             "output_format": "Unknown",
-            "result": "2339c1b3bf5c195d4ff88363cffa7336"
+            "result": "4320324e32f3eb59a745643911e04e99"
         },
         {
             "name": "am03_88",
@@ -2345,7 +2345,7 @@
             "source_checksum": "318901fe746911a3ab79b7705298a089",
             "input_file": "am02_24.adif",
             "output_format": "Unknown",
-            "result": "17c34307426f27e6b0b3dbd37c4d1642"
+            "result": ""
         },
         {
             "name": "al15_08",
@@ -2353,7 +2353,7 @@
             "source_checksum": "c351bb10904374e006adbedc3a94ad82",
             "input_file": "al15_08.adif",
             "output_format": "Unknown",
-            "result": "32bc1a8518593d6d349697de75743bb4"
+            "result": "cc0eaf34dccfa2702c3dc87e41eae088"
         },
         {
             "name": "as07_44",
@@ -2361,7 +2361,7 @@
             "source_checksum": "a91d0157422b124bda52c187b3a53cf1",
             "input_file": "as07_44.adif",
             "output_format": "Unknown",
-            "result": "bf6f23968f5eb9c89b23eb13b305d2ee"
+            "result": "085350565881a963a3ad4cae99a91f02"
         },
         {
             "name": "al06_48",
@@ -2369,7 +2369,7 @@
             "source_checksum": "f5dfeb9040b05bc9f254f87e39f37978",
             "input_file": "al06_48.adif",
             "output_format": "Unknown",
-            "result": "492d15822528982fa6f5cb082558b8b6"
+            "result": "4979e6a7e1e61e051c85d1b7d738845f"
         },
         {
             "name": "as08_16",
@@ -2377,7 +2377,7 @@
             "source_checksum": "3fa5924deb11931fe2f743a96054058a",
             "input_file": "as08_16.adif",
             "output_format": "Unknown",
-            "result": "68d618f6205b247015b7a728829ec516"
+            "result": "de780ed0c5bc65a8b7fc268dda22b8b5"
         },
         {
             "name": "al10_12",
@@ -2385,7 +2385,7 @@
             "source_checksum": "8d0bb47777f83aa00c0a3ed9553b5e9b",
             "input_file": "al10_12.adif",
             "output_format": "Unknown",
-            "result": "78396d476a15d6d5d1b5f09686e3b7dd"
+            "result": "38c1ba5d4543309ae6c9aa1ee38eb242"
         },
         {
             "name": "as00_08",
@@ -2393,7 +2393,7 @@
             "source_checksum": "c29f62f26e46869b584c509a91465894",
             "input_file": "as00_08.adif",
             "output_format": "Unknown",
-            "result": "9f2b75421052f06d8ec5170f5d7e44a6"
+            "result": "f852727b02e8195bc975fe7342821cb3"
         },
         {
             "name": "al08_16",
@@ -2401,7 +2401,7 @@
             "source_checksum": "1247c1221eaeae9f3ca1f0c8c3aa531d",
             "input_file": "al08_16.adif",
             "output_format": "Unknown",
-            "result": "4f856f4ac1ef362626d19ef8070bb20d"
+            "result": "cbb19d0daf6f45e3cfafbf2d9780d758"
         },
         {
             "name": "am07_44",
@@ -2409,7 +2409,7 @@
             "source_checksum": "7055d3ac07b0e7240fdb385b682bcc93",
             "input_file": "am07_44.adif",
             "output_format": "Unknown",
-            "result": "f786f8ed8c5a50c4d8077ab6b82e9485"
+            "result": ""
         },
         {
             "name": "al14_22",
@@ -2417,7 +2417,7 @@
             "source_checksum": "bd7bb659b39ec5b79ef1917b995dd427",
             "input_file": "al14_22.adif",
             "output_format": "Unknown",
-            "result": "eeaae62689c0cfd63778ed83e332891d"
+            "result": "9e85dec1e7c4e72e889eeb3b9a7c5d02"
         },
         {
             "name": "am00_16",
@@ -2425,7 +2425,7 @@
             "source_checksum": "da2ce2e8909132d9fe7d5965b13b2398",
             "input_file": "am00_16.adif",
             "output_format": "Unknown",
-            "result": "746fc937c0c106feace2586d61b550f8"
+            "result": ""
         },
         {
             "name": "al06_24",
@@ -2433,7 +2433,7 @@
             "source_checksum": "473bd942a3fe600536000145a182ed5b",
             "input_file": "al06_24.adif",
             "output_format": "Unknown",
-            "result": "a9b0b23a74da7c3be7e98ec3fd9063de"
+            "result": "7608666b6e0dfeca71883389302f2fe0"
         },
         {
             "name": "al02_24",
@@ -2441,7 +2441,7 @@
             "source_checksum": "e09d9c42e1638fe643201c101626a57c",
             "input_file": "al02_24.adif",
             "output_format": "Unknown",
-            "result": "2a1d7b0ef91f222b3065cd5dac554e74"
+            "result": "db09ed12bdb1cbaf49dfe9bd7e1046b5"
         },
         {
             "name": "as03_22",
@@ -2449,7 +2449,7 @@
             "source_checksum": "2c6ad17ff9f1d2ead09ca0ba7bd28b69",
             "input_file": "as03_22.adif",
             "output_format": "Unknown",
-            "result": "479097b77fe9ed40faa9df12295fef7c"
+            "result": "60873fde0040eae4680267487c338185"
         },
         {
             "name": "am07_24",
@@ -2457,7 +2457,7 @@
             "source_checksum": "3bbc106d00d15af257c60ed8c919bb06",
             "input_file": "am07_24.adif",
             "output_format": "Unknown",
-            "result": "6471b8925a069fa8d2f72b316f89c892"
+            "result": ""
         },
         {
             "name": "as16_24",
@@ -2465,7 +2465,7 @@
             "source_checksum": "b860919f417f12608818613027221504",
             "input_file": "as16_24.adif",
             "output_format": "Unknown",
-            "result": "cce1fd5ef92bb911ca9ed31ff9a1f7f7"
+            "result": "9576e0ff192755ea369507485c58279e"
         },
         {
             "name": "al16_96",
@@ -2473,7 +2473,7 @@
             "source_checksum": "49d0c08f2e76329ef65ba8cd5de02a1a",
             "input_file": "al16_96.adif",
             "output_format": "Unknown",
-            "result": "791977f6e5128f789c1feda93d405d82"
+            "result": "0f621d7167bfe6b3bacd7d74b2369875"
         },
         {
             "name": "as06_24",
@@ -2481,7 +2481,7 @@
             "source_checksum": "0bdde69c632529ed01881784ba2b20b9",
             "input_file": "as06_24.adif",
             "output_format": "Unknown",
-            "result": "678368d6904fbc8b1bbf72fcd9b0938c"
+            "result": "2d6e341afd09aa7225a3286e6aeca4e7"
         },
         {
             "name": "al16_16",
@@ -2489,7 +2489,7 @@
             "source_checksum": "8ef8cf87ae8f0b95c1c62efd8a851dd7",
             "input_file": "al16_16.adif",
             "output_format": "Unknown",
-            "result": "b6edb1cd8d38186da791a81adce84763"
+            "result": "0f98f372b70cdb58f24d868c6c792610"
         },
         {
             "name": "al05_48",
@@ -2497,7 +2497,7 @@
             "source_checksum": "d7f21b4772a6d7200311ed2748f2243e",
             "input_file": "al05_48.adif",
             "output_format": "Unknown",
-            "result": "72d6a6bdc8f7e11c5045b16f0b4affa5"
+            "result": "d72ef57b7bad160905b7d1650360c474"
         },
         {
             "name": "al14_24",
@@ -2505,7 +2505,7 @@
             "source_checksum": "2c1bf0af880429c3131379670884a87d",
             "input_file": "al14_24.adif",
             "output_format": "Unknown",
-            "result": "a30b5c3d69751fa21eba7601ee84074a"
+            "result": "744f7fd7aef4005110b26134c89938f6"
         },
         {
             "name": "al02_11",
@@ -2513,7 +2513,7 @@
             "source_checksum": "dd0f6ad621f67b522954ea86b51261fd",
             "input_file": "al02_11.adif",
             "output_format": "Unknown",
-            "result": "c01a6ab37750601d4c2402a34e25fa4b"
+            "result": "6919665a2023157452cff79d0ea54f4c"
         },
         {
             "name": "as16_96",
@@ -2521,7 +2521,7 @@
             "source_checksum": "ef061cb8ec1b71cfa772e8acecd3a3b6",
             "input_file": "as16_96.adif",
             "output_format": "Unknown",
-            "result": "bea87dd0f3b414e8d68d3ff276ea09d9"
+            "result": "cb972cdb4e5c63d467f7776fa3828699"
         },
         {
             "name": "as10_24",
@@ -2529,7 +2529,7 @@
             "source_checksum": "3b5a1835c89796817665e46085616a6f",
             "input_file": "as10_24.adif",
             "output_format": "Unknown",
-            "result": "f6bcb17d41b774561741b9e0850b28ea"
+            "result": "b3e9246d5753333f14341f4cefd6edf2"
         },
         {
             "name": "as05_16",
@@ -2537,7 +2537,7 @@
             "source_checksum": "69197de50712adb3921331fea1325fbe",
             "input_file": "as05_16.adif",
             "output_format": "Unknown",
-            "result": "5181745f6837595e079cb9af25fcb8ee"
+            "result": "748cfa097ad0e6fce489f0a44a788742"
         },
         {
             "name": "al17_96",
@@ -2545,7 +2545,7 @@
             "source_checksum": "6c47815257e74d28fe1536bdce8070bb",
             "input_file": "al17_96.adif",
             "output_format": "Unknown",
-            "result": "dacdf06c5f83eded4932333d92cdd026"
+            "result": "2db5470e36e27f85dbbe9e49d1ff0c13"
         },
         {
             "name": "as04_12",
@@ -2553,7 +2553,7 @@
             "source_checksum": "06380ae021e223877b57d8d8ae757aa0",
             "input_file": "as04_12.adif",
             "output_format": "Unknown",
-            "result": "14554fda3ff6e2d4b44517df3105d282"
+            "result": "1f56b8ef778b40628b873e55c03dba60"
         },
         {
             "name": "al03_64",
@@ -2561,7 +2561,7 @@
             "source_checksum": "21d2d76310871a46b9ee72198d384a02",
             "input_file": "al03_64.adif",
             "output_format": "Unknown",
-            "result": "8dc242e65af1291a3652728bf313fcd6"
+            "result": "352d2c45ae42514dde7d018bbcdd538c"
         },
         {
             "name": "al02_44",
@@ -2569,7 +2569,7 @@
             "source_checksum": "ecbed11de361afd7cfb639f95957e9fa",
             "input_file": "al02_44.adif",
             "output_format": "Unknown",
-            "result": "ccf297dbf63eb9db6eab3aa95559bc9b"
+            "result": "976f11accce8764adff7f6fe13c1d204"
         },
         {
             "name": "as17_22",
@@ -2577,7 +2577,7 @@
             "source_checksum": "6d91a0fc5b7694b410f5c4fa8a3b785d",
             "input_file": "as17_22.adif",
             "output_format": "Unknown",
-            "result": "cf478bd6693810de058733a918636cec"
+            "result": "8f1c79031d95623682ecf9fd8e33392a"
         },
         {
             "name": "as01_24",
@@ -2585,7 +2585,7 @@
             "source_checksum": "1c892b72b201ad7727e15d29156e1c90",
             "input_file": "as01_24.adif",
             "output_format": "Unknown",
-            "result": "d5fbe4c9c8a6588b9776c9f67c825d2b"
+            "result": "a8f4b97f487b82cbe3267f4e06c0f487"
         },
         {
             "name": "am02_32",
@@ -2593,7 +2593,7 @@
             "source_checksum": "3595d955fc9d5b1e8f9e12bd03d784a8",
             "input_file": "am02_32.adif",
             "output_format": "Unknown",
-            "result": "9215e2c2da657bda91d108847f608c18"
+            "result": ""
         },
         {
             "name": "am07_22",
@@ -2601,7 +2601,7 @@
             "source_checksum": "3a8242c2464e4a0b3225d6a1874b638d",
             "input_file": "am07_22.adif",
             "output_format": "Unknown",
-            "result": "2e6967553f45465c82405c76f854f91c"
+            "result": ""
         },
         {
             "name": "am05_08",
@@ -2609,7 +2609,7 @@
             "source_checksum": "07a00475dd08af84b7c5b5b3a18d7bb2",
             "input_file": "am05_08.adif",
             "output_format": "Unknown",
-            "result": "d0cd7d4c6fc2c1d30bc065e1e28a6459"
+            "result": ""
         },
         {
             "name": "al05_11",
@@ -2617,7 +2617,7 @@
             "source_checksum": "e35a25f489d4aa3f319af84b262d7c61",
             "input_file": "al05_11.adif",
             "output_format": "Unknown",
-            "result": "704c5e478d28f9f5a51e009a309a7fa9"
+            "result": "915e57e4e3865a3ea6a0d4e89f81ba45"
         },
         {
             "name": "al01_96",
@@ -2625,7 +2625,7 @@
             "source_checksum": "60907ad644ed1720c4ba1b36cfef10db",
             "input_file": "al01_96.adif",
             "output_format": "Unknown",
-            "result": "be25c04a0a649d520ea1fb18e273c62e"
+            "result": "4677b93aa04c55103ebd1dce77c6f4c8"
         },
         {
             "name": "as03_96",
@@ -2633,7 +2633,7 @@
             "source_checksum": "9d33b9418f75be820c9361f3933cf53b",
             "input_file": "as03_96.adif",
             "output_format": "Unknown",
-            "result": "f1207cb102f4fd350e943b82e6975df2"
+            "result": "821297607b9b166cebad6a5ba5de4dc7"
         },
         {
             "name": "as08_24",
@@ -2641,7 +2641,7 @@
             "source_checksum": "8b4298e5f1f7f76b88220a3f758ed975",
             "input_file": "as08_24.adif",
             "output_format": "Unknown",
-            "result": "912e8df5ff074fbc807440d667b74d4c"
+            "result": "b081fdd346de4da4a7896cfaecba28e1"
         },
         {
             "name": "al08_08",
@@ -2649,7 +2649,7 @@
             "source_checksum": "ccff973470212ceb4d4423dbd29adf31",
             "input_file": "al08_08.adif",
             "output_format": "Unknown",
-            "result": "18cae4b2b6adbeee5a5ee53607265f38"
+            "result": "6d7174d75cfe8faf8de3b66f5258f595"
         },
         {
             "name": "am01_44",
@@ -2657,7 +2657,7 @@
             "source_checksum": "103a80fd7149ca10c77a06d0cec6b4bd",
             "input_file": "am01_44.adif",
             "output_format": "Unknown",
-            "result": "a9fbe1ca9b4d6a40a9d05892191ad791"
+            "result": ""
         },
         {
             "name": "as12_08",
@@ -2665,7 +2665,7 @@
             "source_checksum": "0f88f3f7bf05f5a44fd203b84b445118",
             "input_file": "as12_08.adif",
             "output_format": "Unknown",
-            "result": "f5f864f633e111f51d5a58b40ea14faf"
+            "result": "ada25d771c467cdc3112323b11cb9251"
         },
         {
             "name": "as16_64",
@@ -2673,7 +2673,7 @@
             "source_checksum": "fd04e42e382f2bed77f9f31b9dfd612f",
             "input_file": "as16_64.adif",
             "output_format": "Unknown",
-            "result": "55a170adc7a98582f55cb3608ddb5622"
+            "result": "f2c8633c48bbec94ce6d900aaf4d1bd2"
         },
         {
             "name": "as05_64",
@@ -2681,7 +2681,7 @@
             "source_checksum": "5ad04e2e5dac2447b8b3694597b4d4ee",
             "input_file": "as05_64.adif",
             "output_format": "Unknown",
-            "result": "5ea923c785dfb14285f0e757bc4b29b5"
+            "result": "82667487c94e609a16cd32285574253c"
         },
         {
             "name": "as13_48",
@@ -2689,7 +2689,7 @@
             "source_checksum": "b6925dbbee31aeb5dd086fc098610412",
             "input_file": "as13_48.adif",
             "output_format": "Unknown",
-            "result": "7a3ae19014a0db7d922923548f8c891a"
+            "result": "c9a81a0fa18615801cdc39e5b163f671"
         },
         {
             "name": "al11_88",
@@ -2697,7 +2697,7 @@
             "source_checksum": "2b5ab09c85a9822ad067f8c3f8959d66",
             "input_file": "al11_88.adif",
             "output_format": "Unknown",
-            "result": "e574d740c10d9d1af361de46e09650e2"
+            "result": "b8c525add273b5c290f71a807a1c4b69"
         },
         {
             "name": "am07_11",
@@ -2705,7 +2705,7 @@
             "source_checksum": "9ee732353f7e053d2ee756f768d10a7e",
             "input_file": "am07_11.adif",
             "output_format": "Unknown",
-            "result": "62e6f795ee20aa3da79b717f9d06e67a"
+            "result": ""
         },
         {
             "name": "am07_64",
@@ -2713,7 +2713,7 @@
             "source_checksum": "db76927fcbc32bea6e604479f32f67d4",
             "input_file": "am07_64.adif",
             "output_format": "Unknown",
-            "result": "16c74c24d70ff2f1a33da9bd80ee8890"
+            "result": ""
         },
         {
             "name": "al00_32",
@@ -2721,7 +2721,7 @@
             "source_checksum": "7edef8328dd3141626a961eae4189016",
             "input_file": "al00_32.adif",
             "output_format": "Unknown",
-            "result": "7fa4939f69a77b6026ab4900181b34ec"
+            "result": "9379f05a63dbbf78e458e88f8b36a4bc"
         },
         {
             "name": "as05_24",
@@ -2729,7 +2729,7 @@
             "source_checksum": "1fa99bef828ec0c1952d9b79cd4e5588",
             "input_file": "as05_24.adif",
             "output_format": "Unknown",
-            "result": "ec9399a31c232ac60960aedc0f3f8e78"
+            "result": "671432646fd41c54fe0b025f278ad3d5"
         },
         {
             "name": "al04_64",
@@ -2737,7 +2737,7 @@
             "source_checksum": "6427cd4305de6aaee0132d654dcd11a7",
             "input_file": "al04_64.adif",
             "output_format": "Unknown",
-            "result": "e1b048ed08965f6decef369dc23fc481"
+            "result": "334e1e916f28c240965ed8e8f3ce6b38"
         },
         {
             "name": "as16_16",
@@ -2745,7 +2745,7 @@
             "source_checksum": "7143d8c054135ef339481af572236aa9",
             "input_file": "as16_16.adif",
             "output_format": "Unknown",
-            "result": "dc751759481fc17de0f518b90ea81815"
+            "result": "481c7a271bd4621dac6475e038a66998"
         },
         {
             "name": "am02_08",
@@ -2753,7 +2753,7 @@
             "source_checksum": "339a14afbdff567391e8e7637add2997",
             "input_file": "am02_08.adif",
             "output_format": "Unknown",
-            "result": "e001887b6c2ea4a9b41aecfa4935f5e0"
+            "result": ""
         },
         {
             "name": "as04_44",
@@ -2761,7 +2761,7 @@
             "source_checksum": "bac487b913571943a47eb3a3afac51a7",
             "input_file": "as04_44.adif",
             "output_format": "Unknown",
-            "result": "475987750e3ac64db60f38305016f247"
+            "result": "ae6dbe2fb03f50ef1498e9b483c988c5"
         },
         {
             "name": "am05_22",
@@ -2769,7 +2769,7 @@
             "source_checksum": "90a0e04fc17447cc2f788e11ebabe204",
             "input_file": "am05_22.adif",
             "output_format": "Unknown",
-            "result": "0a8a4412f335d3c3eb55dcb339c0fda2"
+            "result": ""
         },
         {
             "name": "am07_96",
@@ -2777,7 +2777,7 @@
             "source_checksum": "404dd06f53f9daed60c5a7b785da28e2",
             "input_file": "am07_96.adif",
             "output_format": "Unknown",
-            "result": "6b8a1ebecc32fc9f54fe1c49390d2f43"
+            "result": ""
         },
         {
             "name": "as03_11",
@@ -2785,7 +2785,7 @@
             "source_checksum": "d9f2b0ab1bd8c5d36985d6c1a2174292",
             "input_file": "as03_11.adif",
             "output_format": "Unknown",
-            "result": "4cf7692ff79540f856c51845f3ed1e16"
+            "result": "5ae89c7acd05098ab622609fc0ea2750"
         },
         {
             "name": "as00_64",
@@ -2793,7 +2793,7 @@
             "source_checksum": "27acef7c347a077db5c08457fba3eafe",
             "input_file": "as00_64.adif",
             "output_format": "Unknown",
-            "result": "4b42f5e9b6fbceda49961e741aca5bdd"
+            "result": "1b1b0e509d85afae5f2b6df6ddecbadd"
         },
         {
             "name": "al04_88",
@@ -2801,7 +2801,7 @@
             "source_checksum": "7f9458adfc0a322ca02df23800606e08",
             "input_file": "al04_88.adif",
             "output_format": "Unknown",
-            "result": "4d45a9b91801ac76fb1126bb0d653ab9"
+            "result": "854a65ea3d37c7357482d415acaf826e"
         },
         {
             "name": "as05_22",
@@ -2809,7 +2809,7 @@
             "source_checksum": "06956f3952b58791c6186c1b0b136c5e",
             "input_file": "as05_22.adif",
             "output_format": "Unknown",
-            "result": "3f67dde52a77032d13bb3747974d875a"
+            "result": "bbd39cff4466d45eb47427488d5332db"
         },
         {
             "name": "am07_88",
@@ -2817,7 +2817,7 @@
             "source_checksum": "739386e9c6d4095912e6e3a4da5d4e85",
             "input_file": "am07_88.adif",
             "output_format": "Unknown",
-            "result": "a53682fed44cc0c1aea35d663425f300"
+            "result": ""
         },
         {
             "name": "al06_64",
@@ -2825,7 +2825,7 @@
             "source_checksum": "af7ce6e94f9b72c2b116993ca223a6cc",
             "input_file": "al06_64.adif",
             "output_format": "Unknown",
-            "result": "aeb23dbab8e3c5019d2eac0430aebd9e"
+            "result": "2680ff601df3c7a330656ef0d6d76f6b"
         },
         {
             "name": "as06_44",
@@ -2833,7 +2833,7 @@
             "source_checksum": "4bed53ce51b8b9c9757b59a57c97aff5",
             "input_file": "as06_44.adif",
             "output_format": "Unknown",
-            "result": "764b59482af8bc4f806ed7127c744368"
+            "result": "23f4438eb7a24465d9c1ad6b18d3fe94"
         },
         {
             "name": "as05_12",
@@ -2841,7 +2841,7 @@
             "source_checksum": "ec86382f15428f62d241e2e9271e294b",
             "input_file": "as05_12.adif",
             "output_format": "Unknown",
-            "result": "443099c1a5ed5345c4810e747a113420"
+            "result": "5f962095c6a282b2d1de1628b91ff623"
         },
         {
             "name": "am02_11",
@@ -2849,7 +2849,7 @@
             "source_checksum": "e6572538093228240b1b37f7114c59da",
             "input_file": "am02_11.adif",
             "output_format": "Unknown",
-            "result": "ed1a0e50311aa8492c56b9d7c2882273"
+            "result": ""
         },
         {
             "name": "as07_88",
@@ -2857,7 +2857,7 @@
             "source_checksum": "f3537e73bd64ddf571b49e8b9fd1c2c6",
             "input_file": "as07_88.adif",
             "output_format": "Unknown",
-            "result": "54da22bb9c64a5c017d05c70f70ee0c0"
+            "result": "5f8f5e004f4e5ab7e72e5fdf87451f18"
         },
         {
             "name": "al03_08",
@@ -2865,7 +2865,7 @@
             "source_checksum": "989b4f80831b565e0b864644023dbcf1",
             "input_file": "al03_08.adif",
             "output_format": "Unknown",
-            "result": "27a47a996b754e716fec3287c583aad7"
+            "result": "9e0c9f7586ea7460b87d47f03a2e64d9"
         },
         {
             "name": "al11_22",
@@ -2873,7 +2873,7 @@
             "source_checksum": "9f905477f219d8272bc9b3e1d1d444ab",
             "input_file": "al11_22.adif",
             "output_format": "Unknown",
-            "result": "784bfafcb1675f3a37b61388b1e71250"
+            "result": "e6c07de6c6cbf92bd9c53308443f8c35"
         },
         {
             "name": "as17_12",
@@ -2881,7 +2881,7 @@
             "source_checksum": "b8f02bf79a327bbdad850bdeb0518cee",
             "input_file": "as17_12.adif",
             "output_format": "Unknown",
-            "result": "3eb560b15d403f249a4da028a3be0fe0"
+            "result": "5a4f0593e9931db3b638b234a6796cc0"
         },
         {
             "name": "as14_11",
@@ -2889,7 +2889,7 @@
             "source_checksum": "eba878a65975e0257a034d889b6eabf2",
             "input_file": "as14_11.adif",
             "output_format": "Unknown",
-            "result": "84b28749f7daad99d84252a0bfca6414"
+            "result": "66be4d61aa2181af657c5da70f141a96"
         },
         {
             "name": "al17_44",
@@ -2897,7 +2897,7 @@
             "source_checksum": "25124ba3c9b3eef6b5b2cd340565aeae",
             "input_file": "al17_44.adif",
             "output_format": "Unknown",
-            "result": "0915f618244b26d353a8d8249329e362"
+            "result": "784fdd0888e46c9ec4eb50a08fdb3cc6"
         },
         {
             "name": "al14_64",
@@ -2905,7 +2905,7 @@
             "source_checksum": "2eaef1ec336dc8f133a204be988afa2d",
             "input_file": "al14_64.adif",
             "output_format": "Unknown",
-            "result": "3a6da4bf017b72c3ef05d62ca047aea2"
+            "result": "fee87c426ffe310d83008121fa592bd9"
         },
         {
             "name": "al14_88",
@@ -2913,7 +2913,7 @@
             "source_checksum": "1e36945ac8697b0a8ca02f0b6c00f6e7",
             "input_file": "al14_88.adif",
             "output_format": "Unknown",
-            "result": "1125cb21c0c927babd10d8bcf8e051a6"
+            "result": "93099bfdaf22a5847e010eef08f10537"
         },
         {
             "name": "am03_22",
@@ -2929,7 +2929,7 @@
             "source_checksum": "ab280a740f420e42b58345b9825eb67c",
             "input_file": "as07_16.adif",
             "output_format": "Unknown",
-            "result": "a75b9fbaf778efec7dc0bed97f68316b"
+            "result": "d5378da42756fbee3af7ed323020dea8"
         },
         {
             "name": "al03_24",
@@ -2937,7 +2937,7 @@
             "source_checksum": "13efd26dcc7242256978bd4525123b5d",
             "input_file": "al03_24.adif",
             "output_format": "Unknown",
-            "result": "00b68036735ff290ab17f3d02dea9eb3"
+            "result": "b1b73118761159fff81b5c7af18892c7"
         },
         {
             "name": "al14_16",
@@ -2945,7 +2945,7 @@
             "source_checksum": "5ad60fcc3883956a31308062052075ec",
             "input_file": "al14_16.adif",
             "output_format": "Unknown",
-            "result": "e900da8a341d19a3a93a7a946b98bcb1"
+            "result": "adcf17383ea63c860aca7c047bb4acd5"
         },
         {
             "name": "as15_24",
@@ -2953,7 +2953,7 @@
             "source_checksum": "e6f2d3f188e6f6a3f5e24cf6addc508c",
             "input_file": "as15_24.adif",
             "output_format": "Unknown",
-            "result": "3a2c760007d21bfb7b8c87261672aaa1"
+            "result": "02bfc42a74201206630237e4c7ad381e"
         },
         {
             "name": "al03_88",
@@ -2961,7 +2961,7 @@
             "source_checksum": "e249e577aa5b3ba59e60c0a9094d4dfb",
             "input_file": "al03_88.adif",
             "output_format": "Unknown",
-            "result": "99a75619b7a04ef050616fbc00b30501"
+            "result": "582225859b9df6f9bb2a25c7ec843fdd"
         },
         {
             "name": "as11_24",
@@ -2969,7 +2969,7 @@
             "source_checksum": "c9f65e9c419ec6bd98a2d8f5e9fa29bb",
             "input_file": "as11_24.adif",
             "output_format": "Unknown",
-            "result": "06feaeb50b83519413b70e80b9d3eddb"
+            "result": "e293ad22f9eb770a524d17288b774880"
         },
         {
             "name": "al01_24",
@@ -2977,7 +2977,7 @@
             "source_checksum": "572b9c5f055fb034ff5532cc727876eb",
             "input_file": "al01_24.adif",
             "output_format": "Unknown",
-            "result": "f51c418abb60550317d532e59bd4a737"
+            "result": "2a1f9b80e590bf4009bdcc7feab11a47"
         },
         {
             "name": "as14_12",
@@ -2985,7 +2985,7 @@
             "source_checksum": "2d7bfb85397ce77c49803a5116dcc7f8",
             "input_file": "as14_12.adif",
             "output_format": "Unknown",
-            "result": "79ac71f15f8761aff076a36a44acd435"
+            "result": "cb0d5dbdfddc30ad05585e911fc73d59"
         },
         {
             "name": "as07_22",
@@ -2993,7 +2993,7 @@
             "source_checksum": "3f037c07a8504868b5a0621987ce50ab",
             "input_file": "as07_22.adif",
             "output_format": "Unknown",
-            "result": "eff7c2eead5834ffa3a5d505f6f211e3"
+            "result": "ab4981a6ac7a37d903277c886a14b893"
         },
         {
             "name": "al04_44",
@@ -3001,7 +3001,7 @@
             "source_checksum": "31fa1db0b5049970a552b663053c50f3",
             "input_file": "al04_44.adif",
             "output_format": "Unknown",
-            "result": "9583fc0c94e4faec07e985a19d5799df"
+            "result": "c0955b55a2703be93ad451a3c0cde34d"
         },
         {
             "name": "al15_11",
@@ -3009,7 +3009,7 @@
             "source_checksum": "552f8031828503e675de899c9d1eb6ef",
             "input_file": "al15_11.adif",
             "output_format": "Unknown",
-            "result": "83467e82929ce17468ebd411a8ed4769"
+            "result": "c3622054f2b0ca90bc221444060f19ed"
         },
         {
             "name": "as00_22",
@@ -3017,7 +3017,7 @@
             "source_checksum": "7bbd9ee9b83922fde8364fd5d5b7620a",
             "input_file": "as00_22.adif",
             "output_format": "Unknown",
-            "result": "06a8109455e2ecf2c654f7d1e02535d4"
+            "result": "a4a12aa95046d129e976ce367ca751a7"
         },
         {
             "name": "as02_64",
@@ -3025,7 +3025,7 @@
             "source_checksum": "c065eebafbe7657da9b53dafe57cc546",
             "input_file": "as02_64.adif",
             "output_format": "Unknown",
-            "result": "0912d76dc64f516f7fbf07d16462f666"
+            "result": "251ea0e1b3821235909aba69892ad7d8"
         },
         {
             "name": "al06_32",
@@ -3033,7 +3033,7 @@
             "source_checksum": "2bce6678ff9e9f1cb85484716ed53a67",
             "input_file": "al06_32.adif",
             "output_format": "Unknown",
-            "result": "9e4ca799327871418a808991e35ec246"
+            "result": "b4992535a9e4ce3ce07c8b32cee3de7f"
         },
         {
             "name": "al01_48",
@@ -3041,7 +3041,7 @@
             "source_checksum": "3eb30143e9bf29d8410a22c3e1926f27",
             "input_file": "al01_48.adif",
             "output_format": "Unknown",
-            "result": "4bc5be721cc5b033c06a030970a4da3f"
+            "result": "300f8cc27d8b5abfe5720b69f398bad2"
         },
         {
             "name": "as10_16",
@@ -3049,7 +3049,7 @@
             "source_checksum": "f9c624958552b23464d324fa4acee851",
             "input_file": "as10_16.adif",
             "output_format": "Unknown",
-            "result": "244860e3b52e8c091f3d54a13b910b6d"
+            "result": "075d22277ae9e0a8b47cd7c028a4d3c0"
         },
         {
             "name": "al01_88",
@@ -3057,7 +3057,7 @@
             "source_checksum": "4dc619d077188541e235c878fb16aa18",
             "input_file": "al01_88.adif",
             "output_format": "Unknown",
-            "result": "4af598cbc9d2d8cc4c029cf8fea21c2d"
+            "result": "444692a2f66a9e51e07daec8a1d1a584"
         },
         {
             "name": "as17_44",
@@ -3065,7 +3065,7 @@
             "source_checksum": "7ff8c6ece773f09a305145cd3b9694b3",
             "input_file": "as17_44.adif",
             "output_format": "Unknown",
-            "result": "a4460324542a7d08d3c433d499295d36"
+            "result": "6cb48e019e3819c3b29af695278d478f"
         },
         {
             "name": "al01_11",
@@ -3073,7 +3073,7 @@
             "source_checksum": "ebc2916454bcfacabd96767727bde517",
             "input_file": "al01_11.adif",
             "output_format": "Unknown",
-            "result": "2cbe23de706f08bfbf398b5c8a7d839c"
+            "result": "68ebaf2c433c13381e815db62a7c3385"
         },
         {
             "name": "al00_44",
@@ -3081,7 +3081,7 @@
             "source_checksum": "36a42e265e8bd1f89a2cf61fd5ea6c61",
             "input_file": "al00_44.adif",
             "output_format": "Unknown",
-            "result": "7e4f502ca3dea7027db473fda1e2fa2a"
+            "result": "31f0d7315b2d03acb22d7920f5814855"
         },
         {
             "name": "al00_24",
@@ -3089,7 +3089,7 @@
             "source_checksum": "9214f56b70778eedf86efce5cbe01abb",
             "input_file": "al00_24.adif",
             "output_format": "Unknown",
-            "result": "1ee6d00ece3b6481107881dadeceae27"
+            "result": "3440a3a7649138c087f6b6136314d19d"
         },
         {
             "name": "as04_22",
@@ -3097,7 +3097,7 @@
             "source_checksum": "9e5d9aab1288a9e4587bd9b53ef453a5",
             "input_file": "as04_22.adif",
             "output_format": "Unknown",
-            "result": "685dc318ba1873cb434c3b9899b6b51e"
+            "result": "8df4dd9c6101bc3fc187683955fbc2b6"
         },
         {
             "name": "as09_88",
@@ -3105,7 +3105,7 @@
             "source_checksum": "1de519becf6b1a695c30bc3437a1dcf0",
             "input_file": "as09_88.adif",
             "output_format": "Unknown",
-            "result": "43926cae5cc394c34646d1be6e9835af"
+            "result": "3c45cb22edbf1ffbd69471f1f9e3057e"
         },
         {
             "name": "al08_64",
@@ -3113,7 +3113,7 @@
             "source_checksum": "77fdf57c4afd908078c9b281aa5746d7",
             "input_file": "al08_64.adif",
             "output_format": "Unknown",
-            "result": "51472bf099256adf86fa056df9463f48"
+            "result": "ef16dca24dd66e277185606679118055"
         },
         {
             "name": "as16_08",
@@ -3121,7 +3121,7 @@
             "source_checksum": "fcb9f0badeb7d4e3211835bb7edac771",
             "input_file": "as16_08.adif",
             "output_format": "Unknown",
-            "result": "67ded6f066c28ec2aa0e5fc88363ea58"
+            "result": "0e25ef87bf68f77a6aef86b1b91354cd"
         },
         {
             "name": "al07_24",
@@ -3129,7 +3129,7 @@
             "source_checksum": "c4bf3925aeb3af467244745b4ebc540c",
             "input_file": "al07_24.adif",
             "output_format": "Unknown",
-            "result": "c434e76cb666cc567275305898488553"
+            "result": "3b76ec8fd5fa3d75b1ed903b712a8cad"
         },
         {
             "name": "am06_64",
@@ -3137,7 +3137,7 @@
             "source_checksum": "06d8d6da499c16119d0e5a7780af81ea",
             "input_file": "am06_64.adif",
             "output_format": "Unknown",
-            "result": "562c1a3f2b9a334851d8c0ddd5caa009"
+            "result": ""
         },
         {
             "name": "as00_48",
@@ -3145,7 +3145,7 @@
             "source_checksum": "e76a5eb989020b4f069fd7a00a86ccc2",
             "input_file": "as00_48.adif",
             "output_format": "Unknown",
-            "result": "b43f3d1d896d9d3a0c5b709207f73354"
+            "result": "a061cf8a04c5706e71186aa23d4ee307"
         },
         {
             "name": "al17_12",
@@ -3153,7 +3153,7 @@
             "source_checksum": "43c19c3d7d4f964a60831732e00d6c71",
             "input_file": "al17_12.adif",
             "output_format": "Unknown",
-            "result": "f6364a508fb49bd5918e62eb4b559c4a"
+            "result": "bca856a6877d9a5324d8a1cf5cf8864c"
         },
         {
             "name": "as09_16",
@@ -3161,7 +3161,7 @@
             "source_checksum": "76c179b6045123d5f907b79c35e7fcf0",
             "input_file": "as09_16.adif",
             "output_format": "Unknown",
-            "result": "e1cdce07da36b91a7a1d4406e365c32e"
+            "result": "5a610ae32b3dc675c9b76f7d31426795"
         },
         {
             "name": "as05_88",
@@ -3169,7 +3169,7 @@
             "source_checksum": "963a99bd47662cd1186ef0d73fe3e2e7",
             "input_file": "as05_88.adif",
             "output_format": "Unknown",
-            "result": "a31ae4d98d6819001fef431d23bd3b96"
+            "result": "20b38c0d21a134e573d4d1ca748aad40"
         },
         {
             "name": "as14_08",
@@ -3177,7 +3177,7 @@
             "source_checksum": "52451ee7f52e11ddb8da1a7eb386c9e5",
             "input_file": "as14_08.adif",
             "output_format": "Unknown",
-            "result": "3fae07b5e282156e9ec633af778443b8"
+            "result": "0e25ef87bf68f77a6aef86b1b91354cd"
         },
         {
             "name": "as14_64",
@@ -3185,7 +3185,7 @@
             "source_checksum": "0d945f6f35f9a0cfb3ad0c421bda76a1",
             "input_file": "as14_64.adif",
             "output_format": "Unknown",
-            "result": "893f2831b46983bd96e868615d093600"
+            "result": "f2c8633c48bbec94ce6d900aaf4d1bd2"
         },
         {
             "name": "al07_96",
@@ -3193,7 +3193,7 @@
             "source_checksum": "2bba4e42ed9b2c6f65c0d736c9548c8d",
             "input_file": "al07_96.adif",
             "output_format": "Unknown",
-            "result": "2593b74b1b280a257a0fe4404e3b60d9"
+            "result": "dfe19829b88062d92c52c209e41153c3"
         },
         {
             "name": "as11_32",
@@ -3201,7 +3201,7 @@
             "source_checksum": "51694dcbb79c47052551564a17fc3b88",
             "input_file": "as11_32.adif",
             "output_format": "Unknown",
-            "result": "8f2dab364d24bbb1003ffc01d2b3aa3b"
+            "result": "52b9b783e682ce807b26425bfd01bbe7"
         },
         {
             "name": "as09_22",
@@ -3209,7 +3209,7 @@
             "source_checksum": "22c671135ca4bc6a39a08fe1a4ca4d74",
             "input_file": "as09_22.adif",
             "output_format": "Unknown",
-            "result": "d6ed920004d58504d70d07fba50eb2fb"
+            "result": "6b70f0fe4befa112330a1b4ca9ddd465"
         },
         {
             "name": "as04_08",
@@ -3217,7 +3217,7 @@
             "source_checksum": "dc59f40ec1a536b313c85db1e9e375f5",
             "input_file": "as04_08.adif",
             "output_format": "Unknown",
-            "result": "eab9e8d9792619e10d39a7073eecda5c"
+            "result": "b981e023626023db892096c76c051e28"
         },
         {
             "name": "al03_44",
@@ -3225,7 +3225,7 @@
             "source_checksum": "9805c2cff8d562f4bb50b7f7751bd45b",
             "input_file": "al03_44.adif",
             "output_format": "Unknown",
-            "result": "1ad1e7c9f5f507add23ee3b0c221e11c"
+            "result": "bc6428f68eeac99961b07928d5efb76f"
         },
         {
             "name": "as04_24",
@@ -3233,7 +3233,7 @@
             "source_checksum": "820dfc96a32d051d563ed9502876a86f",
             "input_file": "as04_24.adif",
             "output_format": "Unknown",
-            "result": "c380ce4808007c73d885f7a36a2ae4a1"
+            "result": "05807367a5683dedb6d3d549cd10db77"
         },
         {
             "name": "as09_44",
@@ -3241,7 +3241,7 @@
             "source_checksum": "0c403ad3a983a0e5479436171641e1b1",
             "input_file": "as09_44.adif",
             "output_format": "Unknown",
-            "result": "dbd4ae3f0bf5ff753978c61e18c8a954"
+            "result": "1c94b07c439b666ba0a70cac1f6738fc"
         },
         {
             "name": "al07_22",
@@ -3249,7 +3249,7 @@
             "source_checksum": "23bd303c7e2e5005d0577273b64e7e13",
             "input_file": "al07_22.adif",
             "output_format": "Unknown",
-            "result": "ace96bd171d5d0c0b2354e4b91c97b03"
+            "result": "3b76ec8fd5fa3d75b1ed903b712a8cad"
         },
         {
             "name": "al08_96",
@@ -3257,7 +3257,7 @@
             "source_checksum": "42aa5cb5789129d90b3dca32b0d72f51",
             "input_file": "al08_96.adif",
             "output_format": "Unknown",
-            "result": "e4b0941a903b34a21ef430c9a33d1093"
+            "result": "4677b93aa04c55103ebd1dce77c6f4c8"
         },
         {
             "name": "am05_88",
@@ -3265,7 +3265,7 @@
             "source_checksum": "0f558fd21f4ee90728acfe660a5b2397",
             "input_file": "am05_88.adif",
             "output_format": "Unknown",
-            "result": "f31e04e2cec603917d83a0d567b829a8"
+            "result": ""
         },
         {
             "name": "am06_44",
@@ -3273,7 +3273,7 @@
             "source_checksum": "bc279de3c3e7962bdf47b64216f33900",
             "input_file": "am06_44.adif",
             "output_format": "Unknown",
-            "result": "ba63b8ed1206bbd6d97e65e8d6ed27e6"
+            "result": ""
         },
         {
             "name": "al04_32",
@@ -3281,7 +3281,7 @@
             "source_checksum": "bbf8a03e5af24d57f5e25b477b53dedd",
             "input_file": "al04_32.adif",
             "output_format": "Unknown",
-            "result": "fd2bdeaa782f95bc49436e00f5920269"
+            "result": "b0376ccd5985561b7aedae959f37e7a4"
         },
         {
             "name": "al00_16",
@@ -3289,7 +3289,7 @@
             "source_checksum": "6d08399b1d0e756c8753377588655ded",
             "input_file": "al00_16.adif",
             "output_format": "Unknown",
-            "result": "76a556ef1bdf02b2924b1014b634b671"
+            "result": "5c6c8350621b3ba4c744712746c66213"
         },
         {
             "name": "al15_32",
@@ -3297,7 +3297,7 @@
             "source_checksum": "debe0a23d360e1fac5bfdb8d1236fdb4",
             "input_file": "al15_32.adif",
             "output_format": "Unknown",
-            "result": "f04db1e6892163bc78e4dee37ac0c274"
+            "result": "dc3e02306732c899a66242006e85a6b8"
         },
         {
             "name": "al10_16",
@@ -3305,7 +3305,7 @@
             "source_checksum": "b307946276a3d53b3fe86ea355f929ef",
             "input_file": "al10_16.adif",
             "output_format": "Unknown",
-            "result": "ef281f0b5435db1d3047b8beb27bec8c"
+            "result": "663f9042b68ace25fd7f7c9bba2b72f8"
         },
         {
             "name": "as08_88",
@@ -3313,7 +3313,7 @@
             "source_checksum": "13cc1d46ee8f62e833cd70e6c70f99b2",
             "input_file": "as08_88.adif",
             "output_format": "Unknown",
-            "result": "fd4f61cea997e464361b51be018ae44d"
+            "result": "617034d7418dbaf0d71811fb915d8a53"
         },
         {
             "name": "as12_22",
@@ -3321,7 +3321,7 @@
             "source_checksum": "c3250d9d3fce32c0860179faff2286fe",
             "input_file": "as12_22.adif",
             "output_format": "Unknown",
-            "result": "9282ab05f4d57650f6dec8e1eab08844"
+            "result": "793bdf4e548eec828ae840f15c7c8417"
         },
         {
             "name": "as15_48",
@@ -3329,7 +3329,7 @@
             "source_checksum": "e6633a82dad2115fcc4edf7c2dce6b2b",
             "input_file": "as15_48.adif",
             "output_format": "Unknown",
-            "result": "e9fd821f2f1058bd7e220b2b5d76454a"
+            "result": "c9a81a0fa18615801cdc39e5b163f671"
         },
         {
             "name": "as07_12",
@@ -3337,7 +3337,7 @@
             "source_checksum": "4200d52bd81aec5bb78f9c6177b9a6df",
             "input_file": "as07_12.adif",
             "output_format": "Unknown",
-            "result": "35b1a90b6a803a59545396982e79a12e"
+            "result": "b166a694a0cf6373bea354e056d5910b"
         },
         {
             "name": "am06_12",
@@ -3345,7 +3345,7 @@
             "source_checksum": "5e54a0d219e31d7a264311f12ad56644",
             "input_file": "am06_12.adif",
             "output_format": "Unknown",
-            "result": "4eef4f2de088143d72f56f490aec72dd"
+            "result": ""
         },
         {
             "name": "al16_64",
@@ -3353,7 +3353,7 @@
             "source_checksum": "374a6cdbd9f4703f2a874d51bc50f22d",
             "input_file": "al16_64.adif",
             "output_format": "Unknown",
-            "result": "82d48484273e286000506e0d53c69a05"
+            "result": "0428ad19c2ec717d2e7d4a8bddaa10c3"
         },
         {
             "name": "al14_48",
@@ -3361,7 +3361,7 @@
             "source_checksum": "dacda0d5da41fca70432eadca1f1a046",
             "input_file": "al14_48.adif",
             "output_format": "Unknown",
-            "result": "eb3a9df3a1f2238254addeda25b19ba7"
+            "result": "7b4fb2dd812dd2ecdd449e30e0034086"
         },
         {
             "name": "as01_32",
@@ -3369,7 +3369,7 @@
             "source_checksum": "b8c0032bd3cb8bef265f95c592fa2d2d",
             "input_file": "as01_32.adif",
             "output_format": "Unknown",
-            "result": "590d830ded70c556b093c6a49085d6c1"
+            "result": "1c0e61a364a51f8e59d34d3f11caba1d"
         },
         {
             "name": "al17_48",
@@ -3377,7 +3377,7 @@
             "source_checksum": "d0fb2b78eda4d4398afb7b451fc40dee",
             "input_file": "al17_48.adif",
             "output_format": "Unknown",
-            "result": "96ca60800ea7f5653b7b7d01df121a63"
+            "result": "639ae11166bd1ce3bd23b4d5337008c8"
         },
         {
             "name": "al16_12",
@@ -3385,7 +3385,7 @@
             "source_checksum": "bc274f6fa29242b60b233f4068379f63",
             "input_file": "al16_12.adif",
             "output_format": "Unknown",
-            "result": "c97ef4305fadd0f6b4121be4b6adb09b"
+            "result": "740c6812e891a78b7780e52da56ac901"
         },
         {
             "name": "al03_96",
@@ -3393,7 +3393,7 @@
             "source_checksum": "466721f602d77300514338721341eb4e",
             "input_file": "al03_96.adif",
             "output_format": "Unknown",
-            "result": "d1fec1ec28d30bc2f21d3bc8d4da8734"
+            "result": "c07660b161c8bf333f7703d39cd7829c"
         },
         {
             "name": "al06_44",
@@ -3401,7 +3401,7 @@
             "source_checksum": "df9cd02d50eeebb38a6e983576614d93",
             "input_file": "al06_44.adif",
             "output_format": "Unknown",
-            "result": "5c79f8f3dcdb9d31bc9dcae61e1f077f"
+            "result": "c908646e2162876f19d0cdf958ddc156"
         },
         {
             "name": "am05_48",
@@ -3409,7 +3409,7 @@
             "source_checksum": "a536f7ee51b1d842d61cc65f5cabddcd",
             "input_file": "am05_48.adif",
             "output_format": "Unknown",
-            "result": "4fd9af1f924d24b28217ca9322c296d4"
+            "result": ""
         },
         {
             "name": "as05_08",
@@ -3417,7 +3417,7 @@
             "source_checksum": "3046e117791ce58c8abadaf1aa0fc782",
             "input_file": "as05_08.adif",
             "output_format": "Unknown",
-            "result": "f815aba9b1c3e7d841dd2ad55df45834"
+            "result": "8cdd94e0953cc708e54a22c5ea799cd1"
         },
         {
             "name": "am04_11",
@@ -3425,7 +3425,7 @@
             "source_checksum": "a142562a01bd209c256a124888f1e10a",
             "input_file": "am04_11.adif",
             "output_format": "Unknown",
-            "result": "841dff3289973f53c68558b72f8268c8"
+            "result": ""
         },
         {
             "name": "am01_22",
@@ -3433,7 +3433,7 @@
             "source_checksum": "441bf198af41e64289480052dba0b3f2",
             "input_file": "am01_22.adif",
             "output_format": "Unknown",
-            "result": "5b999b43662bbf77cfecc0346690f522"
+            "result": ""
         },
         {
             "name": "al10_88",
@@ -3441,7 +3441,7 @@
             "source_checksum": "0223eb0cbbc71b4fa3971d3aebd5812c",
             "input_file": "al10_88.adif",
             "output_format": "Unknown",
-            "result": "1bd802adafbd428c91b15ca4726a5d4c"
+            "result": "966b120a081761189dc6a11d8f1a7ddd"
         },
         {
             "name": "al16_44",
@@ -3449,7 +3449,7 @@
             "source_checksum": "cb8d19c224ccd5bdfe845c44dfd2017a",
             "input_file": "al16_44.adif",
             "output_format": "Unknown",
-            "result": "89731513f10de08fc5cc84ec7c471e82"
+            "result": "4943294add67e3168b0686e549f1f707"
         },
         {
             "name": "as04_16",
@@ -3457,7 +3457,7 @@
             "source_checksum": "57cd8d2d166fc51219d6cd518422015e",
             "input_file": "as04_16.adif",
             "output_format": "Unknown",
-            "result": "aaff08517a99b431447156e72aa57ccc"
+            "result": "2aa8ede9facecfd47e2da49c7e0b0bf1"
         },
         {
             "name": "as15_44",
@@ -3465,7 +3465,7 @@
             "source_checksum": "19eeabe4e2d7c8515389fcb43cd147e2",
             "input_file": "as15_44.adif",
             "output_format": "Unknown",
-            "result": "6067f2612a379035675786f6fc8911b0"
+            "result": "14888c909d35b55e76edfb2696f5c0d9"
         },
         {
             "name": "am03_96",
@@ -3481,7 +3481,7 @@
             "source_checksum": "2af028a7d8538d424b1b2e27e83683b7",
             "input_file": "am00_11.adif",
             "output_format": "Unknown",
-            "result": "81984d28bfa1e18f49eb4483bfdac562"
+            "result": ""
         },
         {
             "name": "am07_08",
@@ -3489,7 +3489,7 @@
             "source_checksum": "da8f616c1ff96b93de7cfcf01350fe38",
             "input_file": "am07_08.adif",
             "output_format": "Unknown",
-            "result": "3e6beed537b87093f2381e115860ed0e"
+            "result": ""
         },
         {
             "name": "as08_96",
@@ -3497,7 +3497,7 @@
             "source_checksum": "29867556ab2da11e31af5fe3ca374a4c",
             "input_file": "as08_96.adif",
             "output_format": "Unknown",
-            "result": "176f0183880a896073a47a716d1af2a5"
+            "result": "a5c6e4e4e267f3cf786c7ab76acbe9fa"
         },
         {
             "name": "al02_12",
@@ -3505,7 +3505,7 @@
             "source_checksum": "a5fca3fd74b927fcd767b4ee2e064083",
             "input_file": "al02_12.adif",
             "output_format": "Unknown",
-            "result": "d1438719a8c94a38ac36e7543849490e"
+            "result": "fba7a9108012d70f844bbfe73f862d15"
         },
         {
             "name": "am04_22",
@@ -3513,7 +3513,7 @@
             "source_checksum": "203b22bb326c936ddb9b18314f9a64b2",
             "input_file": "am04_22.adif",
             "output_format": "Unknown",
-            "result": "1d70f1287453058ef32e78f321ac0482"
+            "result": ""
         },
         {
             "name": "am05_32",
@@ -3521,7 +3521,7 @@
             "source_checksum": "7629c8af0f38a4f3382d8fe9e887d9b7",
             "input_file": "am05_32.adif",
             "output_format": "Unknown",
-            "result": "a95557a582722c77973a9bbabf198529"
+            "result": ""
         },
         {
             "name": "am03_24",
@@ -3537,7 +3537,7 @@
             "source_checksum": "1e5d8d0b02b24ef69ef7fe569d8d7e6a",
             "input_file": "as11_48.adif",
             "output_format": "Unknown",
-            "result": "892be5826a84905f92b2a4f465b60be3"
+            "result": "e780e91547c3144c6e472e92ed2210d7"
         },
         {
             "name": "as11_64",
@@ -3545,7 +3545,7 @@
             "source_checksum": "a791a84645d4bda22a2f825a2ce17b18",
             "input_file": "as11_64.adif",
             "output_format": "Unknown",
-            "result": "b46e476ffcfb43fa112a46f2aaf8fd78"
+            "result": "8fa7c4d7b94faff9117bd4d12c349e1b"
         },
         {
             "name": "am02_22",
@@ -3553,7 +3553,7 @@
             "source_checksum": "e7dc757057fbfbb9c198f08f4d5a3387",
             "input_file": "am02_22.adif",
             "output_format": "Unknown",
-            "result": "fc51b1f4ea3dfd744dd31f1062e58828"
+            "result": ""
         },
         {
             "name": "as14_22",
@@ -3561,7 +3561,7 @@
             "source_checksum": "5d0280e294b34fdb4cd911fd7a46ac1d",
             "input_file": "as14_22.adif",
             "output_format": "Unknown",
-            "result": "23949618faecb931b56c4f701db99a91"
+            "result": "02856cceb12e9637bb98fc210daf193b"
         },
         {
             "name": "am00_48",
@@ -3569,7 +3569,7 @@
             "source_checksum": "3ace5dbd49daa0f5180e8c72348d80fc",
             "input_file": "am00_48.adif",
             "output_format": "Unknown",
-            "result": "f08ba3ec4c84203c198398817a0988cb"
+            "result": ""
         },
         {
             "name": "as10_96",
@@ -3577,7 +3577,7 @@
             "source_checksum": "44968383cc09da8aa4c1abcb65bcfcb2",
             "input_file": "as10_96.adif",
             "output_format": "Unknown",
-            "result": "6a70d2ea335f17392979e408ad630cc7"
+            "result": "72487940e6b21e1a5acfe6d5ddd57978"
         },
         {
             "name": "al16_48",
@@ -3585,7 +3585,7 @@
             "source_checksum": "4a004a6ee14301b136cb05fafa7cdeb0",
             "input_file": "al16_48.adif",
             "output_format": "Unknown",
-            "result": "4fd16497625bcc71ed033246c0743b95"
+            "result": "70f8ed0d2b593456e6e47df002fba53e"
         },
         {
             "name": "al07_12",
@@ -3593,7 +3593,7 @@
             "source_checksum": "cd2f7b2a14d13941544b2ce4749bea49",
             "input_file": "al07_12.adif",
             "output_format": "Unknown",
-            "result": "67fd2fcbed415470e767c611f658e478"
+            "result": "d4de30fb19a0873a2357523a21a7c11f"
         },
         {
             "name": "am03_08",
@@ -3609,7 +3609,7 @@
             "source_checksum": "a0da765f6199724795c1913f74acfaa5",
             "input_file": "as08_12.adif",
             "output_format": "Unknown",
-            "result": "bcb0c4adec53d2ca30e54158314b3a6c"
+            "result": "3501043be855b4329c14b0245fe8d603"
         },
         {
             "name": "am04_88",
@@ -3617,7 +3617,7 @@
             "source_checksum": "bbec3d56a852642ac36f362e671c60cc",
             "input_file": "am04_88.adif",
             "output_format": "Unknown",
-            "result": "4d4e8422f0d506cb2d02f4c7984562fb"
+            "result": ""
         },
         {
             "name": "as17_48",
@@ -3625,7 +3625,7 @@
             "source_checksum": "37e2757da8c5a7c085720c99183390d2",
             "input_file": "as17_48.adif",
             "output_format": "Unknown",
-            "result": "ab49397bff0837dca84932822f7b96f8"
+            "result": "ebd19ef16b3576a8bad95c819c42aa47"
         },
         {
             "name": "as13_12",
@@ -3633,7 +3633,7 @@
             "source_checksum": "e26bcb640a891776237d6a883756b598",
             "input_file": "as13_12.adif",
             "output_format": "Unknown",
-            "result": "8406f9d1339cf82e79a190bfcbd40d8a"
+            "result": "971a2bff11d06bc3c578efda34aefa4b"
         },
         {
             "name": "as08_22",
@@ -3641,7 +3641,7 @@
             "source_checksum": "d512b5f71db1be199548f7f7376f0d50",
             "input_file": "as08_22.adif",
             "output_format": "Unknown",
-            "result": "31ff4d7712c9f6764415040cdcb594dd"
+            "result": "db921bd902654720933f799741bb35b2"
         },
         {
             "name": "al06_22",
@@ -3649,7 +3649,7 @@
             "source_checksum": "d71c22ad771c94afd2b6d4f2c6ed6b15",
             "input_file": "al06_22.adif",
             "output_format": "Unknown",
-            "result": "7c6bce1bba9630f25a977bbe37df21ed"
+            "result": "fd272f2518856dfd459c84cf9e7edc93"
         },
         {
             "name": "as06_11",
@@ -3657,7 +3657,7 @@
             "source_checksum": "3fcf9102aaf0952bb4e7c50c8bab1bd8",
             "input_file": "as06_11.adif",
             "output_format": "Unknown",
-            "result": "60c9f40ea2f9cf032a7e2a6f86d6813f"
+            "result": "64d28b9d388a06953a33cc5b556f41ab"
         },
         {
             "name": "am06_22",
@@ -3665,7 +3665,7 @@
             "source_checksum": "dce4c4c15e1dd16a0f672069ed0f530f",
             "input_file": "am06_22.adif",
             "output_format": "Unknown",
-            "result": "a5bd609d7e7ffd105fa908a68bdecc64"
+            "result": ""
         },
         {
             "name": "as01_08",
@@ -3673,7 +3673,7 @@
             "source_checksum": "212b8322471e7bc9e6b2ad14beeb8761",
             "input_file": "as01_08.adif",
             "output_format": "Unknown",
-            "result": "93db5c24607d9577d67b4dfd778f7970"
+            "result": "0b43057f093305a27b52f168adaaf255"
         },
         {
             "name": "am04_24",
@@ -3681,7 +3681,7 @@
             "source_checksum": "b2aa87427e18b45f2f31fc49743c61c1",
             "input_file": "am04_24.adif",
             "output_format": "Unknown",
-            "result": "2ea351471a0ccd542a6a7c83794c6013"
+            "result": ""
         },
         {
             "name": "am06_96",
@@ -3689,7 +3689,7 @@
             "source_checksum": "7191ad8979bc199124040cbf02aa0378",
             "input_file": "am06_96.adif",
             "output_format": "Unknown",
-            "result": "84c3ec49dbd2c5955fa1b329bec6830a"
+            "result": ""
         },
         {
             "name": "al11_64",
@@ -3697,7 +3697,7 @@
             "source_checksum": "ff8f5f5225cbc9c95f1149c956b1e2c0",
             "input_file": "al11_64.adif",
             "output_format": "Unknown",
-            "result": "92209ed48504665ef4235098227c157f"
+            "result": "6d76d82bff1109a27323d1b70f609a04"
         },
         {
             "name": "al04_24",
@@ -3705,7 +3705,7 @@
             "source_checksum": "3a22102baf5d6da1f30ae4ed249b40a1",
             "input_file": "al04_24.adif",
             "output_format": "Unknown",
-            "result": "2b19484602c94489c81dc0a4e2977d20"
+            "result": "9bfbda2644d94dca52dd3b7b5b6a49b6"
         },
         {
             "name": "as14_32",
@@ -3713,7 +3713,7 @@
             "source_checksum": "5bd0381e5698ded6435918777cd75118",
             "input_file": "as14_32.adif",
             "output_format": "Unknown",
-            "result": "fb1c818d086c6d6ea9ccf5b2a368d1f1"
+            "result": "b4b3c045e136191c6d42df8fc352d3cf"
         },
         {
             "name": "al10_24",
@@ -3721,7 +3721,7 @@
             "source_checksum": "e127b47545b9dcc8b6e9bcdc9b1de84d",
             "input_file": "al10_24.adif",
             "output_format": "Unknown",
-            "result": "d7ba4d9aeb7fc9de9095cb159c59c906"
+            "result": "58449a346b4090b8602eaedf03739fe3"
         },
         {
             "name": "as01_12",
@@ -3729,7 +3729,7 @@
             "source_checksum": "60d77c353f7fce8c053909939cf9f891",
             "input_file": "as01_12.adif",
             "output_format": "Unknown",
-            "result": "e17e60509e350f622aef1577a370d2dd"
+            "result": "d83c4c702798b93f6e57812c4064ab1f"
         },
         {
             "name": "al00_22",
@@ -3737,7 +3737,7 @@
             "source_checksum": "8cc14dc053495aeee852d83e1bf2a81b",
             "input_file": "al00_22.adif",
             "output_format": "Unknown",
-            "result": "070e022e2c88f63e682ef7fc3e05c36e"
+            "result": "fc7d20249eb3f883c9244e88986eebb9"
         },
         {
             "name": "am00_44",
@@ -3745,7 +3745,7 @@
             "source_checksum": "d5436682dc95dfe02f76c902ce6d7910",
             "input_file": "am00_44.adif",
             "output_format": "Unknown",
-            "result": "905e70a30106a8827146e839a4cb85ad"
+            "result": ""
         },
         {
             "name": "as16_11",
@@ -3753,7 +3753,7 @@
             "source_checksum": "8862531c4e255ee2d9d87832e1722d19",
             "input_file": "as16_11.adif",
             "output_format": "Unknown",
-            "result": "f2e9dd22dcd910d4f707ede8bdf23a99"
+            "result": "66be4d61aa2181af657c5da70f141a96"
         },
         {
             "name": "al15_48",
@@ -3761,7 +3761,7 @@
             "source_checksum": "9c72e4694edfd3d7eb9554720f601acd",
             "input_file": "al15_48.adif",
             "output_format": "Unknown",
-            "result": "e71bf6a566923ae9442e063975a96d4f"
+            "result": "01a27d489878dbaf7a76b480a80f5abb"
         },
         {
             "name": "al17_11",
@@ -3769,7 +3769,7 @@
             "source_checksum": "347c553b4258235e908d2f709e9df8eb",
             "input_file": "al17_11.adif",
             "output_format": "Unknown",
-            "result": "3646d6663df0fe6b0eef002471ca068e"
+            "result": "77d09b536b5c5cc251faa21e5aecb413"
         },
         {
             "name": "al05_22",
@@ -3777,7 +3777,7 @@
             "source_checksum": "b08ba27954f42f9acc402d97f05ff1be",
             "input_file": "al05_22.adif",
             "output_format": "Unknown",
-            "result": "9f9a5792e64c15632f402bc9ca207897"
+            "result": "c297fd5aba3dbe1b55f41757e0ad518d"
         },
         {
             "name": "al06_11",
@@ -3785,7 +3785,7 @@
             "source_checksum": "166de66883ba6dc9ef1e1c393b6025cd",
             "input_file": "al06_11.adif",
             "output_format": "Unknown",
-            "result": "a55154f0d88e18fa386f37238055f3f4"
+            "result": "b1d3abe29c049fae6f83b218f7bc0677"
         },
         {
             "name": "al08_44",
@@ -3793,7 +3793,7 @@
             "source_checksum": "32879a6c083e9604cc58fd5e82de0993",
             "input_file": "al08_44.adif",
             "output_format": "Unknown",
-            "result": "09c68933cc2cfe99a2c34f15901fe5e8"
+            "result": "ac48dbb44e76757732c7060fce50b773"
         },
         {
             "name": "am02_48",
@@ -3801,7 +3801,7 @@
             "source_checksum": "743db775068807269bb9725720adc606",
             "input_file": "am02_48.adif",
             "output_format": "Unknown",
-            "result": "42ede1f447d7c892c3cd807ff886598b"
+            "result": ""
         },
         {
             "name": "al03_11",
@@ -3809,7 +3809,7 @@
             "source_checksum": "5ff540a63aa030a2ed30b95330482e2b",
             "input_file": "al03_11.adif",
             "output_format": "Unknown",
-            "result": "f594d3dc377ca0232b4b9ca91a73433d"
+            "result": "cb5054b764e9019be9d0fcbfe3776835"
         },
         {
             "name": "as15_16",
@@ -3817,7 +3817,7 @@
             "source_checksum": "bfd30e9d134a16407b218e3224ef23c0",
             "input_file": "as15_16.adif",
             "output_format": "Unknown",
-            "result": "d99a945f913a413b1a94feba612245e4"
+            "result": "a4c66f7b5287477f02e2e46482b93fd2"
         },
         {
             "name": "al11_48",
@@ -3825,7 +3825,7 @@
             "source_checksum": "3d295436e8f68c2ec55a5c20f3f8ae3b",
             "input_file": "al11_48.adif",
             "output_format": "Unknown",
-            "result": "437636894d0dc66296fbb87edd605a9f"
+            "result": "a84e4a8cf3d4e8a5531c94fb8a08f8f8"
         },
         {
             "name": "as09_11",
@@ -3833,7 +3833,7 @@
             "source_checksum": "1b8581d0b15b6f7f5cd716569ad2ab09",
             "input_file": "as09_11.adif",
             "output_format": "Unknown",
-            "result": "439f3adbd6aded992b6fb2e572665ee0"
+            "result": "f1e414104151e770be3a8de90fae8b7e"
         },
         {
             "name": "al02_08",
@@ -3841,7 +3841,7 @@
             "source_checksum": "788c20b0fcdfc57dc15e0a09a47eb1d0",
             "input_file": "al02_08.adif",
             "output_format": "Unknown",
-            "result": "37d599fbb28258644ab41ece65378604"
+            "result": "48e6870f8ccdcaefacd80036e6971aa4"
         },
         {
             "name": "as00_24",
@@ -3849,7 +3849,7 @@
             "source_checksum": "7a5a1e3981b096dc97c0bf51830e85e8",
             "input_file": "as00_24.adif",
             "output_format": "Unknown",
-            "result": "e4eb8d7e7674ba19a9314e3f1d48605a"
+            "result": "f55b20bf2eaaca20b8e12dfe76eb0d7d"
         },
         {
             "name": "as12_96",
@@ -3857,7 +3857,7 @@
             "source_checksum": "8e88b481ca1d46edc579fc4ecc28c695",
             "input_file": "as12_96.adif",
             "output_format": "Unknown",
-            "result": "1d4a325dd32db853190028912f2b5d8f"
+            "result": "84cfdbb1547092e3e15d28b2e9b274d5"
         },
         {
             "name": "am02_96",
@@ -3865,7 +3865,7 @@
             "source_checksum": "166bc87d9c433afa1c0b01a184469e5b",
             "input_file": "am02_96.adif",
             "output_format": "Unknown",
-            "result": "9f7d938d429941be9224be48f187d2f6"
+            "result": ""
         },
         {
             "name": "as09_48",
@@ -3873,7 +3873,7 @@
             "source_checksum": "1ec6c1375d18ccbc7c6a052491047ec2",
             "input_file": "as09_48.adif",
             "output_format": "Unknown",
-            "result": "e2ecfd14f43df3779e73398a91e7d5ec"
+            "result": "27d560f65a1e11a757ad189a1f8bde77"
         },
         {
             "name": "am06_16",
@@ -3881,7 +3881,7 @@
             "source_checksum": "bdd2aa77cc5c82b1923c7d7fff1f887d",
             "input_file": "am06_16.adif",
             "output_format": "Unknown",
-            "result": "2fa55a073a12c11c4493c7ca920dd350"
+            "result": ""
         },
         {
             "name": "as00_12",
@@ -3889,7 +3889,7 @@
             "source_checksum": "3a5927af46366d62cbda59089436a074",
             "input_file": "as00_12.adif",
             "output_format": "Unknown",
-            "result": "13e927092d4072201e66845ca330f444"
+            "result": "30ef66aa6a39b0b5d3a77aea1061928b"
         },
         {
             "name": "as10_48",
@@ -3897,7 +3897,7 @@
             "source_checksum": "c9b6bb61e02ee79b14df737d1fe125d5",
             "input_file": "as10_48.adif",
             "output_format": "Unknown",
-            "result": "db031a4ae18dc74f6f2a7a5e15edaeb4"
+            "result": "b66a6582c6c636102251dd3b020e22e2"
         },
         {
             "name": "am01_32",
@@ -3905,7 +3905,7 @@
             "source_checksum": "be0d7cc4444f4950758da784ff278f90",
             "input_file": "am01_32.adif",
             "output_format": "Unknown",
-            "result": "40e08c874b6ce277ca8da3061aa170bd"
+            "result": ""
         },
         {
             "name": "as12_44",
@@ -3913,7 +3913,7 @@
             "source_checksum": "913b6c922079246975e308661f2f76ac",
             "input_file": "as12_44.adif",
             "output_format": "Unknown",
-            "result": "2350f36d455457d7e47a89008dbc5162"
+            "result": "8dfea67806acf9b1fdb52efe7134dd04"
         },
         {
             "name": "am03_48",
@@ -3929,7 +3929,7 @@
             "source_checksum": "f4bc933bdaee8fa9808dc69c2f7c967d",
             "input_file": "al11_44.adif",
             "output_format": "Unknown",
-            "result": "92c88930c426b980f4597ea4f3e17dc1"
+            "result": "a84e4a8cf3d4e8a5531c94fb8a08f8f8"
         },
         {
             "name": "as04_88",
@@ -3937,7 +3937,7 @@
             "source_checksum": "0507769e27d2e01595df2a87dfa32eaa",
             "input_file": "as04_88.adif",
             "output_format": "Unknown",
-            "result": "c582f94eca011bd13b5e6648b8e3a217"
+            "result": "a2a2fc6b38a3190b8dde068cddfed7fe"
         }
     ]
 }

--- a/test_suites/aac/MPEG2_AAC-ADTS.json
+++ b/test_suites/aac/MPEG2_AAC-ADTS.json
@@ -9,7 +9,7 @@
             "source_checksum": "27929bfbce9d06fb61274cb013d04e9a",
             "input_file": "al12_48.adts",
             "output_format": "fltp",
-            "result": "bae4b43109f5689160b54890f47efd0c"
+            "result": "d4497dd09304c27484a4461b2f568b60"
         },
         {
             "name": "as20_24",
@@ -17,7 +17,7 @@
             "source_checksum": "711515116cd73b67d1f76862edc9cb10",
             "input_file": "as20_24.adts",
             "output_format": "fltp",
-            "result": "636e36d9061bbde4a6c7d39e676b4dfb"
+            "result": "d5e46ba493f520194429846c1b377589"
         },
         {
             "name": "al09_11",
@@ -25,7 +25,7 @@
             "source_checksum": "d9c69bdd4677c4998591272e6de378e7",
             "input_file": "al09_11.adts",
             "output_format": "fltp",
-            "result": "45f3814f5372b5e325a959de1552913c"
+            "result": "ada779fe594fdcab99af4fc47e23559f"
         },
         {
             "name": "as21_44",
@@ -33,7 +33,7 @@
             "source_checksum": "8318287c05fcdde7031de892a154dc7a",
             "input_file": "as21_44.adts",
             "output_format": "fltp",
-            "result": "0f749b75c489016e2ca65eb54fc90966"
+            "result": "d862ac356292d4b0822cdf6aa76b9c16"
         },
         {
             "name": "as19_44",
@@ -41,7 +41,7 @@
             "source_checksum": "5622d850cdae2178bf8cca590fdfa011",
             "input_file": "as19_44.adts",
             "output_format": "fltp",
-            "result": "8b41a564f3cf744dca89fd7360f42115"
+            "result": "06180286f29acf2b250cc6e29bd3a0a3"
         },
         {
             "name": "al09_08",
@@ -49,7 +49,7 @@
             "source_checksum": "2843464c7d9b40adac27c075ef100705",
             "input_file": "al09_08.adts",
             "output_format": "fltp",
-            "result": "3f7da1c1bcf393002f9797fd16a4352a"
+            "result": "385198f06cb664a13c535ff49c04b88c"
         },
         {
             "name": "as19_24",
@@ -57,7 +57,7 @@
             "source_checksum": "d95b1df14e768ae90fecebab57219b58",
             "input_file": "as19_24.adts",
             "output_format": "fltp",
-            "result": "6d4222dd6fdf5d6dc9367abce33584f8"
+            "result": "d622aee91247ec1273194aa6de5c9745"
         },
         {
             "name": "as19_32",
@@ -65,7 +65,7 @@
             "source_checksum": "9e4044870f052175df24acdd6d04cd39",
             "input_file": "as19_32.adts",
             "output_format": "fltp",
-            "result": "3fab333995a90a5fc75f23833853bc06"
+            "result": "eb269af031d50a8b3bed859d6bd25a4a"
         },
         {
             "name": "as20_96",
@@ -73,7 +73,7 @@
             "source_checksum": "0ffe6dc8a1a8817bc9f4f95bb0a272cf",
             "input_file": "as20_96.adts",
             "output_format": "fltp",
-            "result": "adf796a93e39217cc7aea43ea25dc987"
+            "result": "6f8594ae06969889a84608bf6ffd5e63"
         },
         {
             "name": "as19_88",
@@ -81,7 +81,7 @@
             "source_checksum": "5843d8d610d372283455b48f74cbe0d3",
             "input_file": "as19_88.adts",
             "output_format": "fltp",
-            "result": "f3d277bb3cd856d9596803ca0ad0a3be"
+            "result": "71511bbda2ff1142753fb067b8248d99"
         },
         {
             "name": "as21_11",
@@ -89,7 +89,7 @@
             "source_checksum": "09b1c407c41e2370417abb5dedffce9c",
             "input_file": "as21_11.adts",
             "output_format": "fltp",
-            "result": "e0532456fb45380ede0806139b525ffe"
+            "result": "cdfca8758bec798142cf6d5337aa5f5b"
         },
         {
             "name": "as18_24",
@@ -97,7 +97,7 @@
             "source_checksum": "192ab015b67c34d36d22aa0675ca5560",
             "input_file": "as18_24.adts",
             "output_format": "fltp",
-            "result": "291ef2da08d74f10512523eeedbcc6d8"
+            "result": "e683ef621ad09675f21632b06f89b894"
         },
         {
             "name": "as19_64",
@@ -105,7 +105,7 @@
             "source_checksum": "e45128742ebd2432e82c007f18a631b9",
             "input_file": "as19_64.adts",
             "output_format": "fltp",
-            "result": "8651fb75bfa0bac064898fefc815b3f2"
+            "result": "a5b63ad2134366d0b149854439dd87be"
         },
         {
             "name": "as20_88",
@@ -113,7 +113,7 @@
             "source_checksum": "d9a81756fa3880d19821de84ca37dd9a",
             "input_file": "as20_88.adts",
             "output_format": "fltp",
-            "result": "e77dd105421e7457894f3b1399886a73"
+            "result": "babc22cc098d8e7d797fbaa41e6663e4"
         },
         {
             "name": "as20_08",
@@ -121,7 +121,7 @@
             "source_checksum": "ad7d08193b166cf1c46ff84a3f3ebb7d",
             "input_file": "as20_08.adts",
             "output_format": "fltp",
-            "result": "fe7804ed8d57899d6950bf0ad752b7f3"
+            "result": "88514de302080fc199c2c5426fbbb256"
         },
         {
             "name": "as21_64",
@@ -129,7 +129,7 @@
             "source_checksum": "6c595906c5e563a765ed97c825719cc6",
             "input_file": "as21_64.adts",
             "output_format": "fltp",
-            "result": "e184f9f254277e80d7bef094ccb9ace4"
+            "result": "ad991bc9a517fb82965911570146a624"
         },
         {
             "name": "as21_24",
@@ -137,7 +137,7 @@
             "source_checksum": "7d54f1ca0dea1a42491252e61e0b0ade",
             "input_file": "as21_24.adts",
             "output_format": "fltp",
-            "result": "edb6c10f72ff1d9b3044dfa1bd0c7a2a"
+            "result": "d619feee354716ce44a7c2966b9ab000"
         },
         {
             "name": "as21_16",
@@ -145,7 +145,7 @@
             "source_checksum": "29c98dae5c26f6739fa449607dc6adf9",
             "input_file": "as21_16.adts",
             "output_format": "fltp",
-            "result": "824863661814a170cfa742b9fa860989"
+            "result": "b44abf44783aebd3abc2478522c5889c"
         },
         {
             "name": "as18_88",
@@ -153,7 +153,7 @@
             "source_checksum": "c565798d39dbbc3a0c3dcb07d7210df8",
             "input_file": "as18_88.adts",
             "output_format": "fltp",
-            "result": "4ece0dc1422c1d40a429020cdcd48b0e"
+            "result": "201a8ee48bfa77a78679dd26646382ac"
         },
         {
             "name": "as18_11",
@@ -161,7 +161,7 @@
             "source_checksum": "f5ffb91d23d125853afcb8297d925404",
             "input_file": "as18_11.adts",
             "output_format": "fltp",
-            "result": "0497fed5162a3f9e7596515c6a46b759"
+            "result": "c6ce39ac9f3a19c727c9f1a6df0a3b24"
         },
         {
             "name": "as20_48",
@@ -169,7 +169,7 @@
             "source_checksum": "569bb98829b5a308c3bb9c7afc83cdc6",
             "input_file": "as20_48.adts",
             "output_format": "fltp",
-            "result": "a30ad97baeee7d8381c0a1a3f85d7d90"
+            "result": "fa1e9486032f1dd20d3a4c5d760553d2"
         },
         {
             "name": "as21_22",
@@ -177,7 +177,7 @@
             "source_checksum": "316b53896aff83108f32d2db8aa39fcf",
             "input_file": "as21_22.adts",
             "output_format": "fltp",
-            "result": "2c0bbe9200f2fb031e1864683ebaf367"
+            "result": "04d847223c86171e00fe677929ee3186"
         },
         {
             "name": "as20_22",
@@ -185,7 +185,7 @@
             "source_checksum": "3cefa90c24155f261826bebb95065fe0",
             "input_file": "as20_22.adts",
             "output_format": "fltp",
-            "result": "180e2fc1eae7e8cc3bcd63e03a485e21"
+            "result": "0238c48dee49b5c46d17c87889ad9d7d"
         },
         {
             "name": "as21_08",
@@ -193,7 +193,7 @@
             "source_checksum": "a8ba0949a1e983cb076dafa6726082d4",
             "input_file": "as21_08.adts",
             "output_format": "fltp",
-            "result": "3d99bcabac1e06a0e619b598d157fe54"
+            "result": "04c3c5d0994244b9a0abb57f0a20a211"
         },
         {
             "name": "as20_44",
@@ -201,7 +201,7 @@
             "source_checksum": "c6c903ccd30accc90b44dbe556bf3701",
             "input_file": "as20_44.adts",
             "output_format": "fltp",
-            "result": "949d889b7fc27a65f94987925bb6e3a1"
+            "result": "279af7b736395078a76289d9983e149d"
         },
         {
             "name": "as20_11",
@@ -209,7 +209,7 @@
             "source_checksum": "6d3260070f0e55a02e41272edce11d23",
             "input_file": "as20_11.adts",
             "output_format": "fltp",
-            "result": "0272a9d25316b8f2ac024feb11d7b4ff"
+            "result": "c3f2298751f0b3c9b2d50ff8b4fd9d4e"
         },
         {
             "name": "as19_48",
@@ -217,7 +217,7 @@
             "source_checksum": "a7a3032f2d9abb74ba53c59f8edaefec",
             "input_file": "as19_48.adts",
             "output_format": "fltp",
-            "result": "8c77378bfa853a7a37ad4323ee927582"
+            "result": "ba89239240bc73639dfb558223bc6fc2"
         },
         {
             "name": "as19_08",
@@ -225,7 +225,7 @@
             "source_checksum": "035f0a74173468a7940e901da1599d55",
             "input_file": "as19_08.adts",
             "output_format": "fltp",
-            "result": "a24bfcb0382b64ff3b828d4a97c6a598"
+            "result": "bce7bf321502962190947a6b504801e7"
         },
         {
             "name": "as19_16",
@@ -233,7 +233,7 @@
             "source_checksum": "4a7dda41b06c18a35b9f9d7dbad42bc7",
             "input_file": "as19_16.adts",
             "output_format": "fltp",
-            "result": "4b1d4c8a33e99e30a42afbb781578368"
+            "result": "17af6ae5dbd337a059710648c9ff996d"
         },
         {
             "name": "al09_64",
@@ -241,7 +241,7 @@
             "source_checksum": "154b9a2a184284d5f27aa9109324578a",
             "input_file": "al09_64.adts",
             "output_format": "fltp",
-            "result": "6b7786cdfa6a79b6261bd3eaca246e65"
+            "result": "5f92fd7fada10e5dbd08b9587f19e8e1"
         },
         {
             "name": "al09_24",
@@ -249,7 +249,7 @@
             "source_checksum": "3e5a52c0c73cc9bb46d98d4c28378374",
             "input_file": "al09_24.adts",
             "output_format": "fltp",
-            "result": "8c4be460009dede1e84c9cc26efe0589"
+            "result": "b7c13b112a6dde20f831f325bb694aa6"
         },
         {
             "name": "al09_44",
@@ -257,7 +257,7 @@
             "source_checksum": "8d67429688392ceaf915ae92dc0eb14e",
             "input_file": "al09_44.adts",
             "output_format": "fltp",
-            "result": "e76639802041a3665dccd6bd02a20fa6"
+            "result": "f94ac68ef4dc6c9bce35a7fd51000ac6"
         },
         {
             "name": "al13_48",
@@ -265,7 +265,7 @@
             "source_checksum": "92e966b0c730d9dcde6373636d869534",
             "input_file": "al13_48.adts",
             "output_format": "fltp",
-            "result": "df98107109e884737dd74b6db0feb33d"
+            "result": "dbbebf84893807b7180eb7c9cc36099a"
         },
         {
             "name": "as19_96",
@@ -273,7 +273,7 @@
             "source_checksum": "78ecb299d42f2aa4aa07d15240013e78",
             "input_file": "as19_96.adts",
             "output_format": "fltp",
-            "result": "9e13c300fb44756929c1ecaae969ad8d"
+            "result": "0f7b79ceebf35154b63adf2d3ddd4ca5"
         },
         {
             "name": "as20_12",
@@ -281,7 +281,7 @@
             "source_checksum": "f694118f7ff688c2915d6fe4060bef33",
             "input_file": "as20_12.adts",
             "output_format": "fltp",
-            "result": "af2728b4ad681184dce08bae1a183162"
+            "result": "15e83d3892a9532d46c4be01cd78cbe8"
         },
         {
             "name": "as20_64",
@@ -289,7 +289,7 @@
             "source_checksum": "da230df29e16888934ef7a64ca544243",
             "input_file": "as20_64.adts",
             "output_format": "fltp",
-            "result": "dd6c03d3bab856fdda6d83c426bea305"
+            "result": "a49b9fdaac7c3bc18d7ea3254fc994b7"
         },
         {
             "name": "as21_48",
@@ -297,7 +297,7 @@
             "source_checksum": "1c98f957869644bbc3f1095d0ee90ec4",
             "input_file": "as21_48.adts",
             "output_format": "fltp",
-            "result": "72eef2fe807292fbb99a5b34398420c0"
+            "result": "d9c561723a11e490b82c34f8405c9e79"
         },
         {
             "name": "as18_32",
@@ -305,7 +305,7 @@
             "source_checksum": "e12fc78483b5c2a5bf4cab5aca1cd921",
             "input_file": "as18_32.adts",
             "output_format": "fltp",
-            "result": "c5292512cdf48ce153811a43ae36bbba"
+            "result": "9cc0ae49da101bd127a800aad247abf3"
         },
         {
             "name": "al09_32",
@@ -313,7 +313,7 @@
             "source_checksum": "56e57d9b3c98efaf74c2e75e46b94707",
             "input_file": "al09_32.adts",
             "output_format": "fltp",
-            "result": "8674ec6187098dc77d26780cec906964"
+            "result": "30d1b4ea7670a46a5bd7d19491e753c3"
         },
         {
             "name": "as18_16",
@@ -321,7 +321,7 @@
             "source_checksum": "a5bb06ebb5238ebd2539f481515aec11",
             "input_file": "as18_16.adts",
             "output_format": "fltp",
-            "result": "b74074eebf121f6a22b4fcb754d70088"
+            "result": "6a12f289a1f5a4f51b5b32364cb9dd01"
         },
         {
             "name": "as18_48",
@@ -329,7 +329,7 @@
             "source_checksum": "e5fd7fb3db6bea960171e155ffcd81f2",
             "input_file": "as18_48.adts",
             "output_format": "fltp",
-            "result": "cdf0e52da75ae29fd5e327fc7ef1dd12"
+            "result": "cd4d8fa4ce36a8b2d727f31b9d467f3b"
         },
         {
             "name": "as18_44",
@@ -337,7 +337,7 @@
             "source_checksum": "b4b616b26ab554ed57ea7014de845cc0",
             "input_file": "as18_44.adts",
             "output_format": "fltp",
-            "result": "1978712357e67e6148c1429bd35d3bfc"
+            "result": "81ea5c9925e1537495ac8698793d761d"
         },
         {
             "name": "as21_96",
@@ -345,7 +345,7 @@
             "source_checksum": "5f31709d01b272dd9434e5800dd948dd",
             "input_file": "as21_96.adts",
             "output_format": "fltp",
-            "result": "1e2597610c03d93e078c37fe0eb1ee46"
+            "result": "0ec45e077a46af9ed983f847701abb0e"
         },
         {
             "name": "al09_22",
@@ -353,7 +353,7 @@
             "source_checksum": "683f11281b7830def34ee1f778c7130b",
             "input_file": "al09_22.adts",
             "output_format": "fltp",
-            "result": "9296f37fa20f0325093f0d324d7959cb"
+            "result": "42cd6fddbc3e3425c350ee38a01a20c8"
         },
         {
             "name": "as19_12",
@@ -361,7 +361,7 @@
             "source_checksum": "1e22b357bef8f7a32fb5a0655a03cc65",
             "input_file": "as19_12.adts",
             "output_format": "fltp",
-            "result": "14283798dcae218386885921f3e042e1"
+            "result": "33d07752b3f3d2beb45a705754be6584"
         },
         {
             "name": "al09_16",
@@ -369,7 +369,7 @@
             "source_checksum": "8c91b5fc725fdba3c44c8f2390f89381",
             "input_file": "al09_16.adts",
             "output_format": "fltp",
-            "result": "3deda1facfc196a807a1a979926a0e26"
+            "result": "fbc7c9af31c8cdb561f92cb61aaff61c"
         },
         {
             "name": "as18_64",
@@ -377,7 +377,7 @@
             "source_checksum": "8b9d9f7969f20284dcb670c51b425d93",
             "input_file": "as18_64.adts",
             "output_format": "fltp",
-            "result": "a4078a2db7d6e37ec859bf63847066fc"
+            "result": "de4eada5809199644d621d62c4d2b306"
         },
         {
             "name": "as19_11",
@@ -385,7 +385,7 @@
             "source_checksum": "f6415137c41dd5ce5572659abbd61333",
             "input_file": "as19_11.adts",
             "output_format": "fltp",
-            "result": "b55824b9c5f438b0dcebf399c839a58b"
+            "result": "5dda30abdc4fa3399c8fa1a7c602bca8"
         },
         {
             "name": "al09_12",
@@ -393,7 +393,7 @@
             "source_checksum": "cd8ae7d9c7a06f1af755a33683594a98",
             "input_file": "al09_12.adts",
             "output_format": "fltp",
-            "result": "9cc72882eef5f3eccffce630d54f94d1"
+            "result": "51b5beac5200b2794a7c7e9286314632"
         },
         {
             "name": "as20_16",
@@ -401,7 +401,7 @@
             "source_checksum": "a8ec01e8aa200ed65dbae8459b438df6",
             "input_file": "as20_16.adts",
             "output_format": "fltp",
-            "result": "5ef11534ae396695374afea4a465e974"
+            "result": "84a7aa3b4b6cd9fc132916c32b7141f1"
         },
         {
             "name": "al09_88",
@@ -409,7 +409,7 @@
             "source_checksum": "a4d5e526f7c0fc8fb048aad54e4d71c2",
             "input_file": "al09_88.adts",
             "output_format": "fltp",
-            "result": "392baa1e73e036c98ab27c105e15e8af"
+            "result": "ad8bb96b3ac329ba4b290233f22401f8"
         },
         {
             "name": "as18_08",
@@ -417,7 +417,7 @@
             "source_checksum": "a64588993a1bb52acfedb21df39e9b78",
             "input_file": "as18_08.adts",
             "output_format": "fltp",
-            "result": "63413b1486834edf83df0a99bbaa81ed"
+            "result": "1f6f96bd1d3b052e95286c93ebd24160"
         },
         {
             "name": "as18_12",
@@ -425,7 +425,7 @@
             "source_checksum": "b745ffe579e4832c214c6de012485f1f",
             "input_file": "as18_12.adts",
             "output_format": "fltp",
-            "result": "74649c19597a67bfd319a5e6f4c74b8a"
+            "result": "6c33d452b9f9e9c11be869296a706c60"
         },
         {
             "name": "as18_22",
@@ -433,7 +433,7 @@
             "source_checksum": "5369c26e819fa6ea569007ad629ac0ec",
             "input_file": "as18_22.adts",
             "output_format": "fltp",
-            "result": "79e9193f9ed93d960a0f8e3feec9a47b"
+            "result": "7bdf3d0d5f144e49024717fd9a8a269b"
         },
         {
             "name": "al09_48",
@@ -441,7 +441,7 @@
             "source_checksum": "5be05f18cfcf9340c9967a0d0007e4ad",
             "input_file": "al09_48.adts",
             "output_format": "fltp",
-            "result": "d7b2083825a5874dcbb8908cc5735183"
+            "result": "a4af5705b86bec13462ea6483c27802a"
         },
         {
             "name": "al09_96",
@@ -449,7 +449,7 @@
             "source_checksum": "5ccaa6962dbbe8a7988990834b588b61",
             "input_file": "al09_96.adts",
             "output_format": "fltp",
-            "result": "85210932d70e0295e10885fe0f28cb56"
+            "result": "74b3d242c6ac44779826115cfc15c46d"
         },
         {
             "name": "as18_96",
@@ -457,7 +457,7 @@
             "source_checksum": "5fca7fa515d86d5910147cc909bfc9fb",
             "input_file": "as18_96.adts",
             "output_format": "fltp",
-            "result": "ad33cddc35d647740a7eec8dbc37c581"
+            "result": "24f35893403e126343fa56bdb3c6f9d7"
         },
         {
             "name": "as21_12",
@@ -465,7 +465,7 @@
             "source_checksum": "939556a3ce7d04dc581db45317147d08",
             "input_file": "as21_12.adts",
             "output_format": "fltp",
-            "result": "f7a0f91241a27bbae305f8a5b834bcc5"
+            "result": "db64f9c3f19a8136737977be740bfdff"
         },
         {
             "name": "as21_32",
@@ -473,7 +473,7 @@
             "source_checksum": "af841a1ebdefb2a40cd819c174fc1be6",
             "input_file": "as21_32.adts",
             "output_format": "fltp",
-            "result": "98a4083ce37f90fc25a1c6b51faa13ad"
+            "result": "e3c9a074b3d1d32d8c38d6bc3bd25492"
         },
         {
             "name": "as19_22",
@@ -481,7 +481,7 @@
             "source_checksum": "21a24c98f9c0c871422050e31ff5a27a",
             "input_file": "as19_22.adts",
             "output_format": "fltp",
-            "result": "dfcaf44cacd516d8aaeac250bf19d571"
+            "result": "e4152a4e3bce0c8ce8665a1615f9e8f5"
         },
         {
             "name": "as21_88",
@@ -489,7 +489,7 @@
             "source_checksum": "d1675729e2333effc6fcc50ab0b5e94b",
             "input_file": "as21_88.adts",
             "output_format": "fltp",
-            "result": "9f5e4921e04c68ce72d1ec7678810f80"
+            "result": "54c1a5c135243bf076dfcaef2672cfb5"
         },
         {
             "name": "as20_32",
@@ -497,7 +497,7 @@
             "source_checksum": "f9de9178603479f2575db585cc944622",
             "input_file": "as20_32.adts",
             "output_format": "fltp",
-            "result": "60f0f2fee508216ad89b977065710242"
+            "result": "33fef2e3a0d96972297b51ff0662abd4"
         }
     ]
 }


### PR DESCRIPTION
* Include improvements in mpeg reference decoders building
* Add JSON generation from ISO-MPEG2-AAC decoder in "iso_mpeg2_aac.py" file
* Change ""result":" values of MPEG2_AAC-ADIF.json and MPEG2_AAC-ADTS.json, from reference decoder, .pcm files