### PR TITLE
COM-12602-Replace erroneous h266 reference decoder in fluster:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,14 @@ all_reference_decoders: h264_reference_decoder h265_reference_decoder h266_refer
 
 h266_reference_decoder: ## build H.266 reference decoder
 	$(create_dirs)
+	cd $(CONTRIB_DIR) && git clone https://vcgit.hhi.fraunhofer.de/jvet/VVCSoftware_VTM.git --depth=1 || true
+	cd $(CONTRIB_DIR)/VVCSoftware_VTM && git pull --autostash || true
+	cd $(CONTRIB_DIR)/VVCSoftware_VTM && mkdir -p build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
+	$(MAKE) -C $(CONTRIB_DIR)/VVCSoftware_VTM/build
+	find $(CONTRIB_DIR)/VVCSoftware_VTM/bin/ -name "DecoderApp" -type f -exec cp {} $(DECODERS_DIR)/ \;
+
+h266_vvdec_decoder: ## build H.266 VVdeC, the Fraunhofer Versatile Video Decoder
+	$(create_dirs)
 	cd $(CONTRIB_DIR) && git clone https://github.com/fraunhoferhhi/vvdec.git --depth=1 || true
 	cd $(CONTRIB_DIR)/vvdec && git pull --autostash || true
 	cd $(CONTRIB_DIR)/vvdec && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wno-stringop-truncation -Wno-stringop-overflow" && $(MAKE) -C build vvdecapp

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ AAC
 
 H266
     GStreamer-H.266-VVdeC-Gst1.0: GStreamer H.266 VVdeC decoder for GStreamer 1.0... ✔
-    VVdeC-H266: VVdeC H.266/VVC reference decoder... ✔️
+    VVCSoftware_VTM-H266: VVCSoftware_VTM H.266/VVC reference decoder... ✔️
 
 ```
 

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -652,11 +652,11 @@ class GStreamerNvdecSLVP9Gst10Decoder(GStreamer10Video):
 
 @register_decoder
 class GStreamerVVdeCH266Decoder(GStreamer10Video):
-    """GStreamer H.266/VVC VVdeC decoder implementation for GStreamer 1.0"""
+    """GStreamer H.266/VVC VVCSoftware_VTM decoder implementation for GStreamer 1.0"""
 
     codec = Codec.H266
-    decoder_bin = " vvdec "
-    api = "VVdeC"
+    decoder_bin = " Decoder "
+    api = "VVCSoftware_VTM"
 
 
 @register_decoder

--- a/fluster/decoders/h266_vvdec.py
+++ b/fluster/decoders/h266_vvdec.py
@@ -24,10 +24,10 @@ from fluster.utils import file_checksum, run_command
 class H266JCTVTDecoder(Decoder):
     """VVdeC H.266/VVC reference decoder implementation"""
 
-    name = "VVdeC-H266"
-    description = "VVdeC H.266/VVC reference decoder"
+    name = "VVCSoftware_VTM-H266"
+    description = "VVCSoftware_VTM H.266/VVC reference decoder"
     codec = Codec.H266
-    binary = "vvdecapp"
+    binary = "DecoderApp"
 
     def decode(
         self,


### PR DESCRIPTION
* add h266_reference_decoder (VVCSoftware_VTM-H266)
* maintain h266_vvdec_decoder (VVdeC, the Fraunhofer Versatile Video Decoder)
* update README.md