### PR TITLE
COM-12579-3-Add building of all reference decoders and clean up to release workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+.gitignore export-ignore
+.pylintrc export-ignore
+.gitattributes export-ignore
+.github export-ignore
+*.log export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,6 @@
 .pylintrc export-ignore
 .gitattributes export-ignore
 .github export-ignore
-scripts/check.sh
-scripts/install_git_hook.sh
+scripts/check.sh export-ignore
+scripts/install_git_hook.sh export-ignore
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@
 .pylintrc export-ignore
 .gitattributes export-ignore
 .github export-ignore
-*.log export-ignore
+scripts/check.sh
+scripts/install_git_hook.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
       notes:
         description: 'Release notes (e.g., changelog)'
         required: false
-        default: 'Changelog: - Added feature 1\n- Added feature 2\n- Fixed issue 2'
+        default: 'Changelog: \n- Added feature 1\n- Added feature 2\n- Fixed issue 2'
   push:
     tags:
       - 'v*.*.*'
@@ -99,6 +99,7 @@ jobs:
       - name: Create GitHub Release
         run: |
           VERSION=${{ github.event.inputs.version }}
+          git archive --format=zip HEAD
           gh release create v$VERSION \
             --title "Release v$VERSION" \
             --notes "$(cat notes.txt)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,25 @@ jobs:
 
       steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v5
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install dependencies
         run: |
           make install_deps
-          sudo apt update && sudo apt install gstreamer1.0-tools gstreamer1.0-libav gstreamer1.0-plugins-bad ffmpeg vpx-tools
+          sudo apt update && sudo apt install \
+            git \
+            cmake \
+            gcc-multilib \
+            g++-multilib \
+            gstreamer1.0-tools \
+            gstreamer1.0-libav \
+            gstreamer1.0-plugins-bad \
+            ffmpeg \
+            vpx-tools \
+            wget \
+            unzip
       - name: Check
         run: |
           make check
@@ -39,34 +50,48 @@ jobs:
           pip wheel .
 
   linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.11
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.13
     - name: Install dependencies
       run: |
         make install_deps
-        sudo apt update && sudo apt install gstreamer1.0-tools gstreamer1.0-libav gstreamer1.0-plugins-bad ffmpeg vpx-tools
+        sudo apt update && sudo apt install \
+          git \
+          cmake \
+          gcc-multilib \
+          g++-multilib \
+          gstreamer1.0-tools \
+          gstreamer1.0-libav \
+          gstreamer1.0-plugins-bad \
+          ffmpeg \
+          vpx-tools \
+          wget \
+          unzip
     - name: Check
       run: |
         make check
     - name: Test Build the wheel
       run: |
         pip wheel .
+    - name: Build all reference decoders
+      run: |
+        make all_reference_decoders
 
   windows:
     runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v5
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install dependencies
       run: |
         make install_deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,12 @@ jobs:
       - name: Test Build the wheel
         run: |
           pip wheel .
+      - name: Build all reference decoders
+        run: |
+          make all_reference_decoders
+      - name: Clean up
+        run: |
+          make clean
 
   linux:
     runs-on: ubuntu-24.04
@@ -82,6 +88,9 @@ jobs:
     - name: Build all reference decoders
       run: |
         make all_reference_decoders
+    - name: Clean up
+      run: |
+        make clean
 
   windows:
     runs-on: windows-latest

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ lint: format-check ## run static analysis using pylint, flake8 and mypy
 
 create_dirs=mkdir -p $(CONTRIB_DIR) $(DECODERS_DIR)
 
-all_reference_decoders: h264_reference_decoder h265_reference_decoder h266_reference_decoder mpeg_4_aac_reference_decoder mpeg_2_aac_reference_decoder ## build all reference decoders
+all_reference_decoders: h264_reference_decoder h265_reference_decoder h266_reference_decoder mpeg_2_aac_reference_decoder mpeg_4_aac_reference_decoder ## build all reference decoders
 
 h266_reference_decoder: ## build H.266 reference decoder
 	$(create_dirs)
@@ -81,7 +81,7 @@ h265_reference_decoder: ## build H.265 reference decoder
 	$(create_dirs)
 	cd $(CONTRIB_DIR) && git clone https://vcgit.hhi.fraunhofer.de/jct-vc/HM.git --depth=1 || true
 	cd $(CONTRIB_DIR)/HM && git stash && git pull && git stash apply || true
