### PR TITLE
Fix issue with FFmpeg version no patch version

### DIFF
--- a/fluster/decoders/ffmpeg.py
+++ b/fluster/decoders/ffmpeg.py
@@ -155,7 +155,11 @@ class FFmpegDecoder(Decoder):
         # Get ffmpeg version
         output = _run_ffmpeg_command(self.binary, "-version", verbose=verbose)
         version = re.search(r" version n?(\d+)\.(\d+)(?:\.(\d+))?", output)
-        self.ffmpeg_version = tuple(map(int, version.groups())) if version else None
+        self.ffmpeg_version = (
+            tuple(map(lambda x: int(x) if x else 0, version.groups()))
+            if version
+            else None
+        )
 
         # Check if codec can be used
         output = _run_ffmpeg_command(self.binary, "-codecs", verbose=verbose)


### PR DESCRIPTION
When
```
$ ffmpeg -version
ffmpeg version n7.1 Copyright (c) 2000-2024 the FFmpeg developers
```

Error:
```
Traceback (most recent call last):
  File "/home/rgonzalez/src/github.com/fluendo/fluster/./fluster.py", line 23, in <module>
    fluster_main()
  File "/home/rgonzalez/src/github.com/fluendo/fluster/fluster/main.py", line 41, in fluster_main
    main.run()
  File "/home/rgonzalez/src/github.com/fluendo/fluster/fluster/main.py", line 85, in run
    args.func(args, fluster)
  File "/home/rgonzalez/src/github.com/fluendo/fluster/fluster/main.py", line 371, in _list_cmd
    fluster.list_decoders(check=args.check, verbose=args.verbose)
  File "/home/rgonzalez/src/github.com/fluendo/fluster/fluster/fluster.py", line 204, in list_decoders
    if decoder.check(verbose)
       ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rgonzalez/src/github.com/fluendo/fluster/fluster/decoders/ffmpeg.py", line 158, in check
    self.ffmpeg_version = tuple(map(int, version.groups())) if version else None
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```