-	cd $(CONTRIB_DIR)/HM && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release && $(MAKE) -C build TAppDecoder
+	cd $(CONTRIB_DIR)/HM && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wno-array-bounds" && $(MAKE) -C build TAppDecoder
 	find $(CONTRIB_DIR)/HM/bin/umake -name "TAppDecoder" -type f -exec cp {} $(DECODERS_DIR)/ \;
 
 h264_reference_decoder: ## build H.264 reference decoder
@@ -91,73 +91,10 @@ h264_reference_decoder: ## build H.264 reference decoder
 	cd $(CONTRIB_DIR)/JM && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wno-stringop-truncation -Wno-stringop-overflow" && $(MAKE) -C build ldecod
 	find $(CONTRIB_DIR)/JM/bin/umake -name "ldecod" -type f -exec cp {} $(DECODERS_DIR)/ \;
 
-mpeg_4_aac_reference_decoder: ## build ISO MPEG4 AAC reference decoder
-ifeq ("$(dpkg -l | grep gcc-multilib)", "")
-	sudo apt-get install gcc-multilib
-endif
-ifeq ("$(dpkg -l | grep g++-multilib)", "")
-	sudo apt-get install g++-multilib
-endif
-ifeq ($(wildcard /usr/include/asm), )
-ifneq ($(wildcard /usr/include/asm-generic), )
-		sudo ln -s /usr/include/asm-generic /usr/include/asm
-endif
-endif
-
-ifeq ($(wildcard $(CONTRIB_DIR)/C050470e_Electronic_inserts), )
-	$(create_dirs)
-	cd $(CONTRIB_DIR) && rm -f iso_cookies.txt
-	cd $(CONTRIB_DIR) && wget -qO- --keep-session-cookies --save-cookies iso_cookies.txt \
-	'https://standards.iso.org/ittf/PubliclyAvailableStandards/c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip' > /dev/null
-	cd $(CONTRIB_DIR) && wget --keep-session-cookies --load-cookies iso_cookies.txt --post-data 'ok=I+accept' \
-	'https://standards.iso.org/ittf/PubliclyAvailableStandards/c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip'
-	cd $(CONTRIB_DIR) && unzip -oq c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip
-	cd $(CONTRIB_DIR) && rm -f iso_cookies.txt c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip
-
-	cd $(CONTRIB_DIR) && rm -rf isobmff && git clone https://github.com/MPEGGroup/isobmff.git
-	cd $(CONTRIB_DIR)/isobmff && git checkout tags/v0.2.0 -b v0.2.0
-	cd $(CONTRIB_DIR)/isobmff && mkdir -p build && cd build && cmake .. -DCMAKE_C_FLAGS=-m32 && $(MAKE) libisomediafile
-	cd $(CONTRIB_DIR)/isobmff && mv lib/liblibisomediafile.a lib/libisomediafile.a
-	cd $(CONTRIB_DIR) && cp isobmff/lib/libisomediafile.a C050470e_Electronic_inserts/audio/natural/import/lib/
-	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/src/ISOMovies.h C050470e_Electronic_inserts/audio/natural/import/include/
-	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/src/MP4Movies.h C050470e_Electronic_inserts/audio/natural/import/include/
-ifeq ($(OS), Windows_NT)
-	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/w32/MP4OSMacros.h C050470e_Electronic_inserts/audio/natural/import/include/
-else ifeq ($(KERNEL_NAME), Linux)
-	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/linux/MP4OSMacros.h C050470e_Electronic_inserts/audio/natural/import/include/ || true
-else ifeq ($(KERNEL_NAME), Darwin)
-	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/macosx/MP4OSMacros.h C050470e_Electronic_inserts/audio/natural/import/include/ || true
-endif
-	cd $(CONTRIB_DIR) && wget --no-check-certificate https://www-mmsp.ece.mcgill.ca/Documents/Downloads/libtsp/libtsp-v7r0.tar.gz
-	cd $(CONTRIB_DIR) && tar -zxf libtsp-v7r0.tar.gz && chmod -R ugo=rwx libtsp-v7r0/ && cd libtsp-v7r0/ && $(MAKE) -s COPTS=-m32
-	cd $(CONTRIB_DIR) && rm -f libtsp-v7r0.tar.gz
-	cd $(CONTRIB_DIR) && cp libtsp-v7r0/lib/libtsp.a C050470e_Electronic_inserts/audio/natural/import/lib/
-	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp.h C050470e_Electronic_inserts/audio/natural/import/include/
-	cd $(CONTRIB_DIR) && mkdir -p C050470e_Electronic_inserts/audio/natural/import/include/libtsp/
-	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/AFpar.h C050470e_Electronic_inserts/audio/natural/import/include/libtsp/
-	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/UTpar.h C050470e_Electronic_inserts/audio/natural/import/include/libtsp/
-endif
-	cd $(CONTRIB_DIR)/C050470e_Electronic_inserts/audio/natural/mp4mcDec && MAKELEVEL=0 $(MAKE) mp4audec_mc REFSOFT_INCLUDE_PATH=../import/include REFSOFT_LIBRARY_PATH=../import/lib CFLAGS=-m32 LDFLAGS=-m32
-	find $(CONTRIB_DIR)/C050470e_Electronic_inserts/audio/natural/bin/mp4mcDec -name "mp4audec_mc" -type f -exec cp {} $(DECODERS_DIR) \;
-
-ifneq ($(wildcard /usr/include/asm), )
-ifneq ($(wildcard /usr/include/asm-generic), )
-		sudo unlink /usr/include/asm
-endif
-endif
-
 mpeg_2_aac_reference_decoder: ## build ISO MPEG2 AAC reference decoder
-ifeq ("$(dpkg -l | grep gcc-multilib)", "")
-	sudo apt-get install gcc-multilib
-endif
-ifeq ("$(dpkg -l | grep g++-multilib)", "")
-	sudo apt-get install g++-multilib
-endif
-ifeq ($(wildcard /usr/include/asm), )
-ifneq ($(wildcard /usr/include/asm-generic), )
-	sudo ln -s /usr/include/asm-generic /usr/include/asm
-endif
-endif
+	if ! dpkg -l | grep gcc-multilib -c >>/dev/null; then sudo apt-get install gcc-multilib; fi
+	if ! dpkg -l | grep g++-multilib -c >>/dev/null; then sudo apt-get install g++-multilib; fi
+	if [ ! $(wildcard /usr/include/asm) ] && [ $(wildcard /usr/include/asm-generic) ]; then sudo ln -s /usr/include/asm-generic /usr/include/asm; fi
 
 ifeq ($(wildcard $(CONTRIB_DIR)/C039486_Electronic_inserts), )
 	$(create_dirs)
@@ -198,11 +135,50 @@ endif
 	cd $(CONTRIB_DIR)/mpeg2aac/aacDec && MAKELEVEL=0 $(MAKE) aacdec_mc REFSOFT_INCLUDE_PATH=../import/include REFSOFT_LIBRARY_PATH=../import/lib CFLAGS=-m32 LDFLAGS=-m32
 	find $(CONTRIB_DIR)/mpeg2aac/bin/mp4mcDec -name "aacdec_mc" -type f -exec cp {} $(DECODERS_DIR) \;
 
-ifneq ($(wildcard /usr/include/asm), )
-ifneq ($(wildcard /usr/include/asm-generic), )
-	sudo unlink /usr/include/asm
+	sudo rm -f /usr/include/asm
+
+mpeg_4_aac_reference_decoder: ## build ISO MPEG4 AAC reference decoder
+	if ! dpkg -l | grep gcc-multilib -c >>/dev/null; then sudo apt-get install gcc-multilib; fi
+	if ! dpkg -l | grep g++-multilib -c >>/dev/null; then sudo apt-get install g++-multilib; fi
+	if [ ! $(wildcard /usr/include/asm) ] && [ $(wildcard /usr/include/asm-generic) ]; then sudo ln -s /usr/include/asm-generic /usr/include/asm; fi
+
+ifeq ($(wildcard $(CONTRIB_DIR)/C050470e_Electronic_inserts), )
+	$(create_dirs)
+	cd $(CONTRIB_DIR) && rm -f iso_cookies.txt
+	cd $(CONTRIB_DIR) && wget -qO- --keep-session-cookies --save-cookies iso_cookies.txt \
+	'https://standards.iso.org/ittf/PubliclyAvailableStandards/c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip' > /dev/null
+	cd $(CONTRIB_DIR) && wget --keep-session-cookies --load-cookies iso_cookies.txt --post-data 'ok=I+accept' \
+	'https://standards.iso.org/ittf/PubliclyAvailableStandards/c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip'
+	cd $(CONTRIB_DIR) && unzip -oq c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip
+	cd $(CONTRIB_DIR) && rm -f iso_cookies.txt c050470__ISO_IEC_14496-5_2001_Amd_20_2009_Reference_Software.zip
+
+	cd $(CONTRIB_DIR) && rm -rf isobmff && git clone https://github.com/MPEGGroup/isobmff.git
+	cd $(CONTRIB_DIR)/isobmff && git checkout tags/v0.2.0 -b v0.2.0
+	cd $(CONTRIB_DIR)/isobmff && mkdir -p build && cd build && cmake .. -DCMAKE_C_FLAGS=-m32 && $(MAKE) libisomediafile
+	cd $(CONTRIB_DIR)/isobmff && mv lib/liblibisomediafile.a lib/libisomediafile.a
+	cd $(CONTRIB_DIR) && cp isobmff/lib/libisomediafile.a C050470e_Electronic_inserts/audio/natural/import/lib/
+	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/src/ISOMovies.h C050470e_Electronic_inserts/audio/natural/import/include/
+	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/src/MP4Movies.h C050470e_Electronic_inserts/audio/natural/import/include/
+ifeq ($(OS), Windows_NT)
+	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/w32/MP4OSMacros.h C050470e_Electronic_inserts/audio/natural/import/include/
+else ifeq ($(KERNEL_NAME), Linux)
+	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/linux/MP4OSMacros.h C050470e_Electronic_inserts/audio/natural/import/include/ || true
+else ifeq ($(KERNEL_NAME), Darwin)
+	cd $(CONTRIB_DIR) && cp isobmff/IsoLib/libisomediafile/macosx/MP4OSMacros.h C050470e_Electronic_inserts/audio/natural/import/include/ || true
 endif
+	cd $(CONTRIB_DIR) && wget --no-check-certificate https://www-mmsp.ece.mcgill.ca/Documents/Downloads/libtsp/libtsp-v7r0.tar.gz
+	cd $(CONTRIB_DIR) && tar -zxf libtsp-v7r0.tar.gz && chmod -R ugo=rwx libtsp-v7r0/ && cd libtsp-v7r0/ && $(MAKE) -s COPTS=-m32
+	cd $(CONTRIB_DIR) && rm -f libtsp-v7r0.tar.gz
+	cd $(CONTRIB_DIR) && cp libtsp-v7r0/lib/libtsp.a C050470e_Electronic_inserts/audio/natural/import/lib/
+	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp.h C050470e_Electronic_inserts/audio/natural/import/include/
+	cd $(CONTRIB_DIR) && mkdir -p C050470e_Electronic_inserts/audio/natural/import/include/libtsp/
+	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/AFpar.h C050470e_Electronic_inserts/audio/natural/import/include/libtsp/
+	cd $(CONTRIB_DIR) && cp libtsp-v7r0/include/libtsp/UTpar.h C050470e_Electronic_inserts/audio/natural/import/include/libtsp/
 endif
+	cd $(CONTRIB_DIR)/C050470e_Electronic_inserts/audio/natural/mp4mcDec && MAKELEVEL=0 $(MAKE) mp4audec_mc REFSOFT_INCLUDE_PATH=../import/include REFSOFT_LIBRARY_PATH=../import/lib CFLAGS=-m32 LDFLAGS=-m32
+	find $(CONTRIB_DIR)/C050470e_Electronic_inserts/audio/natural/bin/mp4mcDec -name "mp4audec_mc" -type f -exec cp {} $(DECODERS_DIR) \;
+
+	sudo rm -f /usr/include/asm
 
 clean: ## remove contrib temporary folder
 	rm -rf $(CONTRIB_DIR)


### PR DESCRIPTION
- Add building of all reference decoders and clean up to release workflow
- Improvements in Makefile (h.265 "ubuntu 24.04" and mpeg2,4)
- Add `.gitattributes` file to remove unused files in the release package generated.