### PR TITLE
COM-12464 - MPEG-4 AAC mp4

### DIFF
--- a/fluster/decoders/iso_mpeg4_aac.py
+++ b/fluster/decoders/iso_mpeg4_aac.py
@@ -15,6 +15,9 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
+import glob
+import os
+
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
 from fluster.utils import file_checksum, run_command
@@ -48,4 +51,15 @@ class ISOAACDecoder(Decoder):
             timeout=timeout,
             verbose=verbose,
         )
+        base_output = output_filepath[:-4]
+        pcm_out_f00_file = f"{base_output}_f00.pcm"
+
+        if os.path.exists(pcm_out_f00_file):
+            return file_checksum(pcm_out_f00_file)
+
+        output_files = glob.glob(f"{base_output}_f[0-9][0-9].pcm")
+
+        for pcm_file in output_files:
+            return file_checksum(pcm_file)
+
         return file_checksum(output_filepath)

--- a/test_suites/aac/MPEG4_AAC-MP4.json
+++ b/test_suites/aac/MPEG4_AAC-MP4.json
@@ -1,0 +1,6951 @@
+{
+    "name": "MPEG4_AAC-MP4",
+    "codec": "AAC",
+    "description": "ISO IEC 14496-26 MPEG4 AAC MP4 test suite",
+    "test_vectors": [
+        {
+            "name": "al03_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03_88.mp4",
+            "source_checksum": "5c24a9d1cb7f4fa0b2411cd5c06d9b51",
+            "input_file": "al03_88.mp4",
+            "output_format": "Unknown",
+            "result": "582225859b9df6f9bb2a25c7ec843fdd"
+        },
+        {
+            "name": "as12_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as12_12.mp4",
+            "source_checksum": "f8dc0532392017182c88750416530bbf",
+            "input_file": "as12_12.mp4",
+            "output_format": "Unknown",
+            "result": "bda16028a6bf0f84d2466e3689bf73bb"
+        },
+        {
+            "name": "as11_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as11_08.mp4",
+            "source_checksum": "6d94215f3f93a2c902ec0a530c125593",
+            "input_file": "as11_08.mp4",
+            "output_format": "Unknown",
+            "result": "c956ff0d8d65f1157da8db8704a1aa0f"
+        },
+        {
+            "name": "al06sf_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06sf_11.mp4",
+            "source_checksum": "5c70070e209964f0ad617ff3159bb5f3",
+            "input_file": "al06sf_11.mp4",
+            "output_format": "Unknown",
+            "result": "b1d3abe29c049fae6f83b218f7bc0677"
+        },
+        {
+            "name": "as16_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as16_64.mp4",
+            "source_checksum": "18655d2b66c3d82e437cf4ba53c8b846",
+            "input_file": "as16_64.mp4",
+            "output_format": "Unknown",
+            "result": "f2c8633c48bbec94ce6d900aaf4d1bd2"
+        },
+        {
+            "name": "al16_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16_88.mp4",
+            "source_checksum": "2c17bccc6fcc14b8e69d5ef9c6f6499d",
+            "input_file": "al16_88.mp4",
+            "output_format": "Unknown",
+            "result": "55c563d8df797e4c8d308796fb511311"
+        },
+        {
+            "name": "as01_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as01_22.mp4",
+            "source_checksum": "1f85ae3b9c31d6c5f2a62b11cc22373d",
+            "input_file": "as01_22.mp4",
+            "output_format": "Unknown",
+            "result": "575bde090656bf44b9b7d1031cc7b4ac"
+        },
+        {
+            "name": "al03sf_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03sf_22.mp4",
+            "source_checksum": "996de7cf2d6d4eb8d9f61d1e07a3796a",
+            "input_file": "al03sf_22.mp4",
+            "output_format": "Unknown",
+            "result": "6819ba04cee182d2aa3247ed93b9923d"
+        },
+        {
+            "name": "as09_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as09_44.mp4",
+            "source_checksum": "0a59789e5c925ab85c481c068c029fde",
+            "input_file": "as09_44.mp4",
+            "output_format": "Unknown",
+            "result": "1c94b07c439b666ba0a70cac1f6738fc"
+        },
+        {
+            "name": "al01_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01_96.mp4",
+            "source_checksum": "7d68c09d9a5305a5dd800df0c25257a2",
+            "input_file": "al01_96.mp4",
+            "output_format": "Unknown",
+            "result": "4677b93aa04c55103ebd1dce77c6f4c8"
+        },
+        {
+            "name": "al_sbr_cm_48_4",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_cm_48_4.mp4",
+            "source_checksum": "2637f4a3be1eabb6096d06c7efdeb952",
+            "input_file": "al_sbr_cm_48_4.mp4",
+            "output_format": "Unknown",
+            "result": "afd5c60e73e2034d24732d8b9c96e951"
+        },
+        {
+            "name": "am06_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am06_22.mp4",
+            "source_checksum": "7c9e3959cf77ef945a1f21bce9f969b4",
+            "input_file": "am06_22.mp4",
+            "output_format": "Unknown",
+            "result": "a5bd609d7e7ffd105fa908a68bdecc64"
+        },
+        {
+            "name": "al_sbr_sr_64_2_fsaac32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_64_2_fsaac32.mp4",
+            "source_checksum": "9115b198863286afcc2a519de49d8e59",
+            "input_file": "al_sbr_sr_64_2_fsaac32.mp4",
+            "output_format": "Unknown",
+            "result": "b797bd0977e5006b5dcd3c346e1e9ce9"
+        },
+        {
+            "name": "al_sbr_e_44_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_e_44_2.mp4",
+            "source_checksum": "9886fc350bc0f53bddfb92283fde5eb3",
+            "input_file": "al_sbr_e_44_2.mp4",
+            "output_format": "Unknown",
+            "result": "07cc42b87b87ec189458329ea404ed7c"
+        },
+        {
+            "name": "al_sbr_ps_03_new",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_ps_03_new.mp4",
+            "source_checksum": "458b52cac1a86d7f7f4b65833d920d97",
+            "input_file": "al_sbr_ps_03_new.mp4",
+            "output_format": "Unknown",
+            "result": "1c5118874fc64ecf3d2f9b6794d84a8c"
+        },
+        {
+            "name": "am00_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am00_64.mp4",
+            "source_checksum": "32380747173d25cb74d186c1b5ef0633",
+            "input_file": "am00_64.mp4",
+            "output_format": "Unknown",
+            "result": "ced4a01389676291c0b8a72b942f60f3"
+        },
+        {
+            "name": "al960_sbr_e_48_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_e_48_1.mp4",
+            "source_checksum": "391085d91c33a9763aab5639ec31a2ad",
+            "input_file": "al960_sbr_e_48_1.mp4",
+            "output_format": "Unknown",
+            "result": "188d5fbf206ee8e7d86ef6495e6616db"
+        },
+        {
+            "name": "al03sf_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03sf_24.mp4",
+            "source_checksum": "11af69a60e0960eb09d48c9e183d7b72",
+            "input_file": "al03sf_24.mp4",
+            "output_format": "Unknown",
+            "result": "b1b73118761159fff81b5c7af18892c7"
+        },
+        {
+            "name": "as11_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as11_12.mp4",
+            "source_checksum": "5a0216dce0d82663ebe4246fda4d0ce9",
+            "input_file": "as11_12.mp4",
+            "output_format": "Unknown",
+            "result": "3ce237e2c0b6e10f47d7c50c8938148b"
+        },
+        {
+            "name": "al08_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08_64.mp4",
+            "source_checksum": "473c8c3d8318eb0eb943328f50ce11f1",
+            "input_file": "al08_64.mp4",
+            "output_format": "Unknown",
+            "result": "ef16dca24dd66e277185606679118055"
+        },
+        {
+            "name": "al_sbr_i_48_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_i_48_2.mp4",
+            "source_checksum": "8b14d022c0fa21a461635df357483a20",
+            "input_file": "al_sbr_i_48_2.mp4",
+            "output_format": "Unknown",
+            "result": "8a79ab16ba5006c695794965d557a325"
+        },
+        {
+            "name": "er_al10_08_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al10_08_ep0.mp4",
+            "source_checksum": "26bce18b93e6457bafd02f610cc5a4f4",
+            "input_file": "er_al10_08_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as14_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as14_08.mp4",
+            "source_checksum": "d5d8cd2a47398bfadf1d92a8743b0972",
+            "input_file": "as14_08.mp4",
+            "output_format": "Unknown",
+            "result": "0e25ef87bf68f77a6aef86b1b91354cd"
+        },
+        {
+            "name": "am04_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am04_22.mp4",
+            "source_checksum": "c67e3e45c1d39e5919a8a88ea7947bc9",
+            "input_file": "am04_22.mp4",
+            "output_format": "Unknown",
+            "result": "1d70f1287453058ef32e78f321ac0482"
+        },
+        {
+            "name": "al05_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05_11.mp4",
+            "source_checksum": "0ac97958a2d7a800f2117fc8af05a6f4",
+            "input_file": "al05_11.mp4",
+            "output_format": "Unknown",
+            "result": "915e57e4e3865a3ea6a0d4e89f81ba45"
+        },
+        {
+            "name": "as08_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as08_12.mp4",
+            "source_checksum": "24b8fd58f1ea8fbc3d4a45c02625e156",
+            "input_file": "as08_12.mp4",
+            "output_format": "Unknown",
+            "result": "3501043be855b4329c14b0245fe8d603"
+        },
+        {
+            "name": "al960_sbr_e_44_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_e_44_1.mp4",
+            "source_checksum": "ea9693be866a5d3aacf7a49440790ab9",
+            "input_file": "al960_sbr_e_44_1.mp4",
+            "output_format": "Unknown",
+            "result": "eaed84102e1424adf390822dcc096ec6"
+        },
+        {
+            "name": "as12_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as12_08.mp4",
+            "source_checksum": "718c467d92b8175fb7ddd60f0ab78a54",
+            "input_file": "as12_08.mp4",
+            "output_format": "Unknown",
+            "result": "ada25d771c467cdc3112323b11cb9251"
+        },
+        {
+            "name": "er_eld1002np_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1002np_44_ep0.mp4",
+            "source_checksum": "56c25a9ba7dbf2edaa1bd1f62fb7a4e5",
+            "input_file": "er_eld1002np_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al17_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17_48.mp4",
+            "source_checksum": "9c4a1121e14fb1284ebf6c1285d6248a",
+            "input_file": "al17_48.mp4",
+            "output_format": "Unknown",
+            "result": "639ae11166bd1ce3bd23b4d5337008c8"
+        },
+        {
+            "name": "al_sbr_ps_01",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_ps_01.mp4",
+            "source_checksum": "e4463cec5ba8f4fe5359652cf1104042",
+            "input_file": "al_sbr_ps_01.mp4",
+            "output_format": "Unknown",
+            "result": "2ad629b8276a48b0d03da9560fa2d2bc"
+        },
+        {
+            "name": "al08_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08_22.mp4",
+            "source_checksum": "83c7b8d778982275eea5c565288f746b",
+            "input_file": "al08_22.mp4",
+            "output_format": "Unknown",
+            "result": "05c041101be07734c5b7eb4619dea481"
+        },
+        {
+            "name": "al00sf_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00sf_16.mp4",
+            "source_checksum": "b75f00fd53c0247c98cfd7a4ccb447ce",
+            "input_file": "al00sf_16.mp4",
+            "output_format": "Unknown",
+            "result": "5c6c8350621b3ba4c744712746c66213"
+        },
+        {
+            "name": "am02_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am02_88.mp4",
+            "source_checksum": "08e182012990786f8ecac90ba19ef363",
+            "input_file": "am02_88.mp4",
+            "output_format": "Unknown",
+            "result": "d1654244608e1e9470604439a2b56312"
+        },
+        {
+            "name": "al05sf_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05sf_08.mp4",
+            "source_checksum": "a471bf730fa5d94b58ff871704669d1f",
+            "input_file": "al05sf_08.mp4",
+            "output_format": "Unknown",
+            "result": "0af6ed73f0e59937b0ffff6da27a9bc8"
+        },
+        {
+            "name": "al18sf_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18sf_48.mp4",
+            "source_checksum": "3d5bc6a94832f7e7ff2a99b68138af50",
+            "input_file": "al18sf_48.mp4",
+            "output_format": "Unknown",
+            "result": "3c0cd6c01907f6824492b19ee068ddd7"
+        },
+        {
+            "name": "al960_sbr_e_48_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_e_48_2.mp4",
+            "source_checksum": "011abaed897ded65d76ea30a6f24ac71",
+            "input_file": "al960_sbr_e_48_2.mp4",
+            "output_format": "Unknown",
+            "result": "41baba2d7b3feb11a9d4df661b2bbb8a"
+        },
+        {
+            "name": "al00sf_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00sf_12.mp4",
+            "source_checksum": "2d0336993c21b4904ecd818653770530",
+            "input_file": "al00sf_12.mp4",
+            "output_format": "Unknown",
+            "result": "1003860d480d488f2093171008643ca2"
+        },
+        {
+            "name": "am07_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am07_11.mp4",
+            "source_checksum": "daa1f905cd87d897edc102cc3aa0d8c2",
+            "input_file": "am07_11.mp4",
+            "output_format": "Unknown",
+            "result": "62e6f795ee20aa3da79b717f9d06e67a"
+        },
+        {
+            "name": "as07_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as07_11.mp4",
+            "source_checksum": "9f6741379bbf1a6ba8542756373134b7",
+            "input_file": "as07_11.mp4",
+            "output_format": "Unknown",
+            "result": "e88a0c08a34fdcce2f9f917b871240e0"
+        },
+        {
+            "name": "er_ad1103_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1103_24_ep0.mp4",
+            "source_checksum": "8b470529e23025663c48feae4b65b66e",
+            "input_file": "er_ad1103_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al00sf_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00sf_32.mp4",
+            "source_checksum": "c9ae61b1285bd0ff8bdfcd14ccf7a505",
+            "input_file": "al00sf_32.mp4",
+            "output_format": "Unknown",
+            "result": "9379f05a63dbbf78e458e88f8b36a4bc"
+        },
+        {
+            "name": "al_sbr_sr_96_2_fsaac48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_96_2_fsaac48.mp4",
+            "source_checksum": "ad0134224eb11bcc595728df4fb995c0",
+            "input_file": "al_sbr_sr_96_2_fsaac48.mp4",
+            "output_format": "Unknown",
+            "result": "05564115c4b7d5ce395f8e39924b772c"
+        },
+        {
+            "name": "am00_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am00_96.mp4",
+            "source_checksum": "b732ecc2fb827e72afc864c68097c9e3",
+            "input_file": "am00_96.mp4",
+            "output_format": "Unknown",
+            "result": "c2f56da4276be44056df2099fe844862"
+        },
+        {
+            "name": "as15_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as15_12.mp4",
+            "source_checksum": "0e7ca1f469207e13046a1eaba1eb11ca",
+            "input_file": "as15_12.mp4",
+            "output_format": "Unknown",
+            "result": "971a2bff11d06bc3c578efda34aefa4b"
+        },
+        {
+            "name": "er_ad1000np_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1000np_44_ep0.mp4",
+            "source_checksum": "3a1e676b38d716ac0a040b37c0714dec",
+            "input_file": "er_ad1000np_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "er_ad1103np_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1103np_24_ep0.mp4",
+            "source_checksum": "670a533c40dda4b3ec489e704f032424",
+            "input_file": "er_ad1103np_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as01_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as01_44.mp4",
+            "source_checksum": "90da8c0a62dce383be5ce87c2fde0f10",
+            "input_file": "as01_44.mp4",
+            "output_format": "Unknown",
+            "result": "341a1c0cbe9cfb820c5b8ac6ffba3504"
+        },
+        {
+            "name": "al_sbr_gh_48_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_gh_48_2.mp4",
+            "source_checksum": "4b8464f28c43206ac6321ec5d80545ed",
+            "input_file": "al_sbr_gh_48_2.mp4",
+            "output_format": "Unknown",
+            "result": "aa19bbaceb805ba616ced4f955c5620a"
+        },
+        {
+            "name": "am01_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am01_88.mp4",
+            "source_checksum": "3c8b3e9956f9bfe7446db37c0c70f775",
+            "input_file": "am01_88.mp4",
+            "output_format": "Unknown",
+            "result": "da8a298e0336f73be2e6580e9feda34a"
+        },
+        {
+            "name": "al07sf_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07sf_16.mp4",
+            "source_checksum": "ebf2b8c870e7f2cca74d962fde8d3b81",
+            "input_file": "al07sf_16.mp4",
+            "output_format": "Unknown",
+            "result": "d4de30fb19a0873a2357523a21a7c11f"
+        },
+        {
+            "name": "as00_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as00_22.mp4",
+            "source_checksum": "b958c7ba1d8dcc38cb387adc171843d4",
+            "input_file": "as00_22.mp4",
+            "output_format": "Unknown",
+            "result": "a4a12aa95046d129e976ce367ca751a7"
+        },
+        {
+            "name": "er_al21_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al21_24_ep0.mp4",
+            "source_checksum": "83e08abad9e1c275b7a5f94d25a7f2ef",
+            "input_file": "er_al21_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al_sbr_ps_02",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_ps_02.mp4",
+            "source_checksum": "77cec67e9a554b4803bc4edd7e47fc48",
+            "input_file": "al_sbr_ps_02.mp4",
+            "output_format": "Unknown",
+            "result": "78a6feba4604a401af55987d7cc2de1e"
+        },
+        {
+            "name": "al19sf_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19sf_32.mp4",
+            "source_checksum": "4076980291be70769f3bbd2327973b54",
+            "input_file": "al19sf_32.mp4",
+            "output_format": "Unknown",
+            "result": "c71aa3b9ac1c80c4874b8387bc7f0bc3"
+        },
+        {
+            "name": "al960_sbr_s_32_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_s_32_2.mp4",
+            "source_checksum": "fe41d27d07aa77abd4f30e168a74e03e",
+            "input_file": "al960_sbr_s_32_2.mp4",
+            "output_format": "Unknown",
+            "result": "4e4d8591343d2dd7ab19288e4b3ead09"
+        },
+        {
+            "name": "er_al10_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al10_48_ep0.mp4",
+            "source_checksum": "ea64f49436f9bc1e2c085fb2259476b8",
+            "input_file": "er_al10_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "am00_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am00_24.mp4",
+            "source_checksum": "bc9b5c8ae549d28294d1575d359278fe",
+            "input_file": "am00_24.mp4",
+            "output_format": "Unknown",
+            "result": "fd42f61a2fdc9a35a695373dadc79769"
+        },
+        {
+            "name": "al08sf_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08sf_16.mp4",
+            "source_checksum": "299e88abf6cefd830d70fa750d777b11",
+            "input_file": "al08sf_16.mp4",
+            "output_format": "Unknown",
+            "result": "cbb19d0daf6f45e3cfafbf2d9780d758"
+        },
+        {
+            "name": "al_sbr_gh_48_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_gh_48_1.mp4",
+            "source_checksum": "7976f5b42ef81fb987760a46a38dde4d",
+            "input_file": "al_sbr_gh_48_1.mp4",
+            "output_format": "Unknown",
+            "result": "c29f1b0c242b1bb8f7b77cbd7a1035d3"
+        },
+        {
+            "name": "er_ad1009np_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1009np_44_ep0.mp4",
+            "source_checksum": "0db9fd4e9c5b17c53257ae101eb2c290",
+            "input_file": "er_ad1009np_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al01sf_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01sf_12.mp4",
+            "source_checksum": "c8e40e16c0e07645e0d464f7008ffbdc",
+            "input_file": "al01sf_12.mp4",
+            "output_format": "Unknown",
+            "result": "1bf3c602a298c1b7b2f65080c83d4b49"
+        },
+        {
+            "name": "al_sbr_sig_24_2_fsaac24_sig1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sig_24_2_fsaac24_sig1.mp4",
+            "source_checksum": "f3dc920c33288d0fec32812a9d72f986",
+            "input_file": "al_sbr_sig_24_2_fsaac24_sig1.mp4",
+            "output_format": "Unknown",
+            "result": "10161dd7d7ff9402a17182b109f158bb"
+        },
+        {
+            "name": "al_sbr_ps_01_new",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_ps_01_new.mp4",
+            "source_checksum": "37181ac31bbb8a9f1af7d19416aa205d",
+            "input_file": "al_sbr_ps_01_new.mp4",
+            "output_format": "Unknown",
+            "result": "2ad629b8276a48b0d03da9560fa2d2bc"
+        },
+        {
+            "name": "am01_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am01_96.mp4",
+            "source_checksum": "7f63405058532c0fbc2d8e77e0260fc7",
+            "input_file": "am01_96.mp4",
+            "output_format": "Unknown",
+            "result": "973f40dc7d464c8b4b68db9455e23b82"
+        },
+        {
+            "name": "al18_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18_96.mp4",
+            "source_checksum": "0fd2a1046276a648535025a5a2cfb118",
+            "input_file": "al18_96.mp4",
+            "output_format": "Unknown",
+            "result": "21fd073e1f200cf55f9ec3d2e3f9cb3c"
+        },
+        {
+            "name": "al07_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07_08.mp4",
+            "source_checksum": "ccb765da1d3a895d1c08b865b6a9ea61",
+            "input_file": "al07_08.mp4",
+            "output_format": "Unknown",
+            "result": "eaac5252e1c57e7572110d69f4256a22"
+        },
+        {
+            "name": "al_sbr_ps_06",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_ps_06.mp4",
+            "source_checksum": "726dd94f7c29da1dc11314c837c37400",
+            "input_file": "al_sbr_ps_06.mp4",
+            "output_format": "Unknown",
+            "result": "03982f54e327665761f07b4fa6f99d1a"
+        },
+        {
+            "name": "am06_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am06_32.mp4",
+            "source_checksum": "6e378ef43c14c3953903e0f9f3880bc8",
+            "input_file": "am06_32.mp4",
+            "output_format": "Unknown",
+            "result": "28f66eff1fb1e23a8194213eabac5829"
+        },
+        {
+            "name": "al18_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18_64.mp4",
+            "source_checksum": "ec57a5ac44c2d51c5f8f54e4dd719fb9",
+            "input_file": "al18_64.mp4",
+            "output_format": "Unknown",
+            "result": "f527ec839859860dfbb6242a3e742314"
+        },
+        {
+            "name": "er_al21_11_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al21_11_ep0.mp4",
+            "source_checksum": "93cddf58785bcde8b4f21397b4089e07",
+            "input_file": "er_al21_11_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al04sf_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04sf_12.mp4",
+            "source_checksum": "4355c9899f455001a6cfa3c37c6203a7",
+            "input_file": "al04sf_12.mp4",
+            "output_format": "Unknown",
+            "result": "4320324e32f3eb59a745643911e04e99"
+        },
+        {
+            "name": "am05_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am05_48.mp4",
+            "source_checksum": "12d05acb689987524a0bdcaad40b90af",
+            "input_file": "am05_48.mp4",
+            "output_format": "Unknown",
+            "result": "4fd9af1f924d24b28217ca9322c296d4"
+        },
+        {
+            "name": "al06_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06_12.mp4",
+            "source_checksum": "466d81b8c01c4e6d0242298e946e0cbd",
+            "input_file": "al06_12.mp4",
+            "output_format": "Unknown",
+            "result": "0478cbd3efa8e014ca82954e31084f20"
+        },
+        {
+            "name": "al01sf_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01sf_48.mp4",
+            "source_checksum": "5609bd8c37c9c6eaaefad81b3b9fb74f",
+            "input_file": "al01sf_48.mp4",
+            "output_format": "Unknown",
+            "result": "300f8cc27d8b5abfe5720b69f398bad2"
+        },
+        {
+            "name": "er_al10_64_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al10_64_ep0.mp4",
+            "source_checksum": "b26d8ade01bd7a7e97b00de3bf4d0437",
+            "input_file": "er_al10_64_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as00_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as00_88.mp4",
+            "source_checksum": "db39187bafa701fc511de788910db76c",
+            "input_file": "as00_88.mp4",
+            "output_format": "Unknown",
+            "result": "9fad6dc2afb3e4dfe2c48736dc612302"
+        },
+        {
+            "name": "er_ad1109np_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1109np_22_ep0.mp4",
+            "source_checksum": "eb4359696b3bb4cc7829c01b009a923d",
+            "input_file": "er_ad1109np_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al02sf_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02sf_44.mp4",
+            "source_checksum": "0b911fd176602896f567b5e7af08121a",
+            "input_file": "al02sf_44.mp4",
+            "output_format": "Unknown",
+            "result": "976f11accce8764adff7f6fe13c1d204"
+        },
+        {
+            "name": "al00sf_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00sf_24.mp4",
+            "source_checksum": "5c91b7ce3b799a7a13f7559fcfd51987",
+            "input_file": "al00sf_24.mp4",
+            "output_format": "Unknown",
+            "result": "3440a3a7649138c087f6b6136314d19d"
+        },
+        {
+            "name": "al_sbr_sr_16_2_fsaac08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_16_2_fsaac08.mp4",
+            "source_checksum": "2eaa3228c98825d869acacf218cf4b8c",
+            "input_file": "al_sbr_sr_16_2_fsaac08.mp4",
+            "output_format": "Unknown",
+            "result": "57d0484ac20d3a9e0d68d9b5093f2742"
+        },
+        {
+            "name": "al00_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00_96.mp4",
+            "source_checksum": "d07af8a92b07ea72a47ca09fc642b730",
+            "input_file": "al00_96.mp4",
+            "output_format": "Unknown",
+            "result": "7dc7b3c9f121b6afe05020dcd7316f45"
+        },
+        {
+            "name": "as04_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as04_11.mp4",
+            "source_checksum": "7aad49efbfc1ab6385a9e7863771a151",
+            "input_file": "as04_11.mp4",
+            "output_format": "Unknown",
+            "result": "9b1e1cb3d539ac3c605175a667cc426a"
+        },
+        {
+            "name": "as14_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as14_24.mp4",
+            "source_checksum": "35f0954709379de980c7b627ced23f1b",
+            "input_file": "as14_24.mp4",
+            "output_format": "Unknown",
+            "result": "9576e0ff192755ea369507485c58279e"
+        },
+        {
+            "name": "as16_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as16_32.mp4",
+            "source_checksum": "4a98d802ec8bf5e8bb8ace0ddc0c4108",
+            "input_file": "as16_32.mp4",
+            "output_format": "Unknown",
+            "result": "b4b3c045e136191c6d42df8fc352d3cf"
+        },
+        {
+            "name": "al17sf_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17sf_08.mp4",
+            "source_checksum": "5d1813aa237c103faa16fea33402f9f2",
+            "input_file": "al17sf_08.mp4",
+            "output_format": "Unknown",
+            "result": "9ce0c79e5a3b97ba1cd7f9051b9cb813"
+        },
+        {
+            "name": "al960_sbr_s_44_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_s_44_2.mp4",
+            "source_checksum": "d218fe798aa43d3be523fa11e97ffc7e",
+            "input_file": "al960_sbr_s_44_2.mp4",
+            "output_format": "Unknown",
+            "result": "019b6ec95f0e27ca5f58d4c952b7d9b6"
+        },
+        {
+            "name": "am00_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am00_11.mp4",
+            "source_checksum": "f6ac584c5cd93dbb4f8907b139b9c01c",
+            "input_file": "am00_11.mp4",
+            "output_format": "Unknown",
+            "result": "81984d28bfa1e18f49eb4483bfdac562"
+        },
+        {
+            "name": "as12_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as12_44.mp4",
+            "source_checksum": "c570b62fd54751d1353c2d28e9632615",
+            "input_file": "as12_44.mp4",
+            "output_format": "Unknown",
+            "result": "8dfea67806acf9b1fdb52efe7134dd04"
+        },
+        {
+            "name": "er_ad1000np_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1000np_32_ep0.mp4",
+            "source_checksum": "bb2a11db5a4122ec0e367af485232784",
+            "input_file": "er_ad1000np_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al19_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19_08.mp4",
+            "source_checksum": "2cf0e90c3c554ca7b0071ebf989de289",
+            "input_file": "al19_08.mp4",
+            "output_format": "Unknown",
+            "result": "4b8f61b62b569778ded2ad8dc153d54b"
+        },
+        {
+            "name": "er_ad1109np_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1109np_44_ep0.mp4",
+            "source_checksum": "33542e20d1323cf57a75a43d2a4ca765",
+            "input_file": "er_ad1109np_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as12_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as12_16.mp4",
+            "source_checksum": "43cb47b7d553fa2b1657fc206c32ab5b",
+            "input_file": "as12_16.mp4",
+            "output_format": "Unknown",
+            "result": "a987f1846c38136e503b386b0eb1bec8"
+        },
+        {
+            "name": "al08sf_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08sf_08.mp4",
+            "source_checksum": "2d4379bf236597884cc38721f663f95e",
+            "input_file": "al08sf_08.mp4",
+            "output_format": "Unknown",
+            "result": "6d7174d75cfe8faf8de3b66f5258f595"
+        },
+        {
+            "name": "al08sf_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08sf_64.mp4",
+            "source_checksum": "558e8076307ddfe9ffe3f8928067affe",
+            "input_file": "al08sf_64.mp4",
+            "output_format": "Unknown",
+            "result": "ef16dca24dd66e277185606679118055"
+        },
+        {
+            "name": "er_eld2100np_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld2100np_48_ep0.mp4",
+            "source_checksum": "b0a5a5c01392ba233d2f7c1e3879b236",
+            "input_file": "er_eld2100np_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al08sf_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08sf_48.mp4",
+            "source_checksum": "fa9fe405f0ec0000f6ab6102dccda480",
+            "input_file": "al08sf_48.mp4",
+            "output_format": "Unknown",
+            "result": "97e049c5ca237411214a5ba9f0733dbc"
+        },
+        {
+            "name": "am04_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am04_64.mp4",
+            "source_checksum": "589335b559b1ec516f58bbe7b4211689",
+            "input_file": "am04_64.mp4",
+            "output_format": "Unknown",
+            "result": "4c5cea2946487d0c1d6037a6c640ab6d"
+        },
+        {
+            "name": "al17_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17_32.mp4",
+            "source_checksum": "501df2b51f864b59a86772d0f4fd7bfe",
+            "input_file": "al17_32.mp4",
+            "output_format": "Unknown",
+            "result": "fb0aaa3f83522df7406f67744aa5ac0f"
+        },
+        {
+            "name": "as10_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as10_11.mp4",
+            "source_checksum": "48d565af62611dabad34157b83addd9d",
+            "input_file": "as10_11.mp4",
+            "output_format": "Unknown",
+            "result": "48faf4c4165ff42a3ed86f7102e266f6"
+        },
+        {
+            "name": "as08_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as08_32.mp4",
+            "source_checksum": "52516623e699d22ba27bf35f117a2955",
+            "input_file": "as08_32.mp4",
+            "output_format": "Unknown",
+            "result": "11a3cfd97a1fdb82c0a2c46df65514b6"
+        },
+        {
+            "name": "am05_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am05_08.mp4",
+            "source_checksum": "3d7664d878d25053898ed023a1e1cd44",
+            "input_file": "am05_08.mp4",
+            "output_format": "Unknown",
+            "result": "d0cd7d4c6fc2c1d30bc065e1e28a6459"
+        },
+        {
+            "name": "er_ad1102np_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1102np_44_ep0.mp4",
+            "source_checksum": "6688979b54230137d648a929d7291a17",
+            "input_file": "er_ad1102np_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al08sf_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08sf_11.mp4",
+            "source_checksum": "98ab98f9fb6c52b2b26eb0a06df15703",
+            "input_file": "al08sf_11.mp4",
+            "output_format": "Unknown",
+            "result": "8f15c703a727432ceb9102ba19accc12"
+        },
+        {
+            "name": "er_eld2100np_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld2100np_44_ep0.mp4",
+            "source_checksum": "3a4400b0518bb27dab517da22890d797",
+            "input_file": "er_eld2100np_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al16sf_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16sf_08.mp4",
+            "source_checksum": "26c365f74e2bdb5aef239e06a763417d",
+            "input_file": "al16sf_08.mp4",
+            "output_format": "Unknown",
+            "result": "2d72274f4741bdbf24fa296e2f6e996c"
+        },
+        {
+            "name": "al00_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00_44.mp4",
+            "source_checksum": "37d8c9845655a695ebfd33ce13881c63",
+            "input_file": "al00_44.mp4",
+            "output_format": "Unknown",
+            "result": "31f0d7315b2d03acb22d7920f5814855"
+        },
+        {
+            "name": "al00_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00_22.mp4",
+            "source_checksum": "8828741c4a624d98b22a097a030bfe36",
+            "input_file": "al00_22.mp4",
+            "output_format": "Unknown",
+            "result": "fc7d20249eb3f883c9244e88986eebb9"
+        },
+        {
+            "name": "al960_sbr_i_44_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_i_44_2.mp4",
+            "source_checksum": "79ee30f7730c566fd6ad031c8a527157",
+            "input_file": "al960_sbr_i_44_2.mp4",
+            "output_format": "Unknown",
+            "result": "e5fe799601b4b0348a505ad59e58d3c7"
+        },
+        {
+            "name": "al17sf_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17sf_88.mp4",
+            "source_checksum": "913f808968f190b0e1d682fac6ca8373",
+            "input_file": "al17sf_88.mp4",
+            "output_format": "Unknown",
+            "result": "ad70e0b02635cfcb30c928dc70b4ef05"
+        },
+        {
+            "name": "al06sf_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06sf_08.mp4",
+            "source_checksum": "80a185e97370b9341742cd39d6e4a5a3",
+            "input_file": "al06sf_08.mp4",
+            "output_format": "Unknown",
+            "result": "0e0cc8a25f7eb161f66ee3bc65199d04"
+        },
+        {
+            "name": "al17sf_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17sf_64.mp4",
+            "source_checksum": "d53a25e42afa25edd6d23f2df8df07ab",
+            "input_file": "al17sf_64.mp4",
+            "output_format": "Unknown",
+            "result": "9c3bc834d40d27a441ab80ae72eda8c4"
+        },
+        {
+            "name": "al_sbr_sr_44_2_fsaac44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_44_2_fsaac44.mp4",
+            "source_checksum": "d15294569be73d50019d11b8ca993483",
+            "input_file": "al_sbr_sr_44_2_fsaac44.mp4",
+            "output_format": "Unknown",
+            "result": "be2a825ba95b0d680f152d1017515bf5"
+        },
+        {
+            "name": "er_eld1101np_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1101np_22_ep0.mp4",
+            "source_checksum": "9ff710fb9fc6bc3f3ab33224524a75f4",
+            "input_file": "er_eld1101np_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "am02_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am02_32.mp4",
+            "source_checksum": "a416a16587b677eb9cc0028ef8c8f065",
+            "input_file": "am02_32.mp4",
+            "output_format": "Unknown",
+            "result": "9215e2c2da657bda91d108847f608c18"
+        },
+        {
+            "name": "as03_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as03_16.mp4",
+            "source_checksum": "8e85ffafc74b18cdc52bce6479fe8956",
+            "input_file": "as03_16.mp4",
+            "output_format": "Unknown",
+            "result": "0298779243f1f989e4aea5aa255f57ea"
+        },
+        {
+            "name": "as00_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as00_11.mp4",
+            "source_checksum": "df362dbde146c0ab34e502ac493295a0",
+            "input_file": "as00_11.mp4",
+            "output_format": "Unknown",
+            "result": "3629580db303963cdea8dc8d3ecc28e1"
+        },
+        {
+            "name": "al02sf_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02sf_64.mp4",
+            "source_checksum": "7d867af8488df6c06bf66b6cdbedfd23",
+            "input_file": "al02sf_64.mp4",
+            "output_format": "Unknown",
+            "result": "5a1b7aaee8c3e44254fb010268cdcabe"
+        },
+        {
+            "name": "al_sbr_gh_32_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_gh_32_1.mp4",
+            "source_checksum": "5a3db651c2e9ecf7330c00d6fd128875",
+            "input_file": "al_sbr_gh_32_1.mp4",
+            "output_format": "Unknown",
+            "result": "4a50d48c132b690b96db0c779369778e"
+        },
+        {
+            "name": "as08_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as08_22.mp4",
+            "source_checksum": "524caa40d96bc2a271100c89126e3031",
+            "input_file": "as08_22.mp4",
+            "output_format": "Unknown",
+            "result": "db921bd902654720933f799741bb35b2"
+        },
+        {
+            "name": "er_ad1000_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1000_48_ep0.mp4",
+            "source_checksum": "6916186f575fcb043dff05add344cf00",
+            "input_file": "er_ad1000_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al17sf_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17sf_24.mp4",
+            "source_checksum": "54f1fb1859aaa869502ab3da41009529",
+            "input_file": "al17sf_24.mp4",
+            "output_format": "Unknown",
+            "result": "81e7f63e34e349fd6138172552c55936"
+        },
+        {
+            "name": "al14sf_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14sf_24.mp4",
+            "source_checksum": "87d0b157410bc5b9fa0e02d114b56a97",
+            "input_file": "al14sf_24.mp4",
+            "output_format": "Unknown",
+            "result": "744f7fd7aef4005110b26134c89938f6"
+        },
+        {
+            "name": "as17_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as17_88.mp4",
+            "source_checksum": "890a6d08036caaed1b041ceda676f54f",
+            "input_file": "as17_88.mp4",
+            "output_format": "Unknown",
+            "result": "3bf98e171d2dec7242e96170d718c2f7"
+        },
+        {
+            "name": "er_eld2000np_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld2000np_44_ep0.mp4",
+            "source_checksum": "362541312ff9076fee3883121259659f",
+            "input_file": "er_eld2000np_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "am02_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am02_96.mp4",
+            "source_checksum": "c6d0fb7246519fe1d30994eb8fe6bdc9",
+            "input_file": "am02_96.mp4",
+            "output_format": "Unknown",
+            "result": "9f7d938d429941be9224be48f187d2f6"
+        },
+        {
+            "name": "as05_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as05_44.mp4",
+            "source_checksum": "7e82abc7219d4929e6441fc0466f4d30",
+            "input_file": "as05_44.mp4",
+            "output_format": "Unknown",
+            "result": "6d52bc409273a725d7d0688d2be08421"
+        },
+        {
+            "name": "as11_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as11_64.mp4",
+            "source_checksum": "62fc978020e48c0a91a4feb80f822107",
+            "input_file": "as11_64.mp4",
+            "output_format": "Unknown",
+            "result": "8fa7c4d7b94faff9117bd4d12c349e1b"
+        },
+        {
+            "name": "er_al21_08_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al21_08_ep0.mp4",
+            "source_checksum": "ac942aa845d97da613b3b06a3a16585f",
+            "input_file": "er_al21_08_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al06_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06_22.mp4",
+            "source_checksum": "e1738c83d846cf6acbc5438675e08841",
+            "input_file": "al06_22.mp4",
+            "output_format": "Unknown",
+            "result": "fd272f2518856dfd459c84cf9e7edc93"
+        },
+        {
+            "name": "as05_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as05_11.mp4",
+            "source_checksum": "694187cef3068928087ba6fca91df129",
+            "input_file": "as05_11.mp4",
+            "output_format": "Unknown",
+            "result": "4304c8ed55dac9a12a96e88528ce97b7"
+        },
+        {
+            "name": "al04sf_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04sf_16.mp4",
+            "source_checksum": "3578372f1d94f8baf7872fc2e31a942b",
+            "input_file": "al04sf_16.mp4",
+            "output_format": "Unknown",
+            "result": "e9a74efa429e0d6ca38b2c59bdf61652"
+        },
+        {
+            "name": "am01_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am01_16.mp4",
+            "source_checksum": "62f2b0ee9e838030920f433b38e1f5a4",
+            "input_file": "am01_16.mp4",
+            "output_format": "Unknown",
+            "result": "fd2786d9f25f1dcbba7e0c69b4e6e852"
+        },
+        {
+            "name": "al_sbr_sr_22_2_fsaac11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_22_2_fsaac11.mp4",
+            "source_checksum": "8d0180558ac8297d7d869f4cf3049157",
+            "input_file": "al_sbr_sr_22_2_fsaac11.mp4",
+            "output_format": "Unknown",
+            "result": "b17e9cce72c891a1d2ee5a22f3218832"
+        },
+        {
+            "name": "as02_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as02_22.mp4",
+            "source_checksum": "5a43f26bcb977c545443d8a6ccdbb82d",
+            "input_file": "as02_22.mp4",
+            "output_format": "Unknown",
+            "result": "01451e220069c903d77ca277444480c5"
+        },
+        {
+            "name": "al00sf_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00sf_96.mp4",
+            "source_checksum": "83001d60e7f08d92107157021811d7a2",
+            "input_file": "al00sf_96.mp4",
+            "output_format": "Unknown",
+            "result": "7dc7b3c9f121b6afe05020dcd7316f45"
+        },
+        {
+            "name": "al01sf_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01sf_11.mp4",
+            "source_checksum": "a63bfe0ffefb576be2832688bbb0afa1",
+            "input_file": "al01sf_11.mp4",
+            "output_format": "Unknown",
+            "result": "68ebaf2c433c13381e815db62a7c3385"
+        },
+        {
+            "name": "al14sf_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14sf_88.mp4",
+            "source_checksum": "9218e51f2272d72aadee80788fb074ca",
+            "input_file": "al14sf_88.mp4",
+            "output_format": "Unknown",
+            "result": "93099bfdaf22a5847e010eef08f10537"
+        },
+        {
+            "name": "as07_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as07_96.mp4",
+            "source_checksum": "c8ded0ce5fbc3de85465b57d3c9b2eb2",
+            "input_file": "as07_96.mp4",
+            "output_format": "Unknown",
+            "result": "a0e96752daf6523ef7b97ee65781e4a6"
+        },
+        {
+            "name": "al960_sbr_ps_04",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_ps_04.mp4",
+            "source_checksum": "dd14f7358c6d19e5c34a9b5ca56a9e42",
+            "input_file": "al960_sbr_ps_04.mp4",
+            "output_format": "Unknown",
+            "result": "33d6deca5c87f59775535e4173ca0b1f"
+        },
+        {
+            "name": "as03_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as03_44.mp4",
+            "source_checksum": "98372c12b3a36acda6f59bbb9b72e82b",
+            "input_file": "as03_44.mp4",
+            "output_format": "Unknown",
+            "result": "b9d7b1fcf7a918ddf1cd51ef97314043"
+        },
+        {
+            "name": "am04_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am04_11.mp4",
+            "source_checksum": "0292a8763a76ca99e7dc1c3c010a836e",
+            "input_file": "am04_11.mp4",
+            "output_format": "Unknown",
+            "result": "841dff3289973f53c68558b72f8268c8"
+        },
+        {
+            "name": "ap03_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/ap03_48.mp4",
+            "source_checksum": "2f529ffc47bee9f79b28723f7434ad3f",
+            "input_file": "ap03_48.mp4",
+            "output_format": "Unknown",
+            "result": "52d92adafcc39d43c81daf44c422d9cf"
+        },
+        {
+            "name": "as02_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as02_24.mp4",
+            "source_checksum": "0f6315a24c1184187b0cfad0aa431406",
+            "input_file": "as02_24.mp4",
+            "output_format": "Unknown",
+            "result": "90ebe7c4b7924fd5bd0c8a26d904ac79"
+        },
+        {
+            "name": "as14_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as14_88.mp4",
+            "source_checksum": "c8973d5357acff7fab3e641e41344f2e",
+            "input_file": "as14_88.mp4",
+            "output_format": "Unknown",
+            "result": "28e85247ea8004cd8253429f6c1e7248"
+        },
+        {
+            "name": "al04sf_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04sf_32.mp4",
+            "source_checksum": "3ffe860f3421bcf9d3ebbc32f87f7628",
+            "input_file": "al04sf_32.mp4",
+            "output_format": "Unknown",
+            "result": "ba7398cba6f48891b0d23e6acd8fce18"
+        },
+        {
+            "name": "am06_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am06_44.mp4",
+            "source_checksum": "7de5db579169851d20a9fdb5e3c68eee",
+            "input_file": "am06_44.mp4",
+            "output_format": "Unknown",
+            "result": "ba63b8ed1206bbd6d97e65e8d6ed27e6"
+        },
+        {
+            "name": "am07_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am07_48.mp4",
+            "source_checksum": "4c7bc5928b32516bf1bb97e0289b3ac4",
+            "input_file": "am07_48.mp4",
+            "output_format": "Unknown",
+            "result": "54302653e935ea1e520f559cbff17498"
+        },
+        {
+            "name": "er_ad1109_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1109_24_ep0.mp4",
+            "source_checksum": "d1f9fed36b551ed31fbeca28a531d039",
+            "input_file": "er_ad1109_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as04_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as04_44.mp4",
+            "source_checksum": "f2d5c5f9932c454f459b044f5e65bbf6",
+            "input_file": "as04_44.mp4",
+            "output_format": "Unknown",
+            "result": "ae6dbe2fb03f50ef1498e9b483c988c5"
+        },
+        {
+            "name": "al08_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08_12.mp4",
+            "source_checksum": "b46a4651cb2bd6aadaa9450e5f0634fa",
+            "input_file": "al08_12.mp4",
+            "output_format": "Unknown",
+            "result": "85695b2defca606c821ed77f12a3d491"
+        },
+        {
+            "name": "al960_sbr_i_48_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_i_48_1.mp4",
+            "source_checksum": "2407cf004623aa9053b8d6b0b66ef165",
+            "input_file": "al960_sbr_i_48_1.mp4",
+            "output_format": "Unknown",
+            "result": "4a0573eeaa1e6222b4e7303b1b850ca5"
+        },
+        {
+            "name": "as04_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as04_22.mp4",
+            "source_checksum": "3c2cfa3a207e2a916815693ca88342bb",
+            "input_file": "as04_22.mp4",
+            "output_format": "Unknown",
+            "result": "8df4dd9c6101bc3fc187683955fbc2b6"
+        },
+        {
+            "name": "am05_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am05_44.mp4",
+            "source_checksum": "0b114ddc101e17e17c1dc548f0313830",
+            "input_file": "am05_44.mp4",
+            "output_format": "Unknown",
+            "result": "b9808e995c35e7aec73e670f7b09c699"
+        },
+        {
+            "name": "al_sbr_e_32_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_e_32_2.mp4",
+            "source_checksum": "9df84696290af9f66517c15a71933bc0",
+            "input_file": "al_sbr_e_32_2.mp4",
+            "output_format": "Unknown",
+            "result": "9a882d6e096b9cec084854318b2c56fc"
+        },
+        {
+            "name": "al04_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04_64.mp4",
+            "source_checksum": "47a9d91a5b317743feb6075f193face9",
+            "input_file": "al04_64.mp4",
+            "output_format": "Unknown",
+            "result": "334e1e916f28c240965ed8e8f3ce6b38"
+        },
+        {
+            "name": "al02_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02_44.mp4",
+            "source_checksum": "2255f11ea10983761d629c9f56fb80e5",
+            "input_file": "al02_44.mp4",
+            "output_format": "Unknown",
+            "result": "976f11accce8764adff7f6fe13c1d204"
+        },
+        {
+            "name": "er_ad1102_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1102_44_ep0.mp4",
+            "source_checksum": "987ebb50884a34b8499a1cc361fa68cd",
+            "input_file": "er_ad1102_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "er_ad1109np_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1109np_24_ep0.mp4",
+            "source_checksum": "df15f20067ed6da6b9030055724e15ba",
+            "input_file": "er_ad1109np_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al05_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05_48.mp4",
+            "source_checksum": "58978ab191e3bfe9ea610c5a31680b79",
+            "input_file": "al05_48.mp4",
+            "output_format": "Unknown",
+            "result": "d72ef57b7bad160905b7d1650360c474"
+        },
+        {
+            "name": "er_eld1101np_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1101np_44_ep0.mp4",
+            "source_checksum": "f81a9ef31b3fb4ba7cb1e4a49fd21194",
+            "input_file": "er_eld1101np_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al07sf_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07sf_11.mp4",
+            "source_checksum": "6e02eae5a629e9fe451a39bc6365a620",
+            "input_file": "al07sf_11.mp4",
+            "output_format": "Unknown",
+            "result": "d4de30fb19a0873a2357523a21a7c11f"
+        },
+        {
+            "name": "al_sbr_sr_32_2_fsaac32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_32_2_fsaac32.mp4",
+            "source_checksum": "a334dda7d4e5bc7c22c0e89c445ebb08",
+            "input_file": "al_sbr_sr_32_2_fsaac32.mp4",
+            "output_format": "Unknown",
+            "result": "c6db4df3dd747c96f6fe66152e640bc8"
+        },
+        {
+            "name": "er_ad1103np_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1103np_32_ep0.mp4",
+            "source_checksum": "70f96824580ade7379347c76110aa932",
+            "input_file": "er_ad1103np_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al03_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03_64.mp4",
+            "source_checksum": "29511894eeff964d41285708e3c1b303",
+            "input_file": "al03_64.mp4",
+            "output_format": "Unknown",
+            "result": "352d2c45ae42514dde7d018bbcdd538c"
+        },
+        {
+            "name": "as03_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as03_12.mp4",
+            "source_checksum": "c0fe5e48e5fb3e99a65c8fbfe1de6a87",
+            "input_file": "as03_12.mp4",
+            "output_format": "Unknown",
+            "result": "abe28e655b5db49b04de9ea99b431e4e"
+        },
+        {
+            "name": "al18sf_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18sf_12.mp4",
+            "source_checksum": "5d54277997cc0e4781052d258440ca1a",
+            "input_file": "al18sf_12.mp4",
+            "output_format": "Unknown",
+            "result": "448234b88743b1d98d68130810f33293"
+        },
+        {
+            "name": "er_eld2000np_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld2000np_48_ep0.mp4",
+            "source_checksum": "d29d3e2c9d05cfb6d1d7c9ed08a83838",
+            "input_file": "er_eld2000np_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al00sf_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00sf_64.mp4",
+            "source_checksum": "a5589e87e1942e37c4f160725c43ae8f",
+            "input_file": "al00sf_64.mp4",
+            "output_format": "Unknown",
+            "result": "0acee3957588ecf625efa56540f02f6a"
+        },
+        {
+            "name": "am07_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am07_96.mp4",
+            "source_checksum": "8b66be8e9b14913e6c82106648cd8ef4",
+            "input_file": "am07_96.mp4",
+            "output_format": "Unknown",
+            "result": "6b8a1ebecc32fc9f54fe1c49390d2f43"
+        },
+        {
+            "name": "as05_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as05_48.mp4",
+            "source_checksum": "cf5e7954e68f578b1147ed9f0b92c69a",
+            "input_file": "as05_48.mp4",
+            "output_format": "Unknown",
+            "result": "92776cb4dcaa00660145739ac77f3c40"
+        },
+        {
+            "name": "as06_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as06_22.mp4",
+            "source_checksum": "5358a27ce906c0855056121c37696e4c",
+            "input_file": "as06_22.mp4",
+            "output_format": "Unknown",
+            "result": "3d1602d419ff72fd988407ac777dc09d"
+        },
+        {
+            "name": "al_sbr_sig_48_2_sig0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sig_48_2_sig0.mp4",
+            "source_checksum": "9142825e62a0eed0f10667414f55bb78",
+            "input_file": "al_sbr_sig_48_2_sig0.mp4",
+            "output_format": "Unknown",
+            "result": "c010b74a09891368ab5db14471f8a732"
+        },
+        {
+            "name": "tts4",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/tts4.mp4",
+            "source_checksum": "d75a01ac45cbdcd6b9eee02bc014245a",
+            "input_file": "tts4.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al01sf_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01sf_24.mp4",
+            "source_checksum": "faf2f5d95d0a7a078eb2392ed6eb8461",
+            "input_file": "al01sf_24.mp4",
+            "output_format": "Unknown",
+            "result": "2a1f9b80e590bf4009bdcc7feab11a47"
+        },
+        {
+            "name": "al03sf_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03sf_12.mp4",
+            "source_checksum": "8d928dc856f094bdae93004834f7e9d8",
+            "input_file": "al03sf_12.mp4",
+            "output_format": "Unknown",
+            "result": "97c9a4a96818ef0c03dc1c8797aa7279"
+        },
+        {
+            "name": "er_ad1000_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1000_32_ep0.mp4",
+            "source_checksum": "557961d4ba6c5fbdf11564d1d97e85c9",
+            "input_file": "er_ad1000_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "er_eld2100np_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld2100np_32_ep0.mp4",
+            "source_checksum": "0ba1be9b550e52ea133bb5d543266a79",
+            "input_file": "er_eld2100np_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as01_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as01_88.mp4",
+            "source_checksum": "44b435794197dbed317abfc5d6732c01",
+            "input_file": "as01_88.mp4",
+            "output_format": "Unknown",
+            "result": "537a0a3189c650bc1d9e06011f636b26"
+        },
+        {
+            "name": "as11_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as11_16.mp4",
+            "source_checksum": "d6905c984ad9cf428d1fa1b91beb6b9a",
+            "input_file": "as11_16.mp4",
+            "output_format": "Unknown",
+            "result": "d704c48a8c7a7aadbeb0ff2cd664b065"
+        },
+        {
+            "name": "al18sf_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18sf_64.mp4",
+            "source_checksum": "3d507dfee12cbebdb536126cc006d190",
+            "input_file": "al18sf_64.mp4",
+            "output_format": "Unknown",
+            "result": "f30e8eb70deac6dbca8024c7c607cd87"
+        },
+        {
+            "name": "as04_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as04_48.mp4",
+            "source_checksum": "f8bbfe7254f7bc21c9a401cb00d6d976",
+            "input_file": "as04_48.mp4",
+            "output_format": "Unknown",
+            "result": "7ccf38ad07dce3b25b59283013770709"
+        },
+        {
+            "name": "al16_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16_44.mp4",
+            "source_checksum": "a0b3f0990a1a226627c77e17a7ee6f13",
+            "input_file": "al16_44.mp4",
+            "output_format": "Unknown",
+            "result": "4943294add67e3168b0686e549f1f707"
+        },
+        {
+            "name": "am04_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am04_88.mp4",
+            "source_checksum": "212caaf3e6dc1c05ec2ebcd90917731f",
+            "input_file": "am04_88.mp4",
+            "output_format": "Unknown",
+            "result": "4d4e8422f0d506cb2d02f4c7984562fb"
+        },
+        {
+            "name": "as03_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as03_08.mp4",
+            "source_checksum": "48fbfc39e049c059edc87ff8093a12f6",
+            "input_file": "as03_08.mp4",
+            "output_format": "Unknown",
+            "result": "873c6825dee58dba747bb0d1713c9876"
+        },
+        {
+            "name": "as07_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as07_32.mp4",
+            "source_checksum": "77c9bc3fa04218035bba0fc2adbc6ba7",
+            "input_file": "as07_32.mp4",
+            "output_format": "Unknown",
+            "result": "0915e1fbc77e87737d528a0c43051124"
+        },
+        {
+            "name": "as07_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as07_48.mp4",
+            "source_checksum": "55dcc19d653e0023879104eb131ae4d0",
+            "input_file": "as07_48.mp4",
+            "output_format": "Unknown",
+            "result": "06baf14e1baa6f403761fb4aff978608"
+        },
+        {
+            "name": "al07_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07_16.mp4",
+            "source_checksum": "47f105f37cd76d3daabd62f541b15448",
+            "input_file": "al07_16.mp4",
+            "output_format": "Unknown",
+            "result": "d4de30fb19a0873a2357523a21a7c11f"
+        },
+        {
+            "name": "er_al10_12_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al10_12_ep0.mp4",
+            "source_checksum": "78419c443d1cb73f22c2be3a628528c4",
+            "input_file": "er_al10_12_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al18sf_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18sf_44.mp4",
+            "source_checksum": "87cdb14b6ab3c2710c47f7abdc702a67",
+            "input_file": "al18sf_44.mp4",
+            "output_format": "Unknown",
+            "result": "3c0cd6c01907f6824492b19ee068ddd7"
+        },
+        {
+            "name": "al_sbr_ps_03",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_ps_03.mp4",
+            "source_checksum": "17f7d06f1c0dee51e7ca4a01d06b453b",
+            "input_file": "al_sbr_ps_03.mp4",
+            "output_format": "Unknown",
+            "result": "1c5118874fc64ecf3d2f9b6794d84a8c"
+        },
+        {
+            "name": "al01sf_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01sf_44.mp4",
+            "source_checksum": "ab42a1613202e1071e53fd45b253f801",
+            "input_file": "al01sf_44.mp4",
+            "output_format": "Unknown",
+            "result": "0ac8f10d9023e838fd99b79fbd158eab"
+        },
+        {
+            "name": "as11_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as11_48.mp4",
+            "source_checksum": "9ed2ba80fe4e102279641b10556db2bf",
+            "input_file": "as11_48.mp4",
+            "output_format": "Unknown",
+            "result": "e780e91547c3144c6e472e92ed2210d7"
+        },
+        {
+            "name": "al960_sbr_gh_48_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_gh_48_2.mp4",
+            "source_checksum": "a3efc5cae8ad8d0f8b2461b4ea3c1907",
+            "input_file": "al960_sbr_gh_48_2.mp4",
+            "output_format": "Unknown",
+            "result": "ce16b929506c7f0f86b17c9865369bb8"
+        },
+        {
+            "name": "as10_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as10_12.mp4",
+            "source_checksum": "fdd7aaea16de73c9fb0106dd70e09865",
+            "input_file": "as10_12.mp4",
+            "output_format": "Unknown",
+            "result": "f057d8a0ad40f59015672c8d713d44ee"
+        },
+        {
+            "name": "ap02_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/ap02_48.mp4",
+            "source_checksum": "6f81c8d70dc36136f5ffa040d789ecc5",
+            "input_file": "ap02_48.mp4",
+            "output_format": "Unknown",
+            "result": "57f4964f065c75fa825bf7c795ae621f"
+        },
+        {
+            "name": "as17_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as17_08.mp4",
+            "source_checksum": "f4ad708c59b2deb052d7d50d75721f81",
+            "input_file": "as17_08.mp4",
+            "output_format": "Unknown",
+            "result": "43e5ba87c26f08d32b8b89469c9a3d7e"
+        },
+        {
+            "name": "as14_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as14_22.mp4",
+            "source_checksum": "9aad8d04dcb95667d9bb925837e6f539",
+            "input_file": "as14_22.mp4",
+            "output_format": "Unknown",
+            "result": "02856cceb12e9637bb98fc210daf193b"
+        },
+        {
+            "name": "er_ad1109_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1109_32_ep0.mp4",
+            "source_checksum": "99680e8265ccb2081ede038d30bc4081",
+            "input_file": "er_ad1109_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as17_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as17_96.mp4",
+            "source_checksum": "beaa15ce5385414a9c95c7484c3399b7",
+            "input_file": "as17_96.mp4",
+            "output_format": "Unknown",
+            "result": "e5b7d4506a2a7e476c5e173afcf19226"
+        },
+        {
+            "name": "as15_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as15_22.mp4",
+            "source_checksum": "51a7227c4db22f51f65d746403d53e81",
+            "input_file": "as15_22.mp4",
+            "output_format": "Unknown",
+            "result": "3845021412db78720068ec2dcd901fc3"
+        },
+        {
+            "name": "as13_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as13_48.mp4",
+            "source_checksum": "1e204c40c21993c04f2f1155c3631f52",
+            "input_file": "as13_48.mp4",
+            "output_format": "Unknown",
+            "result": "c9a81a0fa18615801cdc39e5b163f671"
+        },
+        {
+            "name": "al08sf_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08sf_88.mp4",
+            "source_checksum": "4025ea18b25f3637cb6fce32ce2029d7",
+            "input_file": "al08sf_88.mp4",
+            "output_format": "Unknown",
+            "result": "c7f958f10a167fb8fdc45b83b0777386"
+        },
+        {
+            "name": "al02_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02_64.mp4",
+            "source_checksum": "4828dbe28aa7e2158ccf937e5d6fb0b2",
+            "input_file": "al02_64.mp4",
+            "output_format": "Unknown",
+            "result": "5a1b7aaee8c3e44254fb010268cdcabe"
+        },
+        {
+            "name": "al960_sbr_i_32_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_i_32_2.mp4",
+            "source_checksum": "e9df5182742a1549d2a3bb90fe78616e",
+            "input_file": "al960_sbr_i_32_2.mp4",
+            "output_format": "Unknown",
+            "result": "0ab59892965a657a142d3707b75324d6"
+        },
+        {
+            "name": "er_ad1009np_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1009np_24_ep0.mp4",
+            "source_checksum": "cd5e9efab90b1e3986c0a0c3bc3f0fe8",
+            "input_file": "er_ad1009np_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al960_sbr_i_44_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_i_44_1.mp4",
+            "source_checksum": "d953b1f6f63c0c53810351e3db16c25b",
+            "input_file": "al960_sbr_i_44_1.mp4",
+            "output_format": "Unknown",
+            "result": "72da9d8f698b0a159fd1d88bf553d544"
+        },
+        {
+            "name": "as03_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as03_22.mp4",
+            "source_checksum": "c56014afc0e75c1cae52b29144f7b0be",
+            "input_file": "as03_22.mp4",
+            "output_format": "Unknown",
+            "result": "60873fde0040eae4680267487c338185"
+        },
+        {
+            "name": "am07_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am07_24.mp4",
+            "source_checksum": "1a731057a5ca36f3505c3c38eb2a4e91",
+            "input_file": "am07_24.mp4",
+            "output_format": "Unknown",
+            "result": "6471b8925a069fa8d2f72b316f89c892"
+        },
+        {
+            "name": "am02_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am02_22.mp4",
+            "source_checksum": "d09bbf40ca8cb81370929979552fd492",
+            "input_file": "am02_22.mp4",
+            "output_format": "Unknown",
+            "result": "fc51b1f4ea3dfd744dd31f1062e58828"
+        },
+        {
+            "name": "er_ad1103_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1103_32_ep0.mp4",
+            "source_checksum": "2abcbadbc3143d23e54e3fb6e3bf95d9",
+            "input_file": "er_ad1103_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as17_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as17_44.mp4",
+            "source_checksum": "60a2c3f590ac837460139e21a0fb7d11",
+            "input_file": "as17_44.mp4",
+            "output_format": "Unknown",
+            "result": "6cb48e019e3819c3b29af695278d478f"
+        },
+        {
+            "name": "er_eld1001np_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1001np_22_ep0.mp4",
+            "source_checksum": "bd1c0f36300e1153adc36e363f8fd368",
+            "input_file": "er_eld1001np_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al06sf_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06sf_48.mp4",
+            "source_checksum": "a5fbb400a14de59fd5662c2523020da3",
+            "input_file": "al06sf_48.mp4",
+            "output_format": "Unknown",
+            "result": "4979e6a7e1e61e051c85d1b7d738845f"
+        },
+        {
+            "name": "er_eld1000np_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1000np_48_ep0.mp4",
+            "source_checksum": "b1ddc9429beb1807daa5e93b9629d29c",
+            "input_file": "er_eld1000np_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as16_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as16_96.mp4",
+            "source_checksum": "f84425e0f778c9f7fe620df8c2eea3f5",
+            "input_file": "as16_96.mp4",
+            "output_format": "Unknown",
+            "result": "cb972cdb4e5c63d467f7776fa3828699"
+        },
+        {
+            "name": "al07sf_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07sf_32.mp4",
+            "source_checksum": "3af0b50bf84d67dd4bb2a471700024be",
+            "input_file": "al07sf_32.mp4",
+            "output_format": "Unknown",
+            "result": "70d924177e92b84d441cc00df378b2c0"
+        },
+        {
+            "name": "al07sf_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07sf_88.mp4",
+            "source_checksum": "ad5e2b8dc87815d82513ddd8d4e78c1f",
+            "input_file": "al07sf_88.mp4",
+            "output_format": "Unknown",
+            "result": "dfe19829b88062d92c52c209e41153c3"
+        },
+        {
+            "name": "al_sbr_gh_44_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_gh_44_1.mp4",
+            "source_checksum": "7ca30d2c1ff1e6e814de56f46665655f",
+            "input_file": "al_sbr_gh_44_1.mp4",
+            "output_format": "Unknown",
+            "result": "907fe5cba03fb3755e68ff209f021822"
+        },
+        {
+            "name": "al04_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04_16.mp4",
+            "source_checksum": "9de47e5621d10f07f646c7c78b564f7e",
+            "input_file": "al04_16.mp4",
+            "output_format": "Unknown",
+            "result": "e9a74efa429e0d6ca38b2c59bdf61652"
+        },
+        {
+            "name": "al02sf_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02sf_12.mp4",
+            "source_checksum": "a6f4ab8ef71c014738c571d335beff7e",
+            "input_file": "al02sf_12.mp4",
+            "output_format": "Unknown",
+            "result": "fba7a9108012d70f844bbfe73f862d15"
+        },
+        {
+            "name": "as12_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as12_96.mp4",
+            "source_checksum": "59c606e0446eb4bceb6429b46bc4f24d",
+            "input_file": "as12_96.mp4",
+            "output_format": "Unknown",
+            "result": "84cfdbb1547092e3e15d28b2e9b274d5"
+        },
+        {
+            "name": "as01_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as01_11.mp4",
+            "source_checksum": "216237a2de5448719388f1e18a61d666",
+            "input_file": "as01_11.mp4",
+            "output_format": "Unknown",
+            "result": "bcdc702495729e0034fbb65cfea176ec"
+        },
+        {
+            "name": "as04_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as04_64.mp4",
+            "source_checksum": "e2badf6bce9b7a7d708f12251e33cf55",
+            "input_file": "as04_64.mp4",
+            "output_format": "Unknown",
+            "result": "e8ba5e37c694b3669d197c8ba5f980a1"
+        },
+        {
+            "name": "as10_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as10_96.mp4",
+            "source_checksum": "f091d78b1d24f8c5da1e9d0551365e60",
+            "input_file": "as10_96.mp4",
+            "output_format": "Unknown",
+            "result": "72487940e6b21e1a5acfe6d5ddd57978"
+        },
+        {
+            "name": "er_eld2000np_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld2000np_22_ep0.mp4",
+            "source_checksum": "270bb6c5a43ead1a36af14aca28cf02f",
+            "input_file": "er_eld2000np_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as11_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as11_24.mp4",
+            "source_checksum": "ceb2a5c94e7d5afd78829582e1787a2e",
+            "input_file": "as11_24.mp4",
+            "output_format": "Unknown",
+            "result": "e293ad22f9eb770a524d17288b774880"
+        },
+        {
+            "name": "as16_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as16_12.mp4",
+            "source_checksum": "c347605f97839f80ae074c58d733d8ab",
+            "input_file": "as16_12.mp4",
+            "output_format": "Unknown",
+            "result": "cb0d5dbdfddc30ad05585e911fc73d59"
+        },
+        {
+            "name": "al960_sbr_ps_06",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_ps_06.mp4",
+            "source_checksum": "f076af1002cdc256cec184f11d4d94ef",
+            "input_file": "al960_sbr_ps_06.mp4",
+            "output_format": "Unknown",
+            "result": "f8c6db2aaae3ad971624122ee21d29e1"
+        },
+        {
+            "name": "al06sf_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06sf_44.mp4",
+            "source_checksum": "e459a84a907d4a61b8ff2c1d9a3f199b",
+            "input_file": "al06sf_44.mp4",
+            "output_format": "Unknown",
+            "result": "c908646e2162876f19d0cdf958ddc156"
+        },
+        {
+            "name": "al960_sbr_ps_02",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_ps_02.mp4",
+            "source_checksum": "fe3cae0219cde4b80f6fc238918ca510",
+            "input_file": "al960_sbr_ps_02.mp4",
+            "output_format": "Unknown",
+            "result": "7d41d79aabd58baa147af08f62636bc9"
+        },
+        {
+            "name": "as15_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as15_48.mp4",
+            "source_checksum": "8ad283b87e3703aa28815e24719a7ddd",
+            "input_file": "as15_48.mp4",
+            "output_format": "Unknown",
+            "result": "c9a81a0fa18615801cdc39e5b163f671"
+        },
+        {
+            "name": "al_sbr_i_32_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_i_32_2.mp4",
+            "source_checksum": "43508f1a6f7b172234459d09b00452be",
+            "input_file": "al_sbr_i_32_2.mp4",
+            "output_format": "Unknown",
+            "result": "95bd62627037c7629648ec2372a13fb2"
+        },
+        {
+            "name": "er_al21_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al21_48_ep0.mp4",
+            "source_checksum": "9b88cbc17d8c6b75f3cb2c08e4e50446",
+            "input_file": "er_al21_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al14sf_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14sf_11.mp4",
+            "source_checksum": "d9237a9270d1b7eab8f9f1ce936bf08d",
+            "input_file": "al14sf_11.mp4",
+            "output_format": "Unknown",
+            "result": "e0f68df4182839866feb36ec0dfa23a2"
+        },
+        {
+            "name": "al960_sbr_ps_03",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_ps_03.mp4",
+            "source_checksum": "0d9d4060708ceafbf5c022a1191e526e",
+            "input_file": "al960_sbr_ps_03.mp4",
+            "output_format": "Unknown",
+            "result": "237e0618263e4bf703a8722786fa6c10"
+        },
+        {
+            "name": "er_eld1100np_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1100np_32_ep0.mp4",
+            "source_checksum": "1852d9d9c8838e01881c09e7d6877e13",
+            "input_file": "er_eld1100np_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al02sf_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02sf_32.mp4",
+            "source_checksum": "84f981fffbbbb1076ea162d85677f512",
+            "input_file": "al02sf_32.mp4",
+            "output_format": "Unknown",
+            "result": "05a8592e1a8de09f7b806367f8123938"
+        },
+        {
+            "name": "al05sf_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05sf_48.mp4",
+            "source_checksum": "71ca0c099a14a2dd3f39f15078e04fa0",
+            "input_file": "al05sf_48.mp4",
+            "output_format": "Unknown",
+            "result": "d72ef57b7bad160905b7d1650360c474"
+        },
+        {
+            "name": "tts3",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/tts3.mp4",
+            "source_checksum": "0ea7698688dea0e16b064ca99037cfb1",
+            "input_file": "tts3.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al14sf_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14sf_96.mp4",
+            "source_checksum": "231ad1ff911ac3e658dd2cd5bfa5937a",
+            "input_file": "al14sf_96.mp4",
+            "output_format": "Unknown",
+            "result": "ab6c0c02ab8224bc5f126264ee403a42"
+        },
+        {
+            "name": "as08_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as08_08.mp4",
+            "source_checksum": "1b60749f9e9b77ec08a72793327dbb0a",
+            "input_file": "as08_08.mp4",
+            "output_format": "Unknown",
+            "result": "e62bcd4999610e37ee6b257bc01542d9"
+        },
+        {
+            "name": "al_sbr_sr_22_2_fsaac22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_22_2_fsaac22.mp4",
+            "source_checksum": "58626cd7db1e0fe382eb80ea561777e3",
+            "input_file": "al_sbr_sr_22_2_fsaac22.mp4",
+            "output_format": "Unknown",
+            "result": "ab63b68e5cd4eca956162ea8850317a6"
+        },
+        {
+            "name": "al17sf_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17sf_22.mp4",
+            "source_checksum": "922be0d507d444d6e3d8e2c53bce4813",
+            "input_file": "al17sf_22.mp4",
+            "output_format": "Unknown",
+            "result": "282a105e716a8a6280f5fd9c162dbbce"
+        },
+        {
+            "name": "al18sf_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18sf_88.mp4",
+            "source_checksum": "f231c117317b7460fa234da621e1b6a4",
+            "input_file": "al18sf_88.mp4",
+            "output_format": "Unknown",
+            "result": "04f4336e8cb00bb62e2dfdc29d61ca40"
+        },
+        {
+            "name": "tts8",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/tts8.mp4",
+            "source_checksum": "0ee163c8c919fd3fba7ba92462f20d70",
+            "input_file": "tts8.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al19_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19_88.mp4",
+            "source_checksum": "48f777931ebc1f4e2381e46c6938823d",
+            "input_file": "al19_88.mp4",
+            "output_format": "Unknown",
+            "result": "b9601c4648ba1e8dab602dbcd3259fbd"
+        },
+        {
+            "name": "as13_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as13_32.mp4",
+            "source_checksum": "5d2a80b9c30c62e4be10270e54a7d4ba",
+            "input_file": "as13_32.mp4",
+            "output_format": "Unknown",
+            "result": "b68d6ea8dd4223af7d1e57497aaea2e8"
+        },
+        {
+            "name": "al14_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14_48.mp4",
+            "source_checksum": "ad1a02e299f886c63eb6f9d02b5d6b14",
+            "input_file": "al14_48.mp4",
+            "output_format": "Unknown",
+            "result": "7b4fb2dd812dd2ecdd449e30e0034086"
+        },
+        {
+            "name": "as13_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as13_44.mp4",
+            "source_checksum": "901841ef112ddf61f8152977a8d078ec",
+            "input_file": "as13_44.mp4",
+            "output_format": "Unknown",
+            "result": "14888c909d35b55e76edfb2696f5c0d9"
+        },
+        {
+            "name": "as04_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as04_88.mp4",
+            "source_checksum": "6370ec402dfca0b3021415838a42ac68",
+            "input_file": "as04_88.mp4",
+            "output_format": "Unknown",
+            "result": "a2a2fc6b38a3190b8dde068cddfed7fe"
+        },
+        {
+            "name": "al03sf_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03sf_16.mp4",
+            "source_checksum": "f8898617a8d9a61df9dea4f905991b20",
+            "input_file": "al03sf_16.mp4",
+            "output_format": "Unknown",
+            "result": "98b5f0df41b303b02037224f09cf45ea"
+        },
+        {
+            "name": "al01_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01_32.mp4",
+            "source_checksum": "3df26533c8c3f84e15d21bcfa42bdc1d",
+            "input_file": "al01_32.mp4",
+            "output_format": "Unknown",
+            "result": "11be4fd08e53a9ee75abaca22469f6dd"
+        },
+        {
+            "name": "al04sf_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04sf_48.mp4",
+            "source_checksum": "f39dfafa67d444d1ad0b66d1a2377a73",
+            "input_file": "al04sf_48.mp4",
+            "output_format": "Unknown",
+            "result": "1f04cda750065aad2633d369241e9aed"
+        },
+        {
+            "name": "al03_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03_32.mp4",
+            "source_checksum": "3db1421eb2390b6898c6f5b81a8d1fc6",
+            "input_file": "al03_32.mp4",
+            "output_format": "Unknown",
+            "result": "5262e32342bfac7cfbad37a17fbdaba2"
+        },
+        {
+            "name": "as08_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as08_64.mp4",
+            "source_checksum": "419530e6661771e85dbd65f48feca692",
+            "input_file": "as08_64.mp4",
+            "output_format": "Unknown",
+            "result": "967475be69d08b82e6b150b78a86f44d"
+        },
+        {
+            "name": "er_ad1103_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1103_48_ep0.mp4",
+            "source_checksum": "1a3d68c67a268bbcd6094c3c21267aa1",
+            "input_file": "er_ad1103_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as16_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as16_24.mp4",
+            "source_checksum": "fc555018c4c4b3a4fbfc08a07a9cfb0b",
+            "input_file": "as16_24.mp4",
+            "output_format": "Unknown",
+            "result": "9576e0ff192755ea369507485c58279e"
+        },
+        {
+            "name": "as15_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as15_08.mp4",
+            "source_checksum": "700efb283282fee2ddaf30afe308e1ac",
+            "input_file": "as15_08.mp4",
+            "output_format": "Unknown",
+            "result": "f48ab7fc21542d1d0caf92eacb51eee3"
+        },
+        {
+            "name": "am07_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am07_16.mp4",
+            "source_checksum": "bec7d8dec5395a4fbf99e31972eff33a",
+            "input_file": "am07_16.mp4",
+            "output_format": "Unknown",
+            "result": "67631d8560a5110815639b122a371003"
+        },
+        {
+            "name": "al17_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17_12.mp4",
+            "source_checksum": "5f4c5f52ac777c3ea169b232fbc03e90",
+            "input_file": "al17_12.mp4",
+            "output_format": "Unknown",
+            "result": "bca856a6877d9a5324d8a1cf5cf8864c"
+        },
+        {
+            "name": "al_sbr_i_32_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_i_32_1.mp4",
+            "source_checksum": "9ce169c73423826af7031d55846e68f8",
+            "input_file": "al_sbr_i_32_1.mp4",
+            "output_format": "Unknown",
+            "result": "8ca9cf4313afaade652e40cc89cb4d29"
+        },
+        {
+            "name": "al960_sbr_e_32_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_e_32_2.mp4",
+            "source_checksum": "a7fbbd07a83e4ef7b4311d0963f73d9b",
+            "input_file": "al960_sbr_e_32_2.mp4",
+            "output_format": "Unknown",
+            "result": "57edd03924ee1fd523825887bf6b47bf"
+        },
+        {
+            "name": "al04_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04_32.mp4",
+            "source_checksum": "fd6c42148a56fe48da847f1d157cec9e",
+            "input_file": "al04_32.mp4",
+            "output_format": "Unknown",
+            "result": "b0376ccd5985561b7aedae959f37e7a4"
+        },
+        {
+            "name": "er_al21_12_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al21_12_ep0.mp4",
+            "source_checksum": "a75277e3bb21b8e71f64ed1c0b87d9a6",
+            "input_file": "er_al21_12_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al19_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19_44.mp4",
+            "source_checksum": "fd9794262e20c0ef1a17cdc185186b8b",
+            "input_file": "al19_44.mp4",
+            "output_format": "Unknown",
+            "result": "c71aa3b9ac1c80c4874b8387bc7f0bc3"
+        },
+        {
+            "name": "al16sf_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16sf_16.mp4",
+            "source_checksum": "056fc1f4343adfecc4c5e2ba23b16704",
+            "input_file": "al16sf_16.mp4",
+            "output_format": "Unknown",
+            "result": "0f98f372b70cdb58f24d868c6c792610"
+        },
+        {
+            "name": "er_al10_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al10_44_ep0.mp4",
+            "source_checksum": "3c1ca2c0ca552073a7c8c43497128aed",
+            "input_file": "er_al10_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as09_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as09_32.mp4",
+            "source_checksum": "8d9a05e24a1930034ff159d84001b66a",
+            "input_file": "as09_32.mp4",
+            "output_format": "Unknown",
+            "result": "c30c42a679a63bb4764920eb82e34101"
+        },
+        {
+            "name": "al18_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18_16.mp4",
+            "source_checksum": "a7795a3423fd9dc95dcb70472fe4e0e6",
+            "input_file": "al18_16.mp4",
+            "output_format": "Unknown",
+            "result": "061939a764fc6b7eb1f36a8fa4238636"
+        },
+        {
+            "name": "al960_sbr_e_32_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_e_32_1.mp4",
+            "source_checksum": "d1eae85954c8e1be74a4f40267bb8ac3",
+            "input_file": "al960_sbr_e_32_1.mp4",
+            "output_format": "Unknown",
+            "result": "a4048c9abd97acfbb56ac5eb7c906258"
+        },
+        {
+            "name": "ap05_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/ap05_48.mp4",
+            "source_checksum": "7b6dceb9f1338f857d9fcd0b7111da77",
+            "input_file": "ap05_48.mp4",
+            "output_format": "Unknown",
+            "result": "e5f3db7043119313eb29f6f670989ecd"
+        },
+        {
+            "name": "al_sbr_s_32_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_s_32_2.mp4",
+            "source_checksum": "34d5e61f00d116d816d407828d0237c6",
+            "input_file": "al_sbr_s_32_2.mp4",
+            "output_format": "Unknown",
+            "result": "27b9533f9cbcd679317776ccbee0fe81"
+        },
+        {
+            "name": "am06_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am06_96.mp4",
+            "source_checksum": "8478cc37fb28b4c91c2d0a0d0b07d30a",
+            "input_file": "am06_96.mp4",
+            "output_format": "Unknown",
+            "result": "84c3ec49dbd2c5955fa1b329bec6830a"
+        },
+        {
+            "name": "al14_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14_16.mp4",
+            "source_checksum": "04abbb1eea01fc50610b77115eba1f5d",
+            "input_file": "al14_16.mp4",
+            "output_format": "Unknown",
+            "result": "adcf17383ea63c860aca7c047bb4acd5"
+        },
+        {
+            "name": "al18sf_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18sf_96.mp4",
+            "source_checksum": "a40f5bf8e61dc757d4c43ecff5112087",
+            "input_file": "al18sf_96.mp4",
+            "output_format": "Unknown",
+            "result": "04f4336e8cb00bb62e2dfdc29d61ca40"
+        },
+        {
+            "name": "am00_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am00_48.mp4",
+            "source_checksum": "703405d4b1847f95ad30103298a9aa69",
+            "input_file": "am00_48.mp4",
+            "output_format": "Unknown",
+            "result": "f08ba3ec4c84203c198398817a0988cb"
+        },
+        {
+            "name": "as03_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as03_48.mp4",
+            "source_checksum": "8a9159c4cd8e76edd279785790f3a9b7",
+            "input_file": "as03_48.mp4",
+            "output_format": "Unknown",
+            "result": "340d9fe3dc66b3a18d59d62df1d71954"
+        },
+        {
+            "name": "as13_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as13_64.mp4",
+            "source_checksum": "9703ffb3589a1997f9f55e0a9afab8c8",
+            "input_file": "as13_64.mp4",
+            "output_format": "Unknown",
+            "result": "9f960c8f0636c7a90bba45ca0cb95de0"
+        },
+        {
+            "name": "as12_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as12_32.mp4",
+            "source_checksum": "50304093bf0cbaf74c48cec0e5189775",
+            "input_file": "as12_32.mp4",
+            "output_format": "Unknown",
+            "result": "473779bf860222b0f5ba126f140ae89f"
+        },
+        {
+            "name": "er_ad1103_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1103_44_ep0.mp4",
+            "source_checksum": "7f4604395275473d21888f02d90d85b0",
+            "input_file": "er_ad1103_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as01_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as01_96.mp4",
+            "source_checksum": "9b427347dca14e73f3aeb6160989c6ba",
+            "input_file": "as01_96.mp4",
+            "output_format": "Unknown",
+            "result": "27786e9b7d83abafd8c0bff805d429b9"
+        },
+        {
+            "name": "er_ad1009np_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1009np_32_ep0.mp4",
+            "source_checksum": "00b95f4c693f8ba63b6724e69dcfa846",
+            "input_file": "er_ad1009np_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as02_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as02_32.mp4",
+            "source_checksum": "1e7216a926d6ea3fc3bf98c21c32eae2",
+            "input_file": "as02_32.mp4",
+            "output_format": "Unknown",
+            "result": "f3ee637a48cf6737058daef20576406c"
+        },
+        {
+            "name": "al19_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19_22.mp4",
+            "source_checksum": "874ebaf2588fb3c5ec49c0973c7fed33",
+            "input_file": "al19_22.mp4",
+            "output_format": "Unknown",
+            "result": "8ac8a8c2e0e6b9b7bcbb6c9c489d641c"
+        },
+        {
+            "name": "am04_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am04_32.mp4",
+            "source_checksum": "1530ce1a7232b041686ab9a3d2fb42e6",
+            "input_file": "am04_32.mp4",
+            "output_format": "Unknown",
+            "result": "8c6c38c3e9fac6b328857621350c90a6"
+        },
+        {
+            "name": "al17sf_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17sf_11.mp4",
+            "source_checksum": "8842aee4256f1741612ce1f78ba6f96c",
+            "input_file": "al17sf_11.mp4",
+            "output_format": "Unknown",
+            "result": "77d09b536b5c5cc251faa21e5aecb413"
+        },
+        {
+            "name": "al03sf_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03sf_32.mp4",
+            "source_checksum": "cf3052d1a5e90f77033f82b3880ec40f",
+            "input_file": "al03sf_32.mp4",
+            "output_format": "Unknown",
+            "result": "e82b1fc1d47d004bbb3be7e0feb1f969"
+        },
+        {
+            "name": "al06sf_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06sf_16.mp4",
+            "source_checksum": "f5841793fec2f26332fd5396ad3dd38c",
+            "input_file": "al06sf_16.mp4",
+            "output_format": "Unknown",
+            "result": "ae346b6e8f7053883dc823c3f4288ff5"
+        },
+        {
+            "name": "as01_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as01_64.mp4",
+            "source_checksum": "168b907c8dbd7f6618c771a951fbf72f",
+            "input_file": "as01_64.mp4",
+            "output_format": "Unknown",
+            "result": "a94e930b4474e51dffb012d46af338d5"
+        },
+        {
+            "name": "er_eld1102np_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1102np_44_ep0.mp4",
+            "source_checksum": "f40d31bdcdc7ab034f24ce09c9f58e07",
+            "input_file": "er_eld1102np_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al18_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18_44.mp4",
+            "source_checksum": "09925e18e04262319694a14d62946e1a",
+            "input_file": "al18_44.mp4",
+            "output_format": "Unknown",
+            "result": "3c0cd6c01907f6824492b19ee068ddd7"
+        },
+        {
+            "name": "as03_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as03_24.mp4",
+            "source_checksum": "acd4a595d5dde588a08c690b0f3e905f",
+            "input_file": "as03_24.mp4",
+            "output_format": "Unknown",
+            "result": "7824e57e3964d56457224f67a9383e7b"
+        },
+        {
+            "name": "al06sf_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06sf_12.mp4",
+            "source_checksum": "538495025b07b5b2092f2edbb6c1fc02",
+            "input_file": "al06sf_12.mp4",
+            "output_format": "Unknown",
+            "result": "0478cbd3efa8e014ca82954e31084f20"
+        },
+        {
+            "name": "al04sf_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04sf_08.mp4",
+            "source_checksum": "f6dcc00b7f539e90d52daa6c4b935952",
+            "input_file": "al04sf_08.mp4",
+            "output_format": "Unknown",
+            "result": "19d650af57f6baa32202f3100aeb1eda"
+        },
+        {
+            "name": "as06_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as06_16.mp4",
+            "source_checksum": "8cef265768eb770b4216ed9bbfe46f0f",
+            "input_file": "as06_16.mp4",
+            "output_format": "Unknown",
+            "result": "481e95a7bc8864e6b97edb66cc561aaa"
+        },
+        {
+            "name": "as12_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as12_88.mp4",
+            "source_checksum": "ba00319344b63c0029190c86949b99ad",
+            "input_file": "as12_88.mp4",
+            "output_format": "Unknown",
+            "result": "ed0edb7557b7ddea6e180555346c8fa4"
+        },
+        {
+            "name": "al05_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05_88.mp4",
+            "source_checksum": "893b8780971ea5d8127037972ebaf456",
+            "input_file": "al05_88.mp4",
+            "output_format": "Unknown",
+            "result": "6b609311bb4090654a70cda3b6df7ee4"
+        },
+        {
+            "name": "al17_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17_22.mp4",
+            "source_checksum": "b339432b9f9bce1cb8094d87028bbc55",
+            "input_file": "al17_22.mp4",
+            "output_format": "Unknown",
+            "result": "282a105e716a8a6280f5fd9c162dbbce"
+        },
+        {
+            "name": "al04_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04_44.mp4",
+            "source_checksum": "caae57b05f32efeafadf24df2b4e0bf9",
+            "input_file": "al04_44.mp4",
+            "output_format": "Unknown",
+            "result": "c0955b55a2703be93ad451a3c0cde34d"
+        },
+        {
+            "name": "al14_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14_22.mp4",
+            "source_checksum": "34dbace05ee7c6d724b76cde73a50040",
+            "input_file": "al14_22.mp4",
+            "output_format": "Unknown",
+            "result": "9e85dec1e7c4e72e889eeb3b9a7c5d02"
+        },
+        {
+            "name": "al07sf_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07sf_44.mp4",
+            "source_checksum": "11d19d5ffbbc3c9f9c6f03a33416d8e9",
+            "input_file": "al07sf_44.mp4",
+            "output_format": "Unknown",
+            "result": "70d924177e92b84d441cc00df378b2c0"
+        },
+        {
+            "name": "as10_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as10_24.mp4",
+            "source_checksum": "e23e91733bfc7beaaf3aa7086f50afbf",
+            "input_file": "as10_24.mp4",
+            "output_format": "Unknown",
+            "result": "b3e9246d5753333f14341f4cefd6edf2"
+        },
+        {
+            "name": "al04sf_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04sf_11.mp4",
+            "source_checksum": "6872e68c729403ccfd445959419bf159",
+            "input_file": "al04sf_11.mp4",
+            "output_format": "Unknown",
+            "result": "ce01170c4b3bbadfb22580879745bb79"
+        },
+        {
+            "name": "as00_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as00_16.mp4",
+            "source_checksum": "6a590d9190232f2440303e6a48b0a51b",
+            "input_file": "as00_16.mp4",
+            "output_format": "Unknown",
+            "result": "3fca6788dceea0bfdb8629150d30a0a4"
+        },
+        {
+            "name": "al00_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00_24.mp4",
+            "source_checksum": "e92415ee0d65e2e3ce524970f938bec0",
+            "input_file": "al00_24.mp4",
+            "output_format": "Unknown",
+            "result": "3440a3a7649138c087f6b6136314d19d"
+        },
+        {
+            "name": "al01_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01_48.mp4",
+            "source_checksum": "638d62f9d2cc71d7d2ad2abdcf4e3c83",
+            "input_file": "al01_48.mp4",
+            "output_format": "Unknown",
+            "result": "300f8cc27d8b5abfe5720b69f398bad2"
+        },
+        {
+            "name": "er_ad1000_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1000_24_ep0.mp4",
+            "source_checksum": "e7c1275f048213fda3056c613a6602e3",
+            "input_file": "er_ad1000_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as14_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as14_12.mp4",
+            "source_checksum": "150d9f39dd6998cb860e104e4d801c26",
+            "input_file": "as14_12.mp4",
+            "output_format": "Unknown",
+            "result": "cb0d5dbdfddc30ad05585e911fc73d59"
+        },
+        {
+            "name": "er_eld1100np_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1100np_48_ep0.mp4",
+            "source_checksum": "f8108cbb185cf3b31db640d1748fad79",
+            "input_file": "er_eld1100np_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al17sf_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17sf_32.mp4",
+            "source_checksum": "72544fca368a868ef90ce329905ca58b",
+            "input_file": "al17sf_32.mp4",
+            "output_format": "Unknown",
+            "result": "dd2086ed1265106a1965a524c3575518"
+        },
+        {
+            "name": "as07_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as07_16.mp4",
+            "source_checksum": "bf52071ffe711ccb37355fe06f103060",
+            "input_file": "as07_16.mp4",
+            "output_format": "Unknown",
+            "result": "d5378da42756fbee3af7ed323020dea8"
+        },
+        {
+            "name": "al14_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14_12.mp4",
+            "source_checksum": "02bda522cc1fae4dbfe683c33029ca6c",
+            "input_file": "al14_12.mp4",
+            "output_format": "Unknown",
+            "result": "0838992422e28225ee77bd8f50505d0a"
+        },
+        {
+            "name": "al18_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18_32.mp4",
+            "source_checksum": "29eb617fea2021b8a569ef13bf9c4b6e",
+            "input_file": "al18_32.mp4",
+            "output_format": "Unknown",
+            "result": "b8f25f651ab354db188f483fdd2c66b1"
+        },
+        {
+            "name": "al_sbr_sr_24_2_fsaac24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_24_2_fsaac24.mp4",
+            "source_checksum": "ed00868e566b83184cc7e55450d79296",
+            "input_file": "al_sbr_sr_24_2_fsaac24.mp4",
+            "output_format": "Unknown",
+            "result": "10161dd7d7ff9402a17182b109f158bb"
+        },
+        {
+            "name": "as02_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as02_44.mp4",
+            "source_checksum": "89bd63616088c838393415f38be52658",
+            "input_file": "as02_44.mp4",
+            "output_format": "Unknown",
+            "result": "1d3d1e73b19feeb4ecbe4a702a4361dc"
+        },
+        {
+            "name": "as00_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as00_24.mp4",
+            "source_checksum": "77d6f518ab6e02b89664d9b4b317720d",
+            "input_file": "as00_24.mp4",
+            "output_format": "Unknown",
+            "result": "f55b20bf2eaaca20b8e12dfe76eb0d7d"
+        },
+        {
+            "name": "as08_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as08_11.mp4",
+            "source_checksum": "0abb176cf48e302de3143ad75db1be9c",
+            "input_file": "as08_11.mp4",
+            "output_format": "Unknown",
+            "result": "ba9b6025a324f400b8974402fc0cb31d"
+        },
+        {
+            "name": "al06_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06_32.mp4",
+            "source_checksum": "c35bc565415d32d2cae6a7cd65e69ba0",
+            "input_file": "al06_32.mp4",
+            "output_format": "Unknown",
+            "result": "b4992535a9e4ce3ce07c8b32cee3de7f"
+        },
+        {
+            "name": "as05_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as05_08.mp4",
+            "source_checksum": "7e9f951b37ad501b77aa1216dbc39678",
+            "input_file": "as05_08.mp4",
+            "output_format": "Unknown",
+            "result": "8cdd94e0953cc708e54a22c5ea799cd1"
+        },
+        {
+            "name": "as07_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as07_88.mp4",
+            "source_checksum": "33d8be62ead955c6d23fe4a059a96d8f",
+            "input_file": "as07_88.mp4",
+            "output_format": "Unknown",
+            "result": "5f8f5e004f4e5ab7e72e5fdf87451f18"
+        },
+        {
+            "name": "al06sf_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06sf_88.mp4",
+            "source_checksum": "e9b052c5fd453c52e0ddbf0fdef50cc8",
+            "input_file": "al06sf_88.mp4",
+            "output_format": "Unknown",
+            "result": "4f1c2fd36e30363132d8ed96360e3b29"
+        },
+        {
+            "name": "al16sf_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16sf_32.mp4",
+            "source_checksum": "5dc20e14fea6907055a4c8692d79027b",
+            "input_file": "al16sf_32.mp4",
+            "output_format": "Unknown",
+            "result": "d5a7bb819c3da7edb65c802b1f06dd8d"
+        },
+        {
+            "name": "er_ad1100np_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1100np_44_ep0.mp4",
+            "source_checksum": "d8948badebdba62c3fa5d3699ed58bc0",
+            "input_file": "er_ad1100np_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "er_ad1103np_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1103np_48_ep0.mp4",
+            "source_checksum": "f24412755c3b9a8b09c07f529886c2df",
+            "input_file": "er_ad1103np_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al06_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06_96.mp4",
+            "source_checksum": "51b0485cb5b2b5aa7227f57d34a7f468",
+            "input_file": "al06_96.mp4",
+            "output_format": "Unknown",
+            "result": "907f07b128d154b6eedd113c495a0473"
+        },
+        {
+            "name": "al03sf_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03sf_88.mp4",
+            "source_checksum": "e965fde7fd3c0636dad5e11f72ef3779",
+            "input_file": "al03sf_88.mp4",
+            "output_format": "Unknown",
+            "result": "582225859b9df6f9bb2a25c7ec843fdd"
+        },
+        {
+            "name": "am07_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am07_08.mp4",
+            "source_checksum": "e18b1d19bd2286d8fb02c1aeba83f783",
+            "input_file": "am07_08.mp4",
+            "output_format": "Unknown",
+            "result": "3e6beed537b87093f2381e115860ed0e"
+        },
+        {
+            "name": "al16_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16_96.mp4",
+            "source_checksum": "28ff8d52a899b714573a1cb1928159d0",
+            "input_file": "al16_96.mp4",
+            "output_format": "Unknown",
+            "result": "0f621d7167bfe6b3bacd7d74b2369875"
+        },
+        {
+            "name": "as00_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as00_32.mp4",
+            "source_checksum": "d8077d3896e6722f52d1a5fc975c8002",
+            "input_file": "as00_32.mp4",
+            "output_format": "Unknown",
+            "result": "ba87750cd665c8d17d0515d5162b6899"
+        },
+        {
+            "name": "al19sf_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19sf_22.mp4",
+            "source_checksum": "4624c9ae845821bebbccb26e6cc6fc81",
+            "input_file": "al19sf_22.mp4",
+            "output_format": "Unknown",
+            "result": "8ac8a8c2e0e6b9b7bcbb6c9c489d641c"
+        },
+        {
+            "name": "al07_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07_64.mp4",
+            "source_checksum": "04379d41b9796162bf4618eda52c0f75",
+            "input_file": "al07_64.mp4",
+            "output_format": "Unknown",
+            "result": "45fc46d86e78b09f6277591a34fc2793"
+        },
+        {
+            "name": "al02_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02_24.mp4",
+            "source_checksum": "08f0a8e22ee22d216a3cf51f078454e1",
+            "input_file": "al02_24.mp4",
+            "output_format": "Unknown",
+            "result": "db09ed12bdb1cbaf49dfe9bd7e1046b5"
+        },
+        {
+            "name": "as05_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as05_24.mp4",
+            "source_checksum": "7fb0b1a367ffc0735f34fc81f9ec122e",
+            "input_file": "as05_24.mp4",
+            "output_format": "Unknown",
+            "result": "671432646fd41c54fe0b025f278ad3d5"
+        },
+        {
+            "name": "al02_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02_11.mp4",
+            "source_checksum": "9b13120b091adfb35025cdd43264e91d",
+            "input_file": "al02_11.mp4",
+            "output_format": "Unknown",
+            "result": "6919665a2023157452cff79d0ea54f4c"
+        },
+        {
+            "name": "as11_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as11_11.mp4",
+            "source_checksum": "1c4a241e07fc19e4a686d728f2fbc4bc",
+            "input_file": "as11_11.mp4",
+            "output_format": "Unknown",
+            "result": "e9ffff20d1b7741befe645289ad0a79d"
+        },
+        {
+            "name": "al14sf_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14sf_12.mp4",
+            "source_checksum": "4ea030493de53d7d9e9c7293d015432f",
+            "input_file": "al14sf_12.mp4",
+            "output_format": "Unknown",
+            "result": "0838992422e28225ee77bd8f50505d0a"
+        },
+        {
+            "name": "am01_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am01_64.mp4",
+            "source_checksum": "1ac99f8e227d51a3e5c7f17008baafd4",
+            "input_file": "am01_64.mp4",
+            "output_format": "Unknown",
+            "result": "b122693c58ec1f26785bf0fdc54a60b6"
+        },
+        {
+            "name": "er_eld1101np_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1101np_24_ep0.mp4",
+            "source_checksum": "d7bb3f920a70bbedf32a1e3c8efac664",
+            "input_file": "er_eld1101np_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al19sf_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19sf_11.mp4",
+            "source_checksum": "6b8e51d41474e7780a7b41770802ceea",
+            "input_file": "al19sf_11.mp4",
+            "output_format": "Unknown",
+            "result": "aee47ab6ccb523949594610942a8f47b"
+        },
+        {
+            "name": "as17_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as17_11.mp4",
+            "source_checksum": "eb359c0992f0d89fd2f56946a765f44d",
+            "input_file": "as17_11.mp4",
+            "output_format": "Unknown",
+            "result": "300e847b3b81826305e6b4c6dc611235"
+        },
+        {
+            "name": "as15_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as15_44.mp4",
+            "source_checksum": "48f22d6308e9d0f6626c18b9a39c4ef0",
+            "input_file": "as15_44.mp4",
+            "output_format": "Unknown",
+            "result": "14888c909d35b55e76edfb2696f5c0d9"
+        },
+        {
+            "name": "al07sf_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07sf_24.mp4",
+            "source_checksum": "c6494437b21079e6c480c786233684d4",
+            "input_file": "al07sf_24.mp4",
+            "output_format": "Unknown",
+            "result": "3b76ec8fd5fa3d75b1ed903b712a8cad"
+        },
+        {
+            "name": "al01sf_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01sf_64.mp4",
+            "source_checksum": "0c36ebcfbbefa2b27262316d24b38735",
+            "input_file": "al01sf_64.mp4",
+            "output_format": "Unknown",
+            "result": "567affc7a30b2b05804877c986b93849"
+        },
+        {
+            "name": "er_ad1103np_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1103np_44_ep0.mp4",
+            "source_checksum": "29f720614143f00a5e267db75cedab67",
+            "input_file": "er_ad1103np_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al16sf_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16sf_64.mp4",
+            "source_checksum": "dd49860c753874a4ca312db247868eb2",
+            "input_file": "al16sf_64.mp4",
+            "output_format": "Unknown",
+            "result": "0428ad19c2ec717d2e7d4a8bddaa10c3"
+        },
+        {
+            "name": "as00_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as00_12.mp4",
+            "source_checksum": "642c4e7c6d4770c68522db5998f4b972",
+            "input_file": "as00_12.mp4",
+            "output_format": "Unknown",
+            "result": "30ef66aa6a39b0b5d3a77aea1061928b"
+        },
+        {
+            "name": "as13_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as13_16.mp4",
+            "source_checksum": "c7a9ab41b0ae1969d0bb556f91d3d19e",
+            "input_file": "as13_16.mp4",
+            "output_format": "Unknown",
+            "result": "a4c66f7b5287477f02e2e46482b93fd2"
+        },
+        {
+            "name": "al960_sbr_s_44_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_s_44_1.mp4",
+            "source_checksum": "067debafa8e8481fc097af5cf2c0baa8",
+            "input_file": "al960_sbr_s_44_1.mp4",
+            "output_format": "Unknown",
+            "result": "d0ebc7e4ef369e2d6317be8f2f9c7c5d"
+        },
+        {
+            "name": "al_sbr_twi_48_1_fsaac24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_twi_48_1_fsaac24.mp4",
+            "source_checksum": "8f6f11f5bbbff7745eb6c29d139dcd56",
+            "input_file": "al_sbr_twi_48_1_fsaac24.mp4",
+            "output_format": "Unknown",
+            "result": "9b19f7e3b1dc533a5b00a8a2497d4c8e"
+        },
+        {
+            "name": "al04sf_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04sf_44.mp4",
+            "source_checksum": "a2a418cc7f79993c35424aa77e106018",
+            "input_file": "al04sf_44.mp4",
+            "output_format": "Unknown",
+            "result": "c0955b55a2703be93ad451a3c0cde34d"
+        },
+        {
+            "name": "al00_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00_12.mp4",
+            "source_checksum": "2e248737516bd9d6c8e7b1038e480e0f",
+            "input_file": "al00_12.mp4",
+            "output_format": "Unknown",
+            "result": "1003860d480d488f2093171008643ca2"
+        },
+        {
+            "name": "er_ad1102np_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1102np_24_ep0.mp4",
+            "source_checksum": "04eee28e92ea2c6528d79a76c2f9c187",
+            "input_file": "er_ad1102np_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al14_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14_11.mp4",
+            "source_checksum": "7c46b9696ce5017d40f3a5c3626716af",
+            "input_file": "al14_11.mp4",
+            "output_format": "Unknown",
+            "result": "e0f68df4182839866feb36ec0dfa23a2"
+        },
+        {
+            "name": "al_sbr_sr_48_2_fsaac48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_48_2_fsaac48.mp4",
+            "source_checksum": "8e0e409d2d36924c124ad55636e90b5c",
+            "input_file": "al_sbr_sr_48_2_fsaac48.mp4",
+            "output_format": "Unknown",
+            "result": "9ce12f0d6576d32d4d1d272a832e64ab"
+        },
+        {
+            "name": "as09_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as09_24.mp4",
+            "source_checksum": "bb1942faf8191f6a16c6bf2b6aeaa349",
+            "input_file": "as09_24.mp4",
+            "output_format": "Unknown",
+            "result": "851b0946a36ffb0d4d309c2a4010ec9b"
+        },
+        {
+            "name": "al03sf_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03sf_96.mp4",
+            "source_checksum": "07d9105a4250e449b1f7fb86ae32777a",
+            "input_file": "al03sf_96.mp4",
+            "output_format": "Unknown",
+            "result": "c07660b161c8bf333f7703d39cd7829c"
+        },
+        {
+            "name": "al08_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08_16.mp4",
+            "source_checksum": "8ae58cfa272b2659b332eb6e72c8f55c",
+            "input_file": "al08_16.mp4",
+            "output_format": "Unknown",
+            "result": "cbb19d0daf6f45e3cfafbf2d9780d758"
+        },
+        {
+            "name": "as05_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as05_88.mp4",
+            "source_checksum": "0d47ff5f6e3628160ae4b3c2bb9a3c9d",
+            "input_file": "as05_88.mp4",
+            "output_format": "Unknown",
+            "result": "20b38c0d21a134e573d4d1ca748aad40"
+        },
+        {
+            "name": "er_al10_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al10_32_ep0.mp4",
+            "source_checksum": "134eced76316c312dd731e92e2997abc",
+            "input_file": "er_al10_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al00_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00_08.mp4",
+            "source_checksum": "e420934e6b638949342cc48636617bcc",
+            "input_file": "al00_08.mp4",
+            "output_format": "Unknown",
+            "result": "974fc5db0dd85a5240956a8a5e593469"
+        },
+        {
+            "name": "al02_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02_88.mp4",
+            "source_checksum": "ce777a65dd783e52d849d3a41833bf9b",
+            "input_file": "al02_88.mp4",
+            "output_format": "Unknown",
+            "result": "ea940a21c761f8e87cb3b2b8ceb91ebd"
+        },
+        {
+            "name": "al14_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14_08.mp4",
+            "source_checksum": "1981b6d96731b5938d592db95f51dec2",
+            "input_file": "al14_08.mp4",
+            "output_format": "Unknown",
+            "result": "c25a053760f16d8340be000648f0a426"
+        },
+        {
+            "name": "al01sf_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01sf_16.mp4",
+            "source_checksum": "9c0e1f66def73be4ab469723cac78adf",
+            "input_file": "al01sf_16.mp4",
+            "output_format": "Unknown",
+            "result": "e2f030fc972340b05f2519b282cdbac3"
+        },
+        {
+            "name": "as10_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as10_48.mp4",
+            "source_checksum": "053444ca4f696efa53dd96f3c1ea4106",
+            "input_file": "as10_48.mp4",
+            "output_format": "Unknown",
+            "result": "b66a6582c6c636102251dd3b020e22e2"
+        },
+        {
+            "name": "al_sbr_e_44_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_e_44_1.mp4",
+            "source_checksum": "36d97ba094a2eb20fbbbceb34b1ca5ed",
+            "input_file": "al_sbr_e_44_1.mp4",
+            "output_format": "Unknown",
+            "result": "e88a06abd57b62ecd374b007f2c33ed0"
+        },
+        {
+            "name": "as12_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as12_64.mp4",
+            "source_checksum": "bd7d6d939e20b7d025d8f91a4eeca627",
+            "input_file": "as12_64.mp4",
+            "output_format": "Unknown",
+            "result": "8839665fc97bff6a189aff3bc2d914e9"
+        },
+        {
+            "name": "al04_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04_96.mp4",
+            "source_checksum": "ef5796c25685b1d5afaff9eb3d7fb250",
+            "input_file": "al04_96.mp4",
+            "output_format": "Unknown",
+            "result": "edb05b74da0fb44f78dc51c5c8e7369f"
+        },
+        {
+            "name": "al00_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00_64.mp4",
+            "source_checksum": "01f7b2264c7426300ce1d6c666e07e1a",
+            "input_file": "al00_64.mp4",
+            "output_format": "Unknown",
+            "result": "0acee3957588ecf625efa56540f02f6a"
+        },
+        {
+            "name": "er_ad1102np_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1102np_22_ep0.mp4",
+            "source_checksum": "85fd8e8724b5e426ff4a189fcd4775cb",
+            "input_file": "er_ad1102np_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al07_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07_88.mp4",
+            "source_checksum": "868ff25b1e1ef696d6df1878defe6776",
+            "input_file": "al07_88.mp4",
+            "output_format": "Unknown",
+            "result": "dfe19829b88062d92c52c209e41153c3"
+        },
+        {
+            "name": "as16_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as16_08.mp4",
+            "source_checksum": "fe34e0cc047002ae4d6fb1b8567eebb5",
+            "input_file": "as16_08.mp4",
+            "output_format": "Unknown",
+            "result": "0e25ef87bf68f77a6aef86b1b91354cd"
+        },
+        {
+            "name": "er_eld1100np_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1100np_24_ep0.mp4",
+            "source_checksum": "49c707647d21102ca48028de76becec2",
+            "input_file": "er_eld1100np_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as14_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as14_48.mp4",
+            "source_checksum": "f759ecf4c6648f643567b365ca43ff4d",
+            "input_file": "as14_48.mp4",
+            "output_format": "Unknown",
+            "result": "58f3a2a2c3bb76ddcdecb80e54e32cda"
+        },
+        {
+            "name": "al14_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14_88.mp4",
+            "source_checksum": "58f4072bb280d614b0ab44becba9543c",
+            "input_file": "al14_88.mp4",
+            "output_format": "Unknown",
+            "result": "93099bfdaf22a5847e010eef08f10537"
+        },
+        {
+            "name": "er_al10_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al10_22_ep0.mp4",
+            "source_checksum": "a059de2f08acf98406b9ecb10af74fdd",
+            "input_file": "er_al10_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "er_ad1102_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1102_22_ep0.mp4",
+            "source_checksum": "9f2c1f6dbc1720ff9f2ff90a6c76962a",
+            "input_file": "er_ad1102_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al03sf_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03sf_11.mp4",
+            "source_checksum": "f4610de3d7a2946c43959d626eae603f",
+            "input_file": "al03sf_11.mp4",
+            "output_format": "Unknown",
+            "result": "cb5054b764e9019be9d0fcbfe3776835"
+        },
+        {
+            "name": "al960_sbr_ps_01",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_ps_01.mp4",
+            "source_checksum": "0d3b1ae7d2b2c667384b0fbb32962ecb",
+            "input_file": "al960_sbr_ps_01.mp4",
+            "output_format": "Unknown",
+            "result": "08b595dbb9e2333653268de58943c0e3"
+        },
+        {
+            "name": "al02_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02_96.mp4",
+            "source_checksum": "d9cb220a08e5d42181ad5eba21563267",
+            "input_file": "al02_96.mp4",
+            "output_format": "Unknown",
+            "result": "c91d263e846628e4060cdef6c9b5c81d"
+        },
+        {
+            "name": "er_ad1103_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1103_22_ep0.mp4",
+            "source_checksum": "f5573b545d9bc589e03381f31a15a76d",
+            "input_file": "er_ad1103_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al06sf_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06sf_24.mp4",
+            "source_checksum": "fc775c3c0d7de17e48ee0655cde5bcab",
+            "input_file": "al06sf_24.mp4",
+            "output_format": "Unknown",
+            "result": "7608666b6e0dfeca71883389302f2fe0"
+        },
+        {
+            "name": "as00_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as00_48.mp4",
+            "source_checksum": "9d60f10cf0bc8f3056aaffef2c191c5e",
+            "input_file": "as00_48.mp4",
+            "output_format": "Unknown",
+            "result": "a061cf8a04c5706e71186aa23d4ee307"
+        },
+        {
+            "name": "as09_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as09_12.mp4",
+            "source_checksum": "a57f3ee37e1911cb7003826b3e3a8c0c",
+            "input_file": "as09_12.mp4",
+            "output_format": "Unknown",
+            "result": "ec6dc14c20693f61c10844ed800a375d"
+        },
+        {
+            "name": "al08_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08_08.mp4",
+            "source_checksum": "45443f90986dbc99f70f5ac31e2afda9",
+            "input_file": "al08_08.mp4",
+            "output_format": "Unknown",
+            "result": "6d7174d75cfe8faf8de3b66f5258f595"
+        },
+        {
+            "name": "er_al10_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al10_24_ep0.mp4",
+            "source_checksum": "aa8aa251ffd77d101a8b864c28dd5c99",
+            "input_file": "er_al10_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al01_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01_16.mp4",
+            "source_checksum": "baa04933553f1665a365738effb5cef8",
+            "input_file": "al01_16.mp4",
+            "output_format": "Unknown",
+            "result": "e2f030fc972340b05f2519b282cdbac3"
+        },
+        {
+            "name": "er_ad1109np_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1109np_48_ep0.mp4",
+            "source_checksum": "9231517c1d5554841d291710be33ef5f",
+            "input_file": "er_ad1109np_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "am01_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am01_22.mp4",
+            "source_checksum": "43f8b18dd38e39e04505a4b2921f2a70",
+            "input_file": "am01_22.mp4",
+            "output_format": "Unknown",
+            "result": "5b999b43662bbf77cfecc0346690f522"
+        },
+        {
+            "name": "al02sf_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02sf_24.mp4",
+            "source_checksum": "9d488dbdedf86719ea8ccca532ccc8d5",
+            "input_file": "al02sf_24.mp4",
+            "output_format": "Unknown",
+            "result": "db09ed12bdb1cbaf49dfe9bd7e1046b5"
+        },
+        {
+            "name": "al16sf_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16sf_24.mp4",
+            "source_checksum": "b231ae2664c1bc0efafe58794e32dccd",
+            "input_file": "al16sf_24.mp4",
+            "output_format": "Unknown",
+            "result": "504ea25bf408453edb069c8874792863"
+        },
+        {
+            "name": "am00_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am00_44.mp4",
+            "source_checksum": "29f723f10166f1478eec34bff80a4fbb",
+            "input_file": "am00_44.mp4",
+            "output_format": "Unknown",
+            "result": "905e70a30106a8827146e839a4cb85ad"
+        },
+        {
+            "name": "al06_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06_48.mp4",
+            "source_checksum": "43c5ffba27fba57156518956d4a868e9",
+            "input_file": "al06_48.mp4",
+            "output_format": "Unknown",
+            "result": "4979e6a7e1e61e051c85d1b7d738845f"
+        },
+        {
+            "name": "as08_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as08_48.mp4",
+            "source_checksum": "80e16d98e501748fcd0fb30e1dbfb023",
+            "input_file": "as08_48.mp4",
+            "output_format": "Unknown",
+            "result": "a9e35a70084e01070ce82663131c4b97"
+        },
+        {
+            "name": "al07_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07_12.mp4",
+            "source_checksum": "c701278f3b3bd5caf30555448548250f",
+            "input_file": "al07_12.mp4",
+            "output_format": "Unknown",
+            "result": "d4de30fb19a0873a2357523a21a7c11f"
+        },
+        {
+            "name": "as03_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as03_88.mp4",
+            "source_checksum": "40ee7c92ea8d6fb60fa6c82ba1ea0273",
+            "input_file": "as03_88.mp4",
+            "output_format": "Unknown",
+            "result": "7c1d95a7d4e0291f22079effbf894a78"
+        },
+        {
+            "name": "al14_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14_32.mp4",
+            "source_checksum": "3ba1c2931ee9076190fa5ea49e9cf9a0",
+            "input_file": "al14_32.mp4",
+            "output_format": "Unknown",
+            "result": "72f133b209330a1f080383a4023dd753"
+        },
+        {
+            "name": "al_sbr_i_44_1_new",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_i_44_1_new.mp4",
+            "source_checksum": "5e650cd7dae12faed8e0cbfc13d3e281",
+            "input_file": "al_sbr_i_44_1_new.mp4",
+            "output_format": "Unknown",
+            "result": "a70374d141078b367be7a1160e5b13ca"
+        },
+        {
+            "name": "er_al10_96_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al10_96_ep0.mp4",
+            "source_checksum": "277c987e9f4ef1de38b973b28e387674",
+            "input_file": "er_al10_96_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al960_sbr_ps_05",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_ps_05.mp4",
+            "source_checksum": "2adf2cd7d54913f57baf4fb56d53c988",
+            "input_file": "al960_sbr_ps_05.mp4",
+            "output_format": "Unknown",
+            "result": "ab619b8b0ec5bd36e832f04d820a2c74"
+        },
+        {
+            "name": "al14_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14_24.mp4",
+            "source_checksum": "451dbefedcb621d1ca7d684cc8538f24",
+            "input_file": "al14_24.mp4",
+            "output_format": "Unknown",
+            "result": "744f7fd7aef4005110b26134c89938f6"
+        },
+        {
+            "name": "al14sf_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14sf_22.mp4",
+            "source_checksum": "9e8834057617c47cf95d4d048dd17013",
+            "input_file": "al14sf_22.mp4",
+            "output_format": "Unknown",
+            "result": "9e85dec1e7c4e72e889eeb3b9a7c5d02"
+        },
+        {
+            "name": "al00_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00_11.mp4",
+            "source_checksum": "f71f3a1241fe252de633e7fd18bc77f1",
+            "input_file": "al00_11.mp4",
+            "output_format": "Unknown",
+            "result": "6eb23f7d1b322d167f0c075234ad66ec"
+        },
+        {
+            "name": "as04_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as04_08.mp4",
+            "source_checksum": "4d1bc12cab3beff626aa28e9955e84a5",
+            "input_file": "as04_08.mp4",
+            "output_format": "Unknown",
+            "result": "b981e023626023db892096c76c051e28"
+        },
+        {
+            "name": "as01_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as01_24.mp4",
+            "source_checksum": "4dd9c4d686e453dd60790d9ee87f2140",
+            "input_file": "as01_24.mp4",
+            "output_format": "Unknown",
+            "result": "a8f4b97f487b82cbe3267f4e06c0f487"
+        },
+        {
+            "name": "as08_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as08_96.mp4",
+            "source_checksum": "d6e2e095158da990472d2706f2346519",
+            "input_file": "as08_96.mp4",
+            "output_format": "Unknown",
+            "result": "a5c6e4e4e267f3cf786c7ab76acbe9fa"
+        },
+        {
+            "name": "al19_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19_24.mp4",
+            "source_checksum": "e8f1b52b765f76868609c7081462f38b",
+            "input_file": "al19_24.mp4",
+            "output_format": "Unknown",
+            "result": "8ac8a8c2e0e6b9b7bcbb6c9c489d641c"
+        },
+        {
+            "name": "al_sbr_cm_48_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_cm_48_1.mp4",
+            "source_checksum": "581ed926ee8dda609c988c678102559e",
+            "input_file": "al_sbr_cm_48_1.mp4",
+            "output_format": "Unknown",
+            "result": "682330f700db73293256178436e38513"
+        },
+        {
+            "name": "am06_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am06_16.mp4",
+            "source_checksum": "30b5704a3979abe96b8060b89fd2cea0",
+            "input_file": "am06_16.mp4",
+            "output_format": "Unknown",
+            "result": "2fa55a073a12c11c4493c7ca920dd350"
+        },
+        {
+            "name": "al07_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07_11.mp4",
+            "source_checksum": "f7c21af5b33c66a915ffd08ca46603ff",
+            "input_file": "al07_11.mp4",
+            "output_format": "Unknown",
+            "result": "d4de30fb19a0873a2357523a21a7c11f"
+        },
+        {
+            "name": "al04sf_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04sf_96.mp4",
+            "source_checksum": "0c1a04af2c8175828c9124de129e20ca",
+            "input_file": "al04sf_96.mp4",
+            "output_format": "Unknown",
+            "result": "edb05b74da0fb44f78dc51c5c8e7369f"
+        },
+        {
+            "name": "er_ad1109_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1109_48_ep0.mp4",
+            "source_checksum": "3810716c26aa101b8cbfffa271398dae",
+            "input_file": "er_ad1109_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al_sbr_qmf_32_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_qmf_32_1.mp4",
+            "source_checksum": "9ec7742ee6e194a4b585b4e590408ed7",
+            "input_file": "al_sbr_qmf_32_1.mp4",
+            "output_format": "Unknown",
+            "result": "16b48aaf22d99be053334fb2b929c7c0"
+        },
+        {
+            "name": "al960_sbr_gh_44_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_gh_44_2.mp4",
+            "source_checksum": "d8529b6c87a56472848052670e7f23e3",
+            "input_file": "al960_sbr_gh_44_2.mp4",
+            "output_format": "Unknown",
+            "result": "883b2ace404bf1518adffcce25ddca9a"
+        },
+        {
+            "name": "al08sf_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08sf_12.mp4",
+            "source_checksum": "ae253dd4329465eeccb0affb70d62b9c",
+            "input_file": "al08sf_12.mp4",
+            "output_format": "Unknown",
+            "result": "85695b2defca606c821ed77f12a3d491"
+        },
+        {
+            "name": "er_ad1000_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1000_44_ep0.mp4",
+            "source_checksum": "0b9f7fb6bcfa23fe47533793d1920155",
+            "input_file": "er_ad1000_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al16_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16_11.mp4",
+            "source_checksum": "1059cdc022b1bb308eb842a4fd4e52d4",
+            "input_file": "al16_11.mp4",
+            "output_format": "Unknown",
+            "result": "db12a7bd65b38be3c2483a85f38e2247"
+        },
+        {
+            "name": "al17sf_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17sf_44.mp4",
+            "source_checksum": "91c6f9c05fbe3ca1ad03ac3c61f7b8a6",
+            "input_file": "al17sf_44.mp4",
+            "output_format": "Unknown",
+            "result": "784fdd0888e46c9ec4eb50a08fdb3cc6"
+        },
+        {
+            "name": "al_sbr_i_48_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_i_48_1.mp4",
+            "source_checksum": "d052544c6583c7bf715e75727a2b3ffb",
+            "input_file": "al_sbr_i_48_1.mp4",
+            "output_format": "Unknown",
+            "result": "02f0627ecaa1c48ea2f352e8dbff4af7"
+        },
+        {
+            "name": "al01_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01_11.mp4",
+            "source_checksum": "8318acdee6ce988f68e073ba200a7cf9",
+            "input_file": "al01_11.mp4",
+            "output_format": "Unknown",
+            "result": "68ebaf2c433c13381e815db62a7c3385"
+        },
+        {
+            "name": "as08_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as08_16.mp4",
+            "source_checksum": "4e7899af8f739c1b06d7c44ed94be536",
+            "input_file": "as08_16.mp4",
+            "output_format": "Unknown",
+            "result": "de780ed0c5bc65a8b7fc268dda22b8b5"
+        },
+        {
+            "name": "as01_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as01_32.mp4",
+            "source_checksum": "f880bdb9fcbf57d3de87e65e3b5d6e7c",
+            "input_file": "as01_32.mp4",
+            "output_format": "Unknown",
+            "result": "1c0e61a364a51f8e59d34d3f11caba1d"
+        },
+        {
+            "name": "er_ad1103np_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1103np_22_ep0.mp4",
+            "source_checksum": "58f29e7132b7aadb7a95b6df93ad294d",
+            "input_file": "er_ad1103np_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al08_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08_88.mp4",
+            "source_checksum": "a90054b220701a7e16de00f735051742",
+            "input_file": "al08_88.mp4",
+            "output_format": "Unknown",
+            "result": "c7f958f10a167fb8fdc45b83b0777386"
+        },
+        {
+            "name": "al05_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05_22.mp4",
+            "source_checksum": "f74dc46f856a4eaf0e8d9f51a0d3cc60",
+            "input_file": "al05_22.mp4",
+            "output_format": "Unknown",
+            "result": "c297fd5aba3dbe1b55f41757e0ad518d"
+        },
+        {
+            "name": "as16_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as16_88.mp4",
+            "source_checksum": "b1bcb17c66f458be90013c04494d481f",
+            "input_file": "as16_88.mp4",
+            "output_format": "Unknown",
+            "result": "28e85247ea8004cd8253429f6c1e7248"
+        },
+        {
+            "name": "am01_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am01_48.mp4",
+            "source_checksum": "bd805934ed8caaf89415f153e94ebbd5",
+            "input_file": "am01_48.mp4",
+            "output_format": "Unknown",
+            "result": "4a8e8fda92a0a62b6223ff70dc01a85d"
+        },
+        {
+            "name": "am00_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am00_32.mp4",
+            "source_checksum": "bf7d2f5d96d87e40f87bcd4b49712e7b",
+            "input_file": "am00_32.mp4",
+            "output_format": "Unknown",
+            "result": "6a9e8658270ddc3d3dc4bc52c7f9b4e4"
+        },
+        {
+            "name": "er_eld2100np_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld2100np_24_ep0.mp4",
+            "source_checksum": "393dc6c5bb2080b1cb1dacd8a6947969",
+            "input_file": "er_eld2100np_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al960_sbr_s_48_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_s_48_1.mp4",
+            "source_checksum": "b8d9951f3fe1681f1d1a4f0808385a54",
+            "input_file": "al960_sbr_s_48_1.mp4",
+            "output_format": "Unknown",
+            "result": "7054144b8149f522a913c43d18aadce4"
+        },
+        {
+            "name": "al08sf_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08sf_44.mp4",
+            "source_checksum": "adad2d11f9210feb7ee91ed862870251",
+            "input_file": "al08sf_44.mp4",
+            "output_format": "Unknown",
+            "result": "ac48dbb44e76757732c7060fce50b773"
+        },
+        {
+            "name": "al03sf_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03sf_44.mp4",
+            "source_checksum": "5f2b94996f409e1b45f390fcb60486af",
+            "input_file": "al03sf_44.mp4",
+            "output_format": "Unknown",
+            "result": "bc6428f68eeac99961b07928d5efb76f"
+        },
+        {
+            "name": "er_ad1009np_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1009np_48_ep0.mp4",
+            "source_checksum": "9ab09cd291073d8930061488bfee7e64",
+            "input_file": "er_ad1009np_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al08sf_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08sf_24.mp4",
+            "source_checksum": "da351f5cdc7375de4a0ab3ef268bd745",
+            "input_file": "al08sf_24.mp4",
+            "output_format": "Unknown",
+            "result": "25e9f186f207c855879a5f4a18686110"
+        },
+        {
+            "name": "as13_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as13_96.mp4",
+            "source_checksum": "c64887f5dcff8c1abd69991662b6205d",
+            "input_file": "as13_96.mp4",
+            "output_format": "Unknown",
+            "result": "4b65363c85dedf3aaf68e78c97abb2a4"
+        },
+        {
+            "name": "al02_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02_08.mp4",
+            "source_checksum": "ee3fe98c1b8899c42e09866ee31264a4",
+            "input_file": "al02_08.mp4",
+            "output_format": "Unknown",
+            "result": "48e6870f8ccdcaefacd80036e6971aa4"
+        },
+        {
+            "name": "al01_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01_22.mp4",
+            "source_checksum": "b375a5f20b21d8bba7f77baac3690e4c",
+            "input_file": "al01_22.mp4",
+            "output_format": "Unknown",
+            "result": "bac71f1c4723760f6c595287d8e8f7a1"
+        },
+        {
+            "name": "am06_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am06_64.mp4",
+            "source_checksum": "5e0485aa85d5c4bdc67749e0adaa202d",
+            "input_file": "am06_64.mp4",
+            "output_format": "Unknown",
+            "result": "562c1a3f2b9a334851d8c0ddd5caa009"
+        },
+        {
+            "name": "al02_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02_12.mp4",
+            "source_checksum": "c3fff529e25417b776e9cc4de7ea14c5",
+            "input_file": "al02_12.mp4",
+            "output_format": "Unknown",
+            "result": "fba7a9108012d70f844bbfe73f862d15"
+        },
+        {
+            "name": "al05sf_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05sf_32.mp4",
+            "source_checksum": "fb451fcca3ea2cb952788de0e7933fae",
+            "input_file": "al05sf_32.mp4",
+            "output_format": "Unknown",
+            "result": "1515aaa1eaa68dcce36c2a31d27dcd82"
+        },
+        {
+            "name": "al18_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18_12.mp4",
+            "source_checksum": "f0187c6c8f2168667209402cc143d287",
+            "input_file": "al18_12.mp4",
+            "output_format": "Unknown",
+            "result": "061939a764fc6b7eb1f36a8fa4238636"
+        },
+        {
+            "name": "as00_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as00_96.mp4",
+            "source_checksum": "e6ddf4e8c464cfc27a15781202132c57",
+            "input_file": "as00_96.mp4",
+            "output_format": "Unknown",
+            "result": "44ea7c5eec39221a7d480380ff7a3ce9"
+        },
+        {
+            "name": "al05sf_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05sf_11.mp4",
+            "source_checksum": "24ffa1875ca14f6ccaf8329d9beed458",
+            "input_file": "al05sf_11.mp4",
+            "output_format": "Unknown",
+            "result": "915e57e4e3865a3ea6a0d4e89f81ba45"
+        },
+        {
+            "name": "er_ad1109np_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1109np_32_ep0.mp4",
+            "source_checksum": "4836a604033b313898fea3fcbbf843f5",
+            "input_file": "er_ad1109np_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as10_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as10_32.mp4",
+            "source_checksum": "8058e568041f1214c43e6ef32e85d4ba",
+            "input_file": "as10_32.mp4",
+            "output_format": "Unknown",
+            "result": "ab0ddce25aaa8554c5eec91b10c0c546"
+        },
+        {
+            "name": "al_sbr_ps_00_new",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_ps_00_new.mp4",
+            "source_checksum": "7c5fb10c494b4034e87569906fc539f0",
+            "input_file": "al_sbr_ps_00_new.mp4",
+            "output_format": "Unknown",
+            "result": "ff9fc125a8e5b7e8df46429240c96ba4"
+        },
+        {
+            "name": "al05_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05_16.mp4",
+            "source_checksum": "e42f5eac7da03c274fab4a94c7e586c7",
+            "input_file": "al05_16.mp4",
+            "output_format": "Unknown",
+            "result": "3e17aa815d1dfbb8228c0723179d9840"
+        },
+        {
+            "name": "al_sbr_s_44_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_s_44_1.mp4",
+            "source_checksum": "73db622719933df9bc75d98b54e5d3b5",
+            "input_file": "al_sbr_s_44_1.mp4",
+            "output_format": "Unknown",
+            "result": "0974d6f7c1a3f2b642fe68754e81ecff"
+        },
+        {
+            "name": "er_eld1102np_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1102np_22_ep0.mp4",
+            "source_checksum": "08a77755bd5479a6b02a10f8b1b8fb6b",
+            "input_file": "er_eld1102np_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "am06_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am06_12.mp4",
+            "source_checksum": "670b46195b97da9da8b0372710b494f4",
+            "input_file": "am06_12.mp4",
+            "output_format": "Unknown",
+            "result": "4eef4f2de088143d72f56f490aec72dd"
+        },
+        {
+            "name": "al00_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00_48.mp4",
+            "source_checksum": "cd6366f7fed82e86241817be2e3e6b39",
+            "input_file": "al00_48.mp4",
+            "output_format": "Unknown",
+            "result": "81aed3ed01060d1453cc96ad6e8e7222"
+        },
+        {
+            "name": "al04_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04_88.mp4",
+            "source_checksum": "87b19eea1e2cf72fd6f14055f20b4124",
+            "input_file": "al04_88.mp4",
+            "output_format": "Unknown",
+            "result": "854a65ea3d37c7357482d415acaf826e"
+        },
+        {
+            "name": "as13_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as13_24.mp4",
+            "source_checksum": "3557998811c6ab68724b97e70552ea29",
+            "input_file": "as13_24.mp4",
+            "output_format": "Unknown",
+            "result": "02bfc42a74201206630237e4c7ad381e"
+        },
+        {
+            "name": "as10_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as10_88.mp4",
+            "source_checksum": "5001a715e54ad20f8fc53fa1b6549713",
+            "input_file": "as10_88.mp4",
+            "output_format": "Unknown",
+            "result": "89d1a1d770e20273220f50c283de459a"
+        },
+        {
+            "name": "as10_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as10_16.mp4",
+            "source_checksum": "d680372b0db8de741b2efd7f67098e00",
+            "input_file": "as10_16.mp4",
+            "output_format": "Unknown",
+            "result": "075d22277ae9e0a8b47cd7c028a4d3c0"
+        },
+        {
+            "name": "al16_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16_24.mp4",
+            "source_checksum": "56e495d1280159e92d018a79d6bdb98d",
+            "input_file": "al16_24.mp4",
+            "output_format": "Unknown",
+            "result": "504ea25bf408453edb069c8874792863"
+        },
+        {
+            "name": "er_ad1102_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1102_48_ep0.mp4",
+            "source_checksum": "a9f4c557eeadbd7e9d051b854141d04c",
+            "input_file": "er_ad1102_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as17_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as17_22.mp4",
+            "source_checksum": "2e6fc7e76d2ba6f2d5b7f6bd949dad20",
+            "input_file": "as17_22.mp4",
+            "output_format": "Unknown",
+            "result": "8f1c79031d95623682ecf9fd8e33392a"
+        },
+        {
+            "name": "al08_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08_32.mp4",
+            "source_checksum": "62459de49a6e9be86f8d5bc879e5952e",
+            "input_file": "al08_32.mp4",
+            "output_format": "Unknown",
+            "result": "f02dcaed96aa7113f6f34ab33a786383"
+        },
+        {
+            "name": "er_eld1102np_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1102np_32_ep0.mp4",
+            "source_checksum": "eeb11678bf04c63a25f937be84fca235",
+            "input_file": "er_eld1102np_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al960_sbr_s_32_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_s_32_1.mp4",
+            "source_checksum": "41dce26e032fc35ca19a8127eaa6032f",
+            "input_file": "al960_sbr_s_32_1.mp4",
+            "output_format": "Unknown",
+            "result": "ca721ee478a021dc0c5898fd8787b02d"
+        },
+        {
+            "name": "al_sbr_gh_32_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_gh_32_2.mp4",
+            "source_checksum": "2bc5ce4f62ba8f323c39aa3c34fc6c01",
+            "input_file": "al_sbr_gh_32_2.mp4",
+            "output_format": "Unknown",
+            "result": "cc5ab7419f5f8027200b21e798af3a42"
+        },
+        {
+            "name": "al17_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17_08.mp4",
+            "source_checksum": "80b44362426f21cc514481fde592f492",
+            "input_file": "al17_08.mp4",
+            "output_format": "Unknown",
+            "result": "9ce0c79e5a3b97ba1cd7f9051b9cb813"
+        },
+        {
+            "name": "as17_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as17_24.mp4",
+            "source_checksum": "7015de8c53f62f24d1e2b9f9a264ac9e",
+            "input_file": "as17_24.mp4",
+            "output_format": "Unknown",
+            "result": "5ec07fb1254f038776533d41dd00e67e"
+        },
+        {
+            "name": "am02_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am02_48.mp4",
+            "source_checksum": "45a57892591431abed93dcb5126fc287",
+            "input_file": "am02_48.mp4",
+            "output_format": "Unknown",
+            "result": "42ede1f447d7c892c3cd807ff886598b"
+        },
+        {
+            "name": "al03_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03_22.mp4",
+            "source_checksum": "4dfe4522d7a3f087178be379340ee410",
+            "input_file": "al03_22.mp4",
+            "output_format": "Unknown",
+            "result": "6819ba04cee182d2aa3247ed93b9923d"
+        },
+        {
+            "name": "al_sbr_cm_48_5",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_cm_48_5.mp4",
+            "source_checksum": "9061405c961b6ea6746820d0148797fe",
+            "input_file": "al_sbr_cm_48_5.mp4",
+            "output_format": "Unknown",
+            "result": "dd452ad3cf658a2f8b6462cc9a7c2e34"
+        },
+        {
+            "name": "am00_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am00_88.mp4",
+            "source_checksum": "5d39ca3d821e014b61465a96537b14ea",
+            "input_file": "am00_88.mp4",
+            "output_format": "Unknown",
+            "result": "4eb776d8feceb2839cc10c09e083eb25"
+        },
+        {
+            "name": "al_sbr_sr_48_2_fsaac24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_48_2_fsaac24.mp4",
+            "source_checksum": "9a3207a28b042f2689f27377d1891f12",
+            "input_file": "al_sbr_sr_48_2_fsaac24.mp4",
+            "output_format": "Unknown",
+            "result": "c010b74a09891368ab5db14471f8a732"
+        },
+        {
+            "name": "al16sf_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16sf_44.mp4",
+            "source_checksum": "8229f887c1d564e136394a654ba406bd",
+            "input_file": "al16sf_44.mp4",
+            "output_format": "Unknown",
+            "result": "4943294add67e3168b0686e549f1f707"
+        },
+        {
+            "name": "am04_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am04_08.mp4",
+            "source_checksum": "946b536b995470f91bf5f7a1e6c4390e",
+            "input_file": "am04_08.mp4",
+            "output_format": "Unknown",
+            "result": "64204501c5c229574ea019ccf153161c"
+        },
+        {
+            "name": "al05_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05_64.mp4",
+            "source_checksum": "0e8db5457d591fa8c76a664b528db698",
+            "input_file": "al05_64.mp4",
+            "output_format": "Unknown",
+            "result": "fd32fac5c93040674baf30e5ebf57c52"
+        },
+        {
+            "name": "as14_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as14_16.mp4",
+            "source_checksum": "686815d71fd3cbdb672dec42013dd71b",
+            "input_file": "as14_16.mp4",
+            "output_format": "Unknown",
+            "result": "481c7a271bd4621dac6475e038a66998"
+        },
+        {
+            "name": "al_sbr_i_32_1_new",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_i_32_1_new.mp4",
+            "source_checksum": "191d4ad6fd4aa33bba03fe046ee0aeeb",
+            "input_file": "al_sbr_i_32_1_new.mp4",
+            "output_format": "Unknown",
+            "result": "10ba4633f6062acf6cc07704f8f61f2f"
+        },
+        {
+            "name": "al06sf_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06sf_22.mp4",
+            "source_checksum": "4a5f502eebfd5a5a1cc598367e5c7cb2",
+            "input_file": "al06sf_22.mp4",
+            "output_format": "Unknown",
+            "result": "fd272f2518856dfd459c84cf9e7edc93"
+        },
+        {
+            "name": "al04_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04_48.mp4",
+            "source_checksum": "b23300879dc9ac8b3f84435169a589e1",
+            "input_file": "al04_48.mp4",
+            "output_format": "Unknown",
+            "result": "1f04cda750065aad2633d369241e9aed"
+        },
+        {
+            "name": "as07_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as07_12.mp4",
+            "source_checksum": "9980c9ae83e1e1beb9cc22352cd248a7",
+            "input_file": "as07_12.mp4",
+            "output_format": "Unknown",
+            "result": "b166a694a0cf6373bea354e056d5910b"
+        },
+        {
+            "name": "al19sf_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19sf_08.mp4",
+            "source_checksum": "62b84a4b3a3eace5498dee792fce3b63",
+            "input_file": "al19sf_08.mp4",
+            "output_format": "Unknown",
+            "result": "4b8f61b62b569778ded2ad8dc153d54b"
+        },
+        {
+            "name": "er_ad1000np_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1000np_48_ep0.mp4",
+            "source_checksum": "37f99e3230375016f305ff559be53862",
+            "input_file": "er_ad1000np_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al00sf_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00sf_08.mp4",
+            "source_checksum": "0c3e82af6f22daddccf34c1932e8e5c6",
+            "input_file": "al00sf_08.mp4",
+            "output_format": "Unknown",
+            "result": "974fc5db0dd85a5240956a8a5e593469"
+        },
+        {
+            "name": "al05sf_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05sf_12.mp4",
+            "source_checksum": "09d3a666bc9eb0f93e8a11c7fac48ee1",
+            "input_file": "al05sf_12.mp4",
+            "output_format": "Unknown",
+            "result": "afbc1483e6a4a6dc56901b63b047969f"
+        },
+        {
+            "name": "al18sf_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18sf_22.mp4",
+            "source_checksum": "8ef3828683844ed928ca7b4f9a547f38",
+            "input_file": "al18sf_22.mp4",
+            "output_format": "Unknown",
+            "result": "e63eb113224e3a9e911d2d6905cf8a84"
+        },
+        {
+            "name": "as00_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as00_64.mp4",
+            "source_checksum": "4bba3fba1c9591880d8301bb9c415f77",
+            "input_file": "as00_64.mp4",
+            "output_format": "Unknown",
+            "result": "1b1b0e509d85afae5f2b6df6ddecbadd"
+        },
+        {
+            "name": "al_sbr_ps_04",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_ps_04.mp4",
+            "source_checksum": "596100860fe4ed5e53fcfcd5a1648f73",
+            "input_file": "al_sbr_ps_04.mp4",
+            "output_format": "Unknown",
+            "result": "ad5b3235a5fe67a9554d4ef6ba1bd4aa"
+        },
+        {
+            "name": "al01_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01_24.mp4",
+            "source_checksum": "6618551acf5368df3246e6b9625bc53e",
+            "input_file": "al01_24.mp4",
+            "output_format": "Unknown",
+            "result": "2a1f9b80e590bf4009bdcc7feab11a47"
+        },
+        {
+            "name": "am01_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am01_08.mp4",
+            "source_checksum": "0cc565164f128fe7e95df2d7f918aa37",
+            "input_file": "am01_08.mp4",
+            "output_format": "Unknown",
+            "result": "b4f2c527b6adc44a166a76a103ed2c77"
+        },
+        {
+            "name": "al16_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16_32.mp4",
+            "source_checksum": "f599b1a5580bf0362cf8830e7db678e7",
+            "input_file": "al16_32.mp4",
+            "output_format": "Unknown",
+            "result": "d5a7bb819c3da7edb65c802b1f06dd8d"
+        },
+        {
+            "name": "al07sf_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07sf_08.mp4",
+            "source_checksum": "affa134e126228b86538668d9a469ece",
+            "input_file": "al07sf_08.mp4",
+            "output_format": "Unknown",
+            "result": "63f239c9de0913b0f88a6c5ebf2bb5ba"
+        },
+        {
+            "name": "er_eld1102np_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1102np_24_ep0.mp4",
+            "source_checksum": "2c3809437807ac57dc7cf5f1fbb3b768",
+            "input_file": "er_eld1102np_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al_sbr_sr_88_2_fsaac44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_88_2_fsaac44.mp4",
+            "source_checksum": "11065bff2f92ce7fce67aa83a43d48b5",
+            "input_file": "al_sbr_sr_88_2_fsaac44.mp4",
+            "output_format": "Unknown",
+            "result": "09da267e73a354bbc10a1c59f16e4131"
+        },
+        {
+            "name": "er_eld1002np_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1002np_22_ep0.mp4",
+            "source_checksum": "d558cfe29bfcd0fc67ecc51d3f7d2b1e",
+            "input_file": "er_eld1002np_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al04sf_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04sf_22.mp4",
+            "source_checksum": "ecb7092c35f7cc8103bed85626371ba3",
+            "input_file": "al04sf_22.mp4",
+            "output_format": "Unknown",
+            "result": "4fc2b48d87982cf7a70e12d167d3c1dd"
+        },
+        {
+            "name": "al07_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07_96.mp4",
+            "source_checksum": "7e561b5baa80f810ea925e0c94962be7",
+            "input_file": "al07_96.mp4",
+            "output_format": "Unknown",
+            "result": "dfe19829b88062d92c52c209e41153c3"
+        },
+        {
+            "name": "am00_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am00_16.mp4",
+            "source_checksum": "2cafacf01ee22ca81c571ffba0613f30",
+            "input_file": "am00_16.mp4",
+            "output_format": "Unknown",
+            "result": "746fc937c0c106feace2586d61b550f8"
+        },
+        {
+            "name": "as04_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as04_16.mp4",
+            "source_checksum": "03a8fc0507437b4e176c22ce6d21e50b",
+            "input_file": "as04_16.mp4",
+            "output_format": "Unknown",
+            "result": "2aa8ede9facecfd47e2da49c7e0b0bf1"
+        },
+        {
+            "name": "as03_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as03_11.mp4",
+            "source_checksum": "1f09faf75b79afdb8c760a77b82632d5",
+            "input_file": "as03_11.mp4",
+            "output_format": "Unknown",
+            "result": "5ae89c7acd05098ab622609fc0ea2750"
+        },
+        {
+            "name": "am01_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am01_44.mp4",
+            "source_checksum": "361d719e2ac4093db07011d60456b082",
+            "input_file": "am01_44.mp4",
+            "output_format": "Unknown",
+            "result": "a9fbe1ca9b4d6a40a9d05892191ad791"
+        },
+        {
+            "name": "al14sf_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14sf_44.mp4",
+            "source_checksum": "5a3d435c4846b028a89bbdce9983304e",
+            "input_file": "al14sf_44.mp4",
+            "output_format": "Unknown",
+            "result": "1ea3fc56401dc70963f7a6d7897a7377"
+        },
+        {
+            "name": "as15_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as15_32.mp4",
+            "source_checksum": "47075e542067cf5cb0929307152b69d0",
+            "input_file": "as15_32.mp4",
+            "output_format": "Unknown",
+            "result": "b68d6ea8dd4223af7d1e57497aaea2e8"
+        },
+        {
+            "name": "am05_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am05_64.mp4",
+            "source_checksum": "e3fea348af3f8f4d251e156c3580739c",
+            "input_file": "am05_64.mp4",
+            "output_format": "Unknown",
+            "result": "c5eaa7025e49b641709a8c962a9fec4f"
+        },
+        {
+            "name": "as01_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as01_12.mp4",
+            "source_checksum": "7d49c20438ba9a0105a73918c0b66b7d",
+            "input_file": "as01_12.mp4",
+            "output_format": "Unknown",
+            "result": "d83c4c702798b93f6e57812c4064ab1f"
+        },
+        {
+            "name": "as10_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as10_44.mp4",
+            "source_checksum": "a566fea96fb45fdaa5e4292d51f7f359",
+            "input_file": "as10_44.mp4",
+            "output_format": "Unknown",
+            "result": "66442b358ffc0b17ff458ebcb910a78d"
+        },
+        {
+            "name": "al19_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19_16.mp4",
+            "source_checksum": "b55947ba9d2966e4a84fc984cf2b7c82",
+            "input_file": "al19_16.mp4",
+            "output_format": "Unknown",
+            "result": "aee47ab6ccb523949594610942a8f47b"
+        },
+        {
+            "name": "as09_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as09_22.mp4",
+            "source_checksum": "a82ebabe9147f7dd88bc6d66852d16ee",
+            "input_file": "as09_22.mp4",
+            "output_format": "Unknown",
+            "result": "6b70f0fe4befa112330a1b4ca9ddd465"
+        },
+        {
+            "name": "er_al21_64_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al21_64_ep0.mp4",
+            "source_checksum": "5e8aec3c8343b2f3292d1321ed9b6171",
+            "input_file": "er_al21_64_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as09_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as09_48.mp4",
+            "source_checksum": "8004bb65fbf47c00666a32c9ee00d644",
+            "input_file": "as09_48.mp4",
+            "output_format": "Unknown",
+            "result": "27d560f65a1e11a757ad189a1f8bde77"
+        },
+        {
+            "name": "al_sbr_e_32_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_e_32_1.mp4",
+            "source_checksum": "49e90e0f2d2910d4cfe261fc6bbda42f",
+            "input_file": "al_sbr_e_32_1.mp4",
+            "output_format": "Unknown",
+            "result": "ae1e761c15d1c8f020031c3697d24b29"
+        },
+        {
+            "name": "al17_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17_88.mp4",
+            "source_checksum": "72fdc70697b00fe9a8495bc418c5b70a",
+            "input_file": "al17_88.mp4",
+            "output_format": "Unknown",
+            "result": "ad70e0b02635cfcb30c928dc70b4ef05"
+        },
+        {
+            "name": "al03_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03_11.mp4",
+            "source_checksum": "e7663a1b6ac7de4f706d4dd92362d378",
+            "input_file": "al03_11.mp4",
+            "output_format": "Unknown",
+            "result": "cb5054b764e9019be9d0fcbfe3776835"
+        },
+        {
+            "name": "al00sf_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00sf_48.mp4",
+            "source_checksum": "25ad69747d03ae0ac7d418f4ce39daea",
+            "input_file": "al00sf_48.mp4",
+            "output_format": "Unknown",
+            "result": "81aed3ed01060d1453cc96ad6e8e7222"
+        },
+        {
+            "name": "al18_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18_08.mp4",
+            "source_checksum": "c946f1f016063a413f968a13be610716",
+            "input_file": "al18_08.mp4",
+            "output_format": "Unknown",
+            "result": "ce99bac5016f9d4393d9441749ef5a09"
+        },
+        {
+            "name": "am06_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am06_48.mp4",
+            "source_checksum": "702e52f621d0d8132c1f9a71b258973d",
+            "input_file": "am06_48.mp4",
+            "output_format": "Unknown",
+            "result": "390b741d1eb0c883d7fa8774bd335c91"
+        },
+        {
+            "name": "as08_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as08_44.mp4",
+            "source_checksum": "04f26e1a759b3c6dc832ba2ece1a99e1",
+            "input_file": "as08_44.mp4",
+            "output_format": "Unknown",
+            "result": "cf0ed6a192d5677699cdd2d0ed48690e"
+        },
+        {
+            "name": "al06_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06_08.mp4",
+            "source_checksum": "05efe944476e4f1f22f3369dd3a0eb4d",
+            "input_file": "al06_08.mp4",
+            "output_format": "Unknown",
+            "result": "0e0cc8a25f7eb161f66ee3bc65199d04"
+        },
+        {
+            "name": "al08sf_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08sf_32.mp4",
+            "source_checksum": "338b1e7b27644c6951324baa3e075eea",
+            "input_file": "al08sf_32.mp4",
+            "output_format": "Unknown",
+            "result": "e95f1e6d5163cbfb193954a07dea2faf"
+        },
+        {
+            "name": "al19_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19_64.mp4",
+            "source_checksum": "bbadeae1fb61300620b18c1323466584",
+            "input_file": "al19_64.mp4",
+            "output_format": "Unknown",
+            "result": "b9601c4648ba1e8dab602dbcd3259fbd"
+        },
+        {
+            "name": "am05_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am05_88.mp4",
+            "source_checksum": "a95635aba8b3c7a1dc3c53da736461d0",
+            "input_file": "am05_88.mp4",
+            "output_format": "Unknown",
+            "result": "f31e04e2cec603917d83a0d567b829a8"
+        },
+        {
+            "name": "al_sbr_ps_00",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_ps_00.mp4",
+            "source_checksum": "1289909057f413705e21e636c333929b",
+            "input_file": "al_sbr_ps_00.mp4",
+            "output_format": "Unknown",
+            "result": "ff9fc125a8e5b7e8df46429240c96ba4"
+        },
+        {
+            "name": "al16_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16_16.mp4",
+            "source_checksum": "f34efbd30a07ed4240a77e9cadf66b51",
+            "input_file": "al16_16.mp4",
+            "output_format": "Unknown",
+            "result": "0f98f372b70cdb58f24d868c6c792610"
+        },
+        {
+            "name": "as07_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as07_64.mp4",
+            "source_checksum": "c2dbe49ff073639b4fe2c96e2c3255d4",
+            "input_file": "as07_64.mp4",
+            "output_format": "Unknown",
+            "result": "c8dccbd7a2c94b812341b369757f2cf6"
+        },
+        {
+            "name": "er_eld1100np_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1100np_44_ep0.mp4",
+            "source_checksum": "6a00489d914334bb340faeb21ce0ca00",
+            "input_file": "er_eld1100np_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al_sbr_cm_48_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_cm_48_2.mp4",
+            "source_checksum": "878de38bdc2098de27bbf0c197b53f13",
+            "input_file": "al_sbr_cm_48_2.mp4",
+            "output_format": "Unknown",
+            "result": "a499497146f4fad33840c170e012681b"
+        },
+        {
+            "name": "er_ad1109_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1109_44_ep0.mp4",
+            "source_checksum": "3f9de602e7072083a42da719ee29a1e9",
+            "input_file": "er_ad1109_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al19sf_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19sf_48.mp4",
+            "source_checksum": "d1837c5c2020aec89317235fce6dcf7c",
+            "input_file": "al19sf_48.mp4",
+            "output_format": "Unknown",
+            "result": "c71aa3b9ac1c80c4874b8387bc7f0bc3"
+        },
+        {
+            "name": "al_sbr_i_44_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_i_44_1.mp4",
+            "source_checksum": "7da09760f4387b6ba5acf9c8febcf713",
+            "input_file": "al_sbr_i_44_1.mp4",
+            "output_format": "Unknown",
+            "result": "c9f4bc6d0c13befe6362c90f6da70a1f"
+        },
+        {
+            "name": "al_sbr_e_48_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_e_48_2.mp4",
+            "source_checksum": "c437f7aa57eb4759699921ef97841525",
+            "input_file": "al_sbr_e_48_2.mp4",
+            "output_format": "Unknown",
+            "result": "68b2380c411572398879e1af58948307"
+        },
+        {
+            "name": "al05_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05_44.mp4",
+            "source_checksum": "b29aa529c53cab58795e62eb7818685c",
+            "input_file": "al05_44.mp4",
+            "output_format": "Unknown",
+            "result": "33f981c92cde037b3941040e2ae8bafa"
+        },
+        {
+            "name": "al14_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14_64.mp4",
+            "source_checksum": "c0c4ad65a59c92b2bb355250c17b933f",
+            "input_file": "al14_64.mp4",
+            "output_format": "Unknown",
+            "result": "fee87c426ffe310d83008121fa592bd9"
+        },
+        {
+            "name": "er_eld1102np_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1102np_48_ep0.mp4",
+            "source_checksum": "b3ed0ac9e400c0daa04a7a9e689b405c",
+            "input_file": "er_eld1102np_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al08sf_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08sf_22.mp4",
+            "source_checksum": "e325d7345813c03e3d9fbdb13927268e",
+            "input_file": "al08sf_22.mp4",
+            "output_format": "Unknown",
+            "result": "05c041101be07734c5b7eb4619dea481"
+        },
+        {
+            "name": "al03_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03_08.mp4",
+            "source_checksum": "c1e1b1b960fd00d52f0a7b1ba6c4df03",
+            "input_file": "al03_08.mp4",
+            "output_format": "Unknown",
+            "result": "9e0c9f7586ea7460b87d47f03a2e64d9"
+        },
+        {
+            "name": "er_eld1001np_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1001np_48_ep0.mp4",
+            "source_checksum": "3c3fb465914729c1ac698cac8a5e0b14",
+            "input_file": "er_eld1001np_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "er_ad1000_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1000_22_ep0.mp4",
+            "source_checksum": "be35f725aea4661a26e90e371c99cf86",
+            "input_file": "er_ad1000_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "am02_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am02_11.mp4",
+            "source_checksum": "43d9f6c2a4a45ad7ebec3aa365f6af34",
+            "input_file": "am02_11.mp4",
+            "output_format": "Unknown",
+            "result": "ed1a0e50311aa8492c56b9d7c2882273"
+        },
+        {
+            "name": "al960_sbr_gh_48_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_gh_48_1.mp4",
+            "source_checksum": "dc76be858b2f52b63a3ac31664ae5068",
+            "input_file": "al960_sbr_gh_48_1.mp4",
+            "output_format": "Unknown",
+            "result": "153279190030d7884713c59f389f9496"
+        },
+        {
+            "name": "al01sf_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01sf_32.mp4",
+            "source_checksum": "621cf292764263787e1d2294c9da6ff5",
+            "input_file": "al01sf_32.mp4",
+            "output_format": "Unknown",
+            "result": "62c5dda7e168f22fe5d1f45e4b8626a1"
+        },
+        {
+            "name": "al07sf_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07sf_22.mp4",
+            "source_checksum": "59504e213fb5d141fe02b2a2537f7e01",
+            "input_file": "al07sf_22.mp4",
+            "output_format": "Unknown",
+            "result": "3b76ec8fd5fa3d75b1ed903b712a8cad"
+        },
+        {
+            "name": "as04_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as04_32.mp4",
+            "source_checksum": "5d0bd68b8541b01f3e890c8d543fac45",
+            "input_file": "as04_32.mp4",
+            "output_format": "Unknown",
+            "result": "5d727123f8f9b07c5e0eae9bf445b72e"
+        },
+        {
+            "name": "al_sbr_sig_48_2_sig1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sig_48_2_sig1.mp4",
+            "source_checksum": "51710c3362c2eb1f2c0b3eb4b28d2f23",
+            "input_file": "al_sbr_sig_48_2_sig1.mp4",
+            "output_format": "Unknown",
+            "result": "c010b74a09891368ab5db14471f8a732"
+        },
+        {
+            "name": "er_eld1000np_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1000np_24_ep0.mp4",
+            "source_checksum": "017173db6979bb2d9894a5ee7b29af6e",
+            "input_file": "er_eld1000np_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al17_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17_11.mp4",
+            "source_checksum": "b761d19038a0311c35cb2f755581dc64",
+            "input_file": "al17_11.mp4",
+            "output_format": "Unknown",
+            "result": "77d09b536b5c5cc251faa21e5aecb413"
+        },
+        {
+            "name": "al01_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01_08.mp4",
+            "source_checksum": "4b82c44a4495789bc15262c242b65123",
+            "input_file": "al01_08.mp4",
+            "output_format": "Unknown",
+            "result": "341ba3ace921eb3a805d31cb5c69852a"
+        },
+        {
+            "name": "al960_sbr_qmf_44_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_qmf_44_1.mp4",
+            "source_checksum": "8c185c545b6920328923c9e119015ba5",
+            "input_file": "al960_sbr_qmf_44_1.mp4",
+            "output_format": "Unknown",
+            "result": "e9f31c7a0b24c0bb559ab73465ad4ac0"
+        },
+        {
+            "name": "er_eld1101np_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1101np_48_ep0.mp4",
+            "source_checksum": "bb0db8c18babc2127dcf23325c138c52",
+            "input_file": "er_eld1101np_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al07sf_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07sf_96.mp4",
+            "source_checksum": "f6a1ceaaf805494e859fa98817f02cf1",
+            "input_file": "al07sf_96.mp4",
+            "output_format": "Unknown",
+            "result": "dfe19829b88062d92c52c209e41153c3"
+        },
+        {
+            "name": "al_sbr_sr_16_2_fsaac16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_16_2_fsaac16.mp4",
+            "source_checksum": "83707bc096568aa0599364441da254a0",
+            "input_file": "al_sbr_sr_16_2_fsaac16.mp4",
+            "output_format": "Unknown",
+            "result": "64d7a3d773d9b83567438992d4c06149"
+        },
+        {
+            "name": "as11_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as11_96.mp4",
+            "source_checksum": "de27ae692e901e74dbcd4d3906131fcf",
+            "input_file": "as11_96.mp4",
+            "output_format": "Unknown",
+            "result": "3877801e23700673823b2678c93c8e3e"
+        },
+        {
+            "name": "as16_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as16_16.mp4",
+            "source_checksum": "7b2e8fe46f2f80c5ececa21f37fbcd2e",
+            "input_file": "as16_16.mp4",
+            "output_format": "Unknown",
+            "result": "481c7a271bd4621dac6475e038a66998"
+        },
+        {
+            "name": "as05_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as05_96.mp4",
+            "source_checksum": "377f9a0aff3e7316c544db6b92f788c2",
+            "input_file": "as05_96.mp4",
+            "output_format": "Unknown",
+            "result": "692a1720c71b0f8ed917ddf21a38f390"
+        },
+        {
+            "name": "al08_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08_11.mp4",
+            "source_checksum": "32a04ca4afa3169cd6ebf415733ad7cb",
+            "input_file": "al08_11.mp4",
+            "output_format": "Unknown",
+            "result": "8f15c703a727432ceb9102ba19accc12"
+        },
+        {
+            "name": "as09_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as09_16.mp4",
+            "source_checksum": "3a258273cc5fa46bb765dcb103097edc",
+            "input_file": "as09_16.mp4",
+            "output_format": "Unknown",
+            "result": "5a610ae32b3dc675c9b76f7d31426795"
+        },
+        {
+            "name": "al01sf_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01sf_22.mp4",
+            "source_checksum": "87457ed95eb206ce0066c72c3abbc30a",
+            "input_file": "al01sf_22.mp4",
+            "output_format": "Unknown",
+            "result": "bac71f1c4723760f6c595287d8e8f7a1"
+        },
+        {
+            "name": "er_eld2000np_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld2000np_32_ep0.mp4",
+            "source_checksum": "0003233dce8db074c0241d731fc302a5",
+            "input_file": "er_eld2000np_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al02sf_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02sf_96.mp4",
+            "source_checksum": "23d41b62d5c798a70702422f7b373abe",
+            "input_file": "al02sf_96.mp4",
+            "output_format": "Unknown",
+            "result": "c91d263e846628e4060cdef6c9b5c81d"
+        },
+        {
+            "name": "am07_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am07_22.mp4",
+            "source_checksum": "f8e817085063beab9c2e27885f82bb64",
+            "input_file": "am07_22.mp4",
+            "output_format": "Unknown",
+            "result": "2e6967553f45465c82405c76f854f91c"
+        },
+        {
+            "name": "al_sbr_s_48_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_s_48_1.mp4",
+            "source_checksum": "47ef66d48ae5531b69896add749368ee",
+            "input_file": "al_sbr_s_48_1.mp4",
+            "output_format": "Unknown",
+            "result": "21e5b8b6cff83957c08799388fe8bcff"
+        },
+        {
+            "name": "al16_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16_08.mp4",
+            "source_checksum": "1a67d3584403b85e3a0f3c2fa36f7d50",
+            "input_file": "al16_08.mp4",
+            "output_format": "Unknown",
+            "result": "830d1866388b7301c96146e0e0614397"
+        },
+        {
+            "name": "as11_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as11_32.mp4",
+            "source_checksum": "68b82a241d8e9e211412440ec014c7c0",
+            "input_file": "as11_32.mp4",
+            "output_format": "Unknown",
+            "result": "52b9b783e682ce807b26425bfd01bbe7"
+        },
+        {
+            "name": "er_al21_16_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al21_16_ep0.mp4",
+            "source_checksum": "3d5c816c9a34cf057dd575112ef6a2f4",
+            "input_file": "er_al21_16_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al_sbr_i_48_1_new",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_i_48_1_new.mp4",
+            "source_checksum": "a9a67a69b6a676c273685b77f81d1528",
+            "input_file": "al_sbr_i_48_1_new.mp4",
+            "output_format": "Unknown",
+            "result": "4fabfb7d251a82733fc21624a5d67454"
+        },
+        {
+            "name": "al18_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18_24.mp4",
+            "source_checksum": "e0047fd1173f0bfe9b53b9e683ee13bb",
+            "input_file": "al18_24.mp4",
+            "output_format": "Unknown",
+            "result": "e389702831ef5798b8d9bf4b6a0cd482"
+        },
+        {
+            "name": "al06_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06_11.mp4",
+            "source_checksum": "bc8794a266ab4892163bdeca474bc6dc",
+            "input_file": "al06_11.mp4",
+            "output_format": "Unknown",
+            "result": "b1d3abe29c049fae6f83b218f7bc0677"
+        },
+        {
+            "name": "as06_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as06_32.mp4",
+            "source_checksum": "93aa58eac841d0dd885607905ae9e514",
+            "input_file": "as06_32.mp4",
+            "output_format": "Unknown",
+            "result": "fcf22800a2bd08404106ba73071589e9"
+        },
+        {
+            "name": "as14_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as14_32.mp4",
+            "source_checksum": "cbf0c36119afc25dd1d31232ffd43e74",
+            "input_file": "as14_32.mp4",
+            "output_format": "Unknown",
+            "result": "b4b3c045e136191c6d42df8fc352d3cf"
+        },
+        {
+            "name": "as04_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as04_24.mp4",
+            "source_checksum": "412146438500065cf6879587d9d9130c",
+            "input_file": "as04_24.mp4",
+            "output_format": "Unknown",
+            "result": "05807367a5683dedb6d3d549cd10db77"
+        },
+        {
+            "name": "al_sbr_gh_44_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_gh_44_2.mp4",
+            "source_checksum": "233d3417b96149bae78a49a7271ee442",
+            "input_file": "al_sbr_gh_44_2.mp4",
+            "output_format": "Unknown",
+            "result": "9e74b05d967bad0e6858634b54271171"
+        },
+        {
+            "name": "al17_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17_16.mp4",
+            "source_checksum": "b6b39006eb0a8d9adff466ece23794ef",
+            "input_file": "al17_16.mp4",
+            "output_format": "Unknown",
+            "result": "578f691643c105bc6e12665c4f595a0a"
+        },
+        {
+            "name": "al02sf_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02sf_88.mp4",
+            "source_checksum": "feb6615811409aca30c98c14e23df993",
+            "input_file": "al02sf_88.mp4",
+            "output_format": "Unknown",
+            "result": "ea940a21c761f8e87cb3b2b8ceb91ebd"
+        },
+        {
+            "name": "as01_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as01_48.mp4",
+            "source_checksum": "4df496356317b2f7c9ab30d638313cbc",
+            "input_file": "as01_48.mp4",
+            "output_format": "Unknown",
+            "result": "39601f6c36e9bed60b5e2b1d700a9acf"
+        },
+        {
+            "name": "al_sbr_ps_04_new",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_ps_04_new.mp4",
+            "source_checksum": "568183c0cdc6c457615f513c0f69aa14",
+            "input_file": "al_sbr_ps_04_new.mp4",
+            "output_format": "Unknown",
+            "result": "ad5b3235a5fe67a9554d4ef6ba1bd4aa"
+        },
+        {
+            "name": "al16_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16_64.mp4",
+            "source_checksum": "15405956bcffeac73437683938222e0b",
+            "input_file": "al16_64.mp4",
+            "output_format": "Unknown",
+            "result": "0428ad19c2ec717d2e7d4a8bddaa10c3"
+        },
+        {
+            "name": "am02_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am02_16.mp4",
+            "source_checksum": "793b296d3099767c80f61f2638e1fbe7",
+            "input_file": "am02_16.mp4",
+            "output_format": "Unknown",
+            "result": "52524ae6d48844ed21487ca2bbadb4e7"
+        },
+        {
+            "name": "al17_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17_64.mp4",
+            "source_checksum": "077bf181b5ad396cf05869612dabcfc8",
+            "input_file": "al17_64.mp4",
+            "output_format": "Unknown",
+            "result": "9c3bc834d40d27a441ab80ae72eda8c4"
+        },
+        {
+            "name": "as10_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as10_64.mp4",
+            "source_checksum": "66d4345f49153feb4b4d62ca06cc89ff",
+            "input_file": "as10_64.mp4",
+            "output_format": "Unknown",
+            "result": "f098fc1ece5df2f3e5ae72b49f7801ec"
+        },
+        {
+            "name": "er_ad1100np_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1100np_24_ep0.mp4",
+            "source_checksum": "5490d765586367e654fc1d9184c093c0",
+            "input_file": "er_ad1100np_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al_sbr_qmf_44_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_qmf_44_1.mp4",
+            "source_checksum": "49e24a234a72f0b50d0fbed854bacf89",
+            "input_file": "al_sbr_qmf_44_1.mp4",
+            "output_format": "Unknown",
+            "result": "cc1682eb7e170cffd97970ebb7834152"
+        },
+        {
+            "name": "tts5",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/tts5.mp4",
+            "source_checksum": "6e22a16904f06188aeb25f902dba4303",
+            "input_file": "tts5.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as12_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as12_22.mp4",
+            "source_checksum": "79da384fc8e245c6291989feddc9a3b1",
+            "input_file": "as12_22.mp4",
+            "output_format": "Unknown",
+            "result": "793bdf4e548eec828ae840f15c7c8417"
+        },
+        {
+            "name": "al18sf_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18sf_11.mp4",
+            "source_checksum": "bf97a2a9057e211a5a4c3998a00ee10c",
+            "input_file": "al18sf_11.mp4",
+            "output_format": "Unknown",
+            "result": "448234b88743b1d98d68130810f33293"
+        },
+        {
+            "name": "as14_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as14_11.mp4",
+            "source_checksum": "e842304ce84f248dc9f42cf782d2d294",
+            "input_file": "as14_11.mp4",
+            "output_format": "Unknown",
+            "result": "66be4d61aa2181af657c5da70f141a96"
+        },
+        {
+            "name": "al960_sbr_i_48_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_i_48_2.mp4",
+            "source_checksum": "34818d6ef2f6715fec963ff847340b71",
+            "input_file": "al960_sbr_i_48_2.mp4",
+            "output_format": "Unknown",
+            "result": "5e5e75b11df5b41b7ad8fc242019dfe6"
+        },
+        {
+            "name": "al06sf_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06sf_96.mp4",
+            "source_checksum": "5c7d524b1cdb9374ac790b20a59cc74c",
+            "input_file": "al06sf_96.mp4",
+            "output_format": "Unknown",
+            "result": "907f07b128d154b6eedd113c495a0473"
+        },
+        {
+            "name": "er_ad1102_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1102_32_ep0.mp4",
+            "source_checksum": "0ef1d4b154ba64f497d351b111ab51ca",
+            "input_file": "er_ad1102_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "er_ad1102_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1102_24_ep0.mp4",
+            "source_checksum": "3fe5ffea36b9fd880094a8a6f1d1a041",
+            "input_file": "er_ad1102_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "am06_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am06_08.mp4",
+            "source_checksum": "ff36a115598cab35eb8ff42237451ab4",
+            "input_file": "am06_08.mp4",
+            "output_format": "Unknown",
+            "result": "d18699c6289b982368a766654cae0327"
+        },
+        {
+            "name": "al14sf_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14sf_32.mp4",
+            "source_checksum": "161d4b00cb5d5b185ed72faf23b245e5",
+            "input_file": "al14sf_32.mp4",
+            "output_format": "Unknown",
+            "result": "72f133b209330a1f080383a4023dd753"
+        },
+        {
+            "name": "al04_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04_12.mp4",
+            "source_checksum": "0b24ddbfd4acf8a4757f8228eb2df7f0",
+            "input_file": "al04_12.mp4",
+            "output_format": "Unknown",
+            "result": "4320324e32f3eb59a745643911e04e99"
+        },
+        {
+            "name": "al17sf_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17sf_12.mp4",
+            "source_checksum": "1aaa7865d57a2fb502a8be4653d7195a",
+            "input_file": "al17sf_12.mp4",
+            "output_format": "Unknown",
+            "result": "bca856a6877d9a5324d8a1cf5cf8864c"
+        },
+        {
+            "name": "tts2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/tts2.mp4",
+            "source_checksum": "b3acd62b59ebc27f15d0e44ac7fcbffd",
+            "input_file": "tts2.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as11_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as11_88.mp4",
+            "source_checksum": "82ebdb128449b938b62af3a798a83dda",
+            "input_file": "as11_88.mp4",
+            "output_format": "Unknown",
+            "result": "77b571d0663181c946c4707c98dda8fd"
+        },
+        {
+            "name": "al00_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00_16.mp4",
+            "source_checksum": "c7da330147aec23623246d501dfe8111",
+            "input_file": "al00_16.mp4",
+            "output_format": "Unknown",
+            "result": "5c6c8350621b3ba4c744712746c66213"
+        },
+        {
+            "name": "as14_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as14_64.mp4",
+            "source_checksum": "a003f362198661240d567b6584de59b5",
+            "input_file": "as14_64.mp4",
+            "output_format": "Unknown",
+            "result": "f2c8633c48bbec94ce6d900aaf4d1bd2"
+        },
+        {
+            "name": "as06_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as06_88.mp4",
+            "source_checksum": "eae59b3ac9a016aa9df474e34ff7bc30",
+            "input_file": "as06_88.mp4",
+            "output_format": "Unknown",
+            "result": "d9fcaa849e98d43d5c9e1272cb45ed5a"
+        },
+        {
+            "name": "ap01_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/ap01_48.mp4",
+            "source_checksum": "bcbf4a494981134650d562aedce44a74",
+            "input_file": "ap01_48.mp4",
+            "output_format": "Unknown",
+            "result": "cb8a260c08236e342d2122496ae126d9"
+        },
+        {
+            "name": "al14sf_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14sf_16.mp4",
+            "source_checksum": "ba2371cfd829ca5ba99958389044a13d",
+            "input_file": "al14sf_16.mp4",
+            "output_format": "Unknown",
+            "result": "adcf17383ea63c860aca7c047bb4acd5"
+        },
+        {
+            "name": "er_eld1001np_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1001np_32_ep0.mp4",
+            "source_checksum": "06d214ebddbf836a898ded9e050cbc49",
+            "input_file": "er_eld1001np_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "am04_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am04_48.mp4",
+            "source_checksum": "6e1a45c0ad27e730bfed9aac3bf136bd",
+            "input_file": "am04_48.mp4",
+            "output_format": "Unknown",
+            "result": "c82d341d09df47d7cd95980103a5047b"
+        },
+        {
+            "name": "al05sf_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05sf_88.mp4",
+            "source_checksum": "fc1311b24a9a75ab7c973d7f0fbbaf31",
+            "input_file": "al05sf_88.mp4",
+            "output_format": "Unknown",
+            "result": "6b609311bb4090654a70cda3b6df7ee4"
+        },
+        {
+            "name": "al07_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07_44.mp4",
+            "source_checksum": "5b89e95ae190edda4f0c6d4c04984823",
+            "input_file": "al07_44.mp4",
+            "output_format": "Unknown",
+            "result": "70d924177e92b84d441cc00df378b2c0"
+        },
+        {
+            "name": "as17_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as17_64.mp4",
+            "source_checksum": "cc346f622afb7c1c1b4c32c594bcb792",
+            "input_file": "as17_64.mp4",
+            "output_format": "Unknown",
+            "result": "95e70c5865bb22a9b7389af0b3d024fb"
+        },
+        {
+            "name": "as13_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as13_22.mp4",
+            "source_checksum": "09cd56caaf9a706ba648bde7ff2091e9",
+            "input_file": "as13_22.mp4",
+            "output_format": "Unknown",
+            "result": "3845021412db78720068ec2dcd901fc3"
+        },
+        {
+            "name": "al02_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02_48.mp4",
+            "source_checksum": "7bfee22ba34a2809b56825412ca40c3f",
+            "input_file": "al02_48.mp4",
+            "output_format": "Unknown",
+            "result": "efce3a472bba51ef2c22a68981f7bd40"
+        },
+        {
+            "name": "al04_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04_22.mp4",
+            "source_checksum": "e725ed8ab39ebb8cdb4e6f8b4e261213",
+            "input_file": "al04_22.mp4",
+            "output_format": "Unknown",
+            "result": "4fc2b48d87982cf7a70e12d167d3c1dd"
+        },
+        {
+            "name": "am07_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am07_12.mp4",
+            "source_checksum": "543475df8b2672c11c527558f7e655ef",
+            "input_file": "am07_12.mp4",
+            "output_format": "Unknown",
+            "result": "97ebb8e64754d2f61049ae3a3ba14ff7"
+        },
+        {
+            "name": "as17_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as17_12.mp4",
+            "source_checksum": "1b6ba485ba74569bc4cbbfaddc467d06",
+            "input_file": "as17_12.mp4",
+            "output_format": "Unknown",
+            "result": "5a4f0593e9931db3b638b234a6796cc0"
+        },
+        {
+            "name": "as08_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as08_88.mp4",
+            "source_checksum": "4cd00c15be53afa276a650ad99503a90",
+            "input_file": "as08_88.mp4",
+            "output_format": "Unknown",
+            "result": "617034d7418dbaf0d71811fb915d8a53"
+        },
+        {
+            "name": "al_sbr_twi_22_1_fsaac22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_twi_22_1_fsaac22.mp4",
+            "source_checksum": "cf3eb2f924b0bc62f3908a267f11e8e7",
+            "input_file": "al_sbr_twi_22_1_fsaac22.mp4",
+            "output_format": "Unknown",
+            "result": "f7974dc6279606de06de596689e96467"
+        },
+        {
+            "name": "al01sf_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01sf_08.mp4",
+            "source_checksum": "c26a53dca13784e41bf7b17ba459b5b9",
+            "input_file": "al01sf_08.mp4",
+            "output_format": "Unknown",
+            "result": "341ba3ace921eb3a805d31cb5c69852a"
+        },
+        {
+            "name": "am05_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am05_24.mp4",
+            "source_checksum": "b75591d27f6348ecbccab61e62ad8da7",
+            "input_file": "am05_24.mp4",
+            "output_format": "Unknown",
+            "result": "d05aeabaf1ead030a43b70110df7e59a"
+        },
+        {
+            "name": "al17_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17_96.mp4",
+            "source_checksum": "b21f85bd4df3104e6d2731413a2d421b",
+            "input_file": "al17_96.mp4",
+            "output_format": "Unknown",
+            "result": "2db5470e36e27f85dbbe9e49d1ff0c13"
+        },
+        {
+            "name": "as01_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as01_08.mp4",
+            "source_checksum": "89069280aaa5ab6549d6858d57c64b3b",
+            "input_file": "as01_08.mp4",
+            "output_format": "Unknown",
+            "result": "0b43057f093305a27b52f168adaaf255"
+        },
+        {
+            "name": "er_eld1002np_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1002np_32_ep0.mp4",
+            "source_checksum": "8652d266e57dd7c62aad4c9c2d8a0d5a",
+            "input_file": "er_eld1002np_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al17sf_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17sf_96.mp4",
+            "source_checksum": "4846bf6828d3434f0dbcd6f59cf4d903",
+            "input_file": "al17sf_96.mp4",
+            "output_format": "Unknown",
+            "result": "2db5470e36e27f85dbbe9e49d1ff0c13"
+        },
+        {
+            "name": "al07sf_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07sf_12.mp4",
+            "source_checksum": "817119f677a9964908ac131eb2bd2f83",
+            "input_file": "al07sf_12.mp4",
+            "output_format": "Unknown",
+            "result": "d4de30fb19a0873a2357523a21a7c11f"
+        },
+        {
+            "name": "al17sf_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17sf_48.mp4",
+            "source_checksum": "593fd8d4dcc051a895266bcc8b28e648",
+            "input_file": "al17sf_48.mp4",
+            "output_format": "Unknown",
+            "result": "639ae11166bd1ce3bd23b4d5337008c8"
+        },
+        {
+            "name": "er_eld1100np_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1100np_22_ep0.mp4",
+            "source_checksum": "305917a2a2ed2da901a327a724f404f1",
+            "input_file": "er_eld1100np_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "am05_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am05_32.mp4",
+            "source_checksum": "66deb0b5089e88dbccfd35a5ac811572",
+            "input_file": "am05_32.mp4",
+            "output_format": "Unknown",
+            "result": "a95557a582722c77973a9bbabf198529"
+        },
+        {
+            "name": "al01sf_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01sf_96.mp4",
+            "source_checksum": "618a01f96456473488a29e8b8b8889d3",
+            "input_file": "al01sf_96.mp4",
+            "output_format": "Unknown",
+            "result": "4677b93aa04c55103ebd1dce77c6f4c8"
+        },
+        {
+            "name": "al03_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03_48.mp4",
+            "source_checksum": "4bbded140f19d1024f63f148db2ca9d9",
+            "input_file": "al03_48.mp4",
+            "output_format": "Unknown",
+            "result": "908d650ff51a6b6f09d22d70ed0eafc3"
+        },
+        {
+            "name": "al960_sbr_e_44_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_e_44_2.mp4",
+            "source_checksum": "079a7bd3d938ee9da525dfd2d9a599ae",
+            "input_file": "al960_sbr_e_44_2.mp4",
+            "output_format": "Unknown",
+            "result": "54e73b0432a3628c52624e36d47cbeda"
+        },
+        {
+            "name": "as15_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as15_16.mp4",
+            "source_checksum": "2986285e99b5e8adbac167752b94c5ff",
+            "input_file": "as15_16.mp4",
+            "output_format": "Unknown",
+            "result": "a4c66f7b5287477f02e2e46482b93fd2"
+        },
+        {
+            "name": "as17_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as17_48.mp4",
+            "source_checksum": "281fe46b3314de5dddea1b4276595757",
+            "input_file": "as17_48.mp4",
+            "output_format": "Unknown",
+            "result": "ebd19ef16b3576a8bad95c819c42aa47"
+        },
+        {
+            "name": "al19sf_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19sf_44.mp4",
+            "source_checksum": "27f2ea6171d48bd339322e2f0e920af5",
+            "input_file": "al19sf_44.mp4",
+            "output_format": "Unknown",
+            "result": "c71aa3b9ac1c80c4874b8387bc7f0bc3"
+        },
+        {
+            "name": "al_sbr_cm_96_5",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_cm_96_5.mp4",
+            "source_checksum": "e1e595c68796a80466521928625d1c05",
+            "input_file": "al_sbr_cm_96_5.mp4",
+            "output_format": "Unknown",
+            "result": "83d56fb2e6d7eb989993a36888a04e27"
+        },
+        {
+            "name": "al17_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17_44.mp4",
+            "source_checksum": "3072c11bfce51d929925d2326253a10a",
+            "input_file": "al17_44.mp4",
+            "output_format": "Unknown",
+            "result": "784fdd0888e46c9ec4eb50a08fdb3cc6"
+        },
+        {
+            "name": "as16_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as16_48.mp4",
+            "source_checksum": "c434c63afdba6e92801e8fa7cf197ab1",
+            "input_file": "as16_48.mp4",
+            "output_format": "Unknown",
+            "result": "58f3a2a2c3bb76ddcdecb80e54e32cda"
+        },
+        {
+            "name": "er_ad1102np_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1102np_48_ep0.mp4",
+            "source_checksum": "c4920c19829bcf5431d76174f2d55989",
+            "input_file": "er_ad1102np_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al18_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18_22.mp4",
+            "source_checksum": "274b2cfe5463dcdacfb7412906ffe4de",
+            "input_file": "al18_22.mp4",
+            "output_format": "Unknown",
+            "result": "e389702831ef5798b8d9bf4b6a0cd482"
+        },
+        {
+            "name": "al14sf_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14sf_48.mp4",
+            "source_checksum": "598d264a119cbe92d7e083c148218f52",
+            "input_file": "al14sf_48.mp4",
+            "output_format": "Unknown",
+            "result": "7b4fb2dd812dd2ecdd449e30e0034086"
+        },
+        {
+            "name": "al18_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18_11.mp4",
+            "source_checksum": "950870bb40071f970ba6638935ead4ff",
+            "input_file": "al18_11.mp4",
+            "output_format": "Unknown",
+            "result": "061939a764fc6b7eb1f36a8fa4238636"
+        },
+        {
+            "name": "al02_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02_22.mp4",
+            "source_checksum": "fe4fd93353b3d8f339d1f76c6f5ec625",
+            "input_file": "al02_22.mp4",
+            "output_format": "Unknown",
+            "result": "f17cde07183e4e9e9986248b099d098c"
+        },
+        {
+            "name": "al960_sbr_i_32_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_i_32_1.mp4",
+            "source_checksum": "824151e8fcbf51c4b91db2c0c3388388",
+            "input_file": "al960_sbr_i_32_1.mp4",
+            "output_format": "Unknown",
+            "result": "b3c499b2f00bf84dad4d8e2fd05f7903"
+        },
+        {
+            "name": "al_sbr_sr_32_2_fsaac16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_32_2_fsaac16.mp4",
+            "source_checksum": "379f19055c19751d670366becd279325",
+            "input_file": "al_sbr_sr_32_2_fsaac16.mp4",
+            "output_format": "Unknown",
+            "result": "10780bdbb9166f4d6b3ea6c4f121d5a1"
+        },
+        {
+            "name": "al07sf_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07sf_48.mp4",
+            "source_checksum": "88b0a2ceed062144c2e4ecd302c47ed4",
+            "input_file": "al07sf_48.mp4",
+            "output_format": "Unknown",
+            "result": "70d924177e92b84d441cc00df378b2c0"
+        },
+        {
+            "name": "er_ad1100np_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1100np_48_ep0.mp4",
+            "source_checksum": "4f5ffc824bae3bd3974d29eedd76653c",
+            "input_file": "er_ad1100np_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al14sf_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14sf_08.mp4",
+            "source_checksum": "86744bb97ec398469fb9dc0c5c537cd7",
+            "input_file": "al14sf_08.mp4",
+            "output_format": "Unknown",
+            "result": "8325f20556b4a9d4c4308a277f0de015"
+        },
+        {
+            "name": "as13_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as13_08.mp4",
+            "source_checksum": "6884d6277734b63f93bdfaadf50bd020",
+            "input_file": "as13_08.mp4",
+            "output_format": "Unknown",
+            "result": "f48ab7fc21542d1d0caf92eacb51eee3"
+        },
+        {
+            "name": "al14_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14_96.mp4",
+            "source_checksum": "3d95dd54f7d8f994169d0eeda6222514",
+            "input_file": "al14_96.mp4",
+            "output_format": "Unknown",
+            "result": "ab6c0c02ab8224bc5f126264ee403a42"
+        },
+        {
+            "name": "er_ad1109_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1109_22_ep0.mp4",
+            "source_checksum": "c49c0652ff473928cdfc84e98fd226c5",
+            "input_file": "er_ad1109_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al02sf_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02sf_22.mp4",
+            "source_checksum": "4907347959ad6f9a20f4d10263cf3a4e",
+            "input_file": "al02sf_22.mp4",
+            "output_format": "Unknown",
+            "result": "f17cde07183e4e9e9986248b099d098c"
+        },
+        {
+            "name": "am04_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am04_44.mp4",
+            "source_checksum": "e8de8bdd160aa9e2c4952994378d3645",
+            "input_file": "am04_44.mp4",
+            "output_format": "Unknown",
+            "result": "aed190e2f215781f3ce5d6b7f049d01f"
+        },
+        {
+            "name": "er_al10_16_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al10_16_ep0.mp4",
+            "source_checksum": "8329f3520bb380d3d615088ac17e0346",
+            "input_file": "er_al10_16_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "tts7",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/tts7.mp4",
+            "source_checksum": "8fa701839fede4f3e747ad0cad86e4c6",
+            "input_file": "tts7.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al05sf_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05sf_24.mp4",
+            "source_checksum": "d87a9ffa217f856ea17436d1d899b8e6",
+            "input_file": "al05sf_24.mp4",
+            "output_format": "Unknown",
+            "result": "6420d66039cd4cef3ff15fbbbe94459b"
+        },
+        {
+            "name": "al07sf_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07sf_64.mp4",
+            "source_checksum": "7af5407fecc0961eebe5ebdde0ea12d9",
+            "input_file": "al07sf_64.mp4",
+            "output_format": "Unknown",
+            "result": "45fc46d86e78b09f6277591a34fc2793"
+        },
+        {
+            "name": "as06_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as06_24.mp4",
+            "source_checksum": "cde92b742552b0e83a80b07332e25160",
+            "input_file": "as06_24.mp4",
+            "output_format": "Unknown",
+            "result": "2d6e341afd09aa7225a3286e6aeca4e7"
+        },
+        {
+            "name": "al05_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05_08.mp4",
+            "source_checksum": "a885bae33702b12b4d80e5329f097963",
+            "input_file": "al05_08.mp4",
+            "output_format": "Unknown",
+            "result": "0af6ed73f0e59937b0ffff6da27a9bc8"
+        },
+        {
+            "name": "al03sf_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03sf_08.mp4",
+            "source_checksum": "99af385d06fe43502636082c0806aa2b",
+            "input_file": "al03sf_08.mp4",
+            "output_format": "Unknown",
+            "result": "9e0c9f7586ea7460b87d47f03a2e64d9"
+        },
+        {
+            "name": "er_eld1001np_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1001np_44_ep0.mp4",
+            "source_checksum": "a2ee90ccb4c66a2b8d0353992eb3e291",
+            "input_file": "er_eld1001np_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "am07_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am07_88.mp4",
+            "source_checksum": "706396a0d021a37a22183523d0a3bdee",
+            "input_file": "am07_88.mp4",
+            "output_format": "Unknown",
+            "result": "a53682fed44cc0c1aea35d663425f300"
+        },
+        {
+            "name": "as15_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as15_24.mp4",
+            "source_checksum": "eb6f7b5a5118bcf840b663861f1eea89",
+            "input_file": "as15_24.mp4",
+            "output_format": "Unknown",
+            "result": "02bfc42a74201206630237e4c7ad381e"
+        },
+        {
+            "name": "al16_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16_22.mp4",
+            "source_checksum": "85cebc1765ab0cc4b5d41ccfe8e15e07",
+            "input_file": "al16_22.mp4",
+            "output_format": "Unknown",
+            "result": "d764858d2fa96357a3214bbb34d75224"
+        },
+        {
+            "name": "as14_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as14_44.mp4",
+            "source_checksum": "a97bedcbd7f50098b46444ad351d2fe4",
+            "input_file": "as14_44.mp4",
+            "output_format": "Unknown",
+            "result": "e9ede9a5a4dad2a4c35d239aec4889fc"
+        },
+        {
+            "name": "al07_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07_32.mp4",
+            "source_checksum": "52e439abc7de90e16cb7803f37f7d8bb",
+            "input_file": "al07_32.mp4",
+            "output_format": "Unknown",
+            "result": "70d924177e92b84d441cc00df378b2c0"
+        },
+        {
+            "name": "as02_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as02_12.mp4",
+            "source_checksum": "bc8b034c8752410fe1405692dabee05d",
+            "input_file": "as02_12.mp4",
+            "output_format": "Unknown",
+            "result": "11af3f565ca36a6ceab18aaabdca4f46"
+        },
+        {
+            "name": "as03_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as03_96.mp4",
+            "source_checksum": "01227892517369c1f1e90dcedf4f8084",
+            "input_file": "as03_96.mp4",
+            "output_format": "Unknown",
+            "result": "821297607b9b166cebad6a5ba5de4dc7"
+        },
+        {
+            "name": "al960_sbr_s_48_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_s_48_2.mp4",
+            "source_checksum": "100283424294920d249faf99e38275ab",
+            "input_file": "al960_sbr_s_48_2.mp4",
+            "output_format": "Unknown",
+            "result": "d7ce7679a81d8f959bd92ef8c4f10a6f"
+        },
+        {
+            "name": "al19sf_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19sf_16.mp4",
+            "source_checksum": "6dcfbfc54c638b9d411cc8af3a19ee80",
+            "input_file": "al19sf_16.mp4",
+            "output_format": "Unknown",
+            "result": "aee47ab6ccb523949594610942a8f47b"
+        },
+        {
+            "name": "as17_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as17_16.mp4",
+            "source_checksum": "8702aa5d14f2b69634e343dd26eea4f6",
+            "input_file": "as17_16.mp4",
+            "output_format": "Unknown",
+            "result": "1aeb35eba5cdc0541e08964402f9b281"
+        },
+        {
+            "name": "as16_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as16_11.mp4",
+            "source_checksum": "fdae6e15afaa07aaaf051b3333627338",
+            "input_file": "as16_11.mp4",
+            "output_format": "Unknown",
+            "result": "66be4d61aa2181af657c5da70f141a96"
+        },
+        {
+            "name": "al03sf_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03sf_48.mp4",
+            "source_checksum": "f0ec4570989d81e4cc64a227cf27d559",
+            "input_file": "al03sf_48.mp4",
+            "output_format": "Unknown",
+            "result": "908d650ff51a6b6f09d22d70ed0eafc3"
+        },
+        {
+            "name": "as06_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as06_08.mp4",
+            "source_checksum": "1cfd6fc1689b4dc396e0d64734e2eefc",
+            "input_file": "as06_08.mp4",
+            "output_format": "Unknown",
+            "result": "555df93edaf95cbe5197e493659311f0"
+        },
+        {
+            "name": "as03_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as03_64.mp4",
+            "source_checksum": "65977418957b2fc7c927c778273adcf3",
+            "input_file": "as03_64.mp4",
+            "output_format": "Unknown",
+            "result": "4309816d3606d6c508746f843df54599"
+        },
+        {
+            "name": "al_sbr_s_48_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_s_48_2.mp4",
+            "source_checksum": "a10d4945997c60a05f9baa84a572b205",
+            "input_file": "al_sbr_s_48_2.mp4",
+            "output_format": "Unknown",
+            "result": "59ca539ddd04301ef2be47fcabe1759d"
+        },
+        {
+            "name": "er_ad1102np_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1102np_32_ep0.mp4",
+            "source_checksum": "ba7d4eaa25f4bc5b05a10bcab5c501a2",
+            "input_file": "er_ad1102np_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as02_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as02_96.mp4",
+            "source_checksum": "2027d3901596844f125749870b58fb8c",
+            "input_file": "as02_96.mp4",
+            "output_format": "Unknown",
+            "result": "d5c8999daac06c904e5327603f51f0cb"
+        },
+        {
+            "name": "al16sf_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16sf_48.mp4",
+            "source_checksum": "42af7dca439ba98891e9e7fb85add054",
+            "input_file": "al16sf_48.mp4",
+            "output_format": "Unknown",
+            "result": "70f8ed0d2b593456e6e47df002fba53e"
+        },
+        {
+            "name": "al18sf_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18sf_32.mp4",
+            "source_checksum": "192e1fcfad60641a19cc836e1b72c019",
+            "input_file": "al18sf_32.mp4",
+            "output_format": "Unknown",
+            "result": "9e67695d020664407eac85b26754247a"
+        },
+        {
+            "name": "as13_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as13_88.mp4",
+            "source_checksum": "e3143a446d03a6d3a0bb3452e231a70b",
+            "input_file": "as13_88.mp4",
+            "output_format": "Unknown",
+            "result": "6b658a186b7b45033d2ec0fce12379cd"
+        },
+        {
+            "name": "am04_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am04_96.mp4",
+            "source_checksum": "a878a66cbe73eab9b7b5f5970c16d6f7",
+            "input_file": "am04_96.mp4",
+            "output_format": "Unknown",
+            "result": "a4575d75131980fa419052202d927699"
+        },
+        {
+            "name": "al16sf_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16sf_96.mp4",
+            "source_checksum": "164aad1fbbff5b515167ab2c8a50c1bd",
+            "input_file": "al16sf_96.mp4",
+            "output_format": "Unknown",
+            "result": "0f621d7167bfe6b3bacd7d74b2369875"
+        },
+        {
+            "name": "am02_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am02_24.mp4",
+            "source_checksum": "da08e0d0241fb206f2a510538a8af2a8",
+            "input_file": "am02_24.mp4",
+            "output_format": "Unknown",
+            "result": "17c34307426f27e6b0b3dbd37c4d1642"
+        },
+        {
+            "name": "er_eld1000np_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1000np_32_ep0.mp4",
+            "source_checksum": "9a1dfe23cab5f47c5d29500ea0c2495c",
+            "input_file": "er_eld1000np_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al960_sbr_ps_00",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_ps_00.mp4",
+            "source_checksum": "cefb3ceb1ba8f9e053e15f110442ead1",
+            "input_file": "al960_sbr_ps_00.mp4",
+            "output_format": "Unknown",
+            "result": "7d41d79aabd58baa147af08f62636bc9"
+        },
+        {
+            "name": "al960_sbr_gh_32_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_gh_32_1.mp4",
+            "source_checksum": "62c6854046835285ddc83678e0392a99",
+            "input_file": "al960_sbr_gh_32_1.mp4",
+            "output_format": "Unknown",
+            "result": "6667f177cc0e6abef98c4dca9e79faa5"
+        },
+        {
+            "name": "as04_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as04_96.mp4",
+            "source_checksum": "f39f08c27f13e2d0e6c532df24049d5e",
+            "input_file": "as04_96.mp4",
+            "output_format": "Unknown",
+            "result": "427a7b0857a8a9b9e5d10c57c3d7f56d"
+        },
+        {
+            "name": "as11_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as11_22.mp4",
+            "source_checksum": "3d3fe1e30be9e5e869a44b0e0474b61b",
+            "input_file": "as11_22.mp4",
+            "output_format": "Unknown",
+            "result": "240d65d4f0e91934c0385d84db957d4a"
+        },
+        {
+            "name": "al03_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03_24.mp4",
+            "source_checksum": "ae796bae7bbdfd94ab1ed35712fd43ad",
+            "input_file": "al03_24.mp4",
+            "output_format": "Unknown",
+            "result": "b1b73118761159fff81b5c7af18892c7"
+        },
+        {
+            "name": "al01sf_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01sf_88.mp4",
+            "source_checksum": "03cc5eea8f51d3df02fcd3bc2329675f",
+            "input_file": "al01sf_88.mp4",
+            "output_format": "Unknown",
+            "result": "444692a2f66a9e51e07daec8a1d1a584"
+        },
+        {
+            "name": "al00sf_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00sf_88.mp4",
+            "source_checksum": "a58f956e34eb5231a2cd9ee19b5e9185",
+            "input_file": "al00sf_88.mp4",
+            "output_format": "Unknown",
+            "result": "70118d5e3c508f4709d4944e098c1c9b"
+        },
+        {
+            "name": "as15_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as15_96.mp4",
+            "source_checksum": "475dcf583ec67d98a6b41feebdd411b1",
+            "input_file": "as15_96.mp4",
+            "output_format": "Unknown",
+            "result": "4b65363c85dedf3aaf68e78c97abb2a4"
+        },
+        {
+            "name": "al04sf_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04sf_24.mp4",
+            "source_checksum": "02bb7ce4a3362cc198f7e2f52de95c23",
+            "input_file": "al04sf_24.mp4",
+            "output_format": "Unknown",
+            "result": "9bfbda2644d94dca52dd3b7b5b6a49b6"
+        },
+        {
+            "name": "as08_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as08_24.mp4",
+            "source_checksum": "f3569ee75480278bc9101ab0dc99e8ec",
+            "input_file": "as08_24.mp4",
+            "output_format": "Unknown",
+            "result": "b081fdd346de4da4a7896cfaecba28e1"
+        },
+        {
+            "name": "al_sbr_cm_48_5.1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_cm_48_5.1.mp4",
+            "source_checksum": "13ec258a49634fc66123ac7dc47087aa",
+            "input_file": "al_sbr_cm_48_5.1.mp4",
+            "output_format": "Unknown",
+            "result": "407be1e700475595edf23193242e264b"
+        },
+        {
+            "name": "er_al10_11_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al10_11_ep0.mp4",
+            "source_checksum": "8c969714e872af07fc374f5dca07bef9",
+            "input_file": "er_al10_11_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "am01_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am01_24.mp4",
+            "source_checksum": "7b9318cfe9481af7c2c93da4126fd7ce",
+            "input_file": "am01_24.mp4",
+            "output_format": "Unknown",
+            "result": "f9f1e2f962c273fa6ac41d39b97908b1"
+        },
+        {
+            "name": "al19sf_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19sf_24.mp4",
+            "source_checksum": "bf58cd6d1a44261b4e2e6e6660515b0b",
+            "input_file": "al19sf_24.mp4",
+            "output_format": "Unknown",
+            "result": "8ac8a8c2e0e6b9b7bcbb6c9c489d641c"
+        },
+        {
+            "name": "tts6",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/tts6.mp4",
+            "source_checksum": "9f84c61cdf07242754f15962145f1947",
+            "input_file": "tts6.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al_sbr_sr_44_2_fsaac22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_44_2_fsaac22.mp4",
+            "source_checksum": "a5216885fcdf279326c066b38507254d",
+            "input_file": "al_sbr_sr_44_2_fsaac22.mp4",
+            "output_format": "Unknown",
+            "result": "e4db9bc4bc56e543212f1d41a0d93bb2"
+        },
+        {
+            "name": "al06_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06_16.mp4",
+            "source_checksum": "6f40f9520536d064b4e4bf8cec6388ac",
+            "input_file": "al06_16.mp4",
+            "output_format": "Unknown",
+            "result": "ae346b6e8f7053883dc823c3f4288ff5"
+        },
+        {
+            "name": "am01_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am01_12.mp4",
+            "source_checksum": "94952d2b681b5d64bba828ebac99db51",
+            "input_file": "am01_12.mp4",
+            "output_format": "Unknown",
+            "result": "74d2561f0d010b57650a96a928f1156d"
+        },
+        {
+            "name": "al16sf_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16sf_12.mp4",
+            "source_checksum": "52ee5e9eb258fd02228a9c2157db77e3",
+            "input_file": "al16sf_12.mp4",
+            "output_format": "Unknown",
+            "result": "740c6812e891a78b7780e52da56ac901"
+        },
+        {
+            "name": "al19_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19_12.mp4",
+            "source_checksum": "8f719bd0faa459617166291d8e2b6b64",
+            "input_file": "al19_12.mp4",
+            "output_format": "Unknown",
+            "result": "aee47ab6ccb523949594610942a8f47b"
+        },
+        {
+            "name": "as05_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as05_64.mp4",
+            "source_checksum": "7891e11ff742b1b039740f27792fb221",
+            "input_file": "as05_64.mp4",
+            "output_format": "Unknown",
+            "result": "82667487c94e609a16cd32285574253c"
+        },
+        {
+            "name": "al04sf_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04sf_64.mp4",
+            "source_checksum": "83c920abad4c14e2fc8c1851d15933f6",
+            "input_file": "al04sf_64.mp4",
+            "output_format": "Unknown",
+            "result": "334e1e916f28c240965ed8e8f3ce6b38"
+        },
+        {
+            "name": "al00sf_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00sf_44.mp4",
+            "source_checksum": "1e5bf13f88a02c893a71a87c7789e5af",
+            "input_file": "al00sf_44.mp4",
+            "output_format": "Unknown",
+            "result": "31f0d7315b2d03acb22d7920f5814855"
+        },
+        {
+            "name": "er_ad1009np_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1009np_22_ep0.mp4",
+            "source_checksum": "a9495a8b4b85a7d15b0567123089cbdf",
+            "input_file": "er_ad1009np_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al05sf_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05sf_16.mp4",
+            "source_checksum": "d9f41df74158657e35f6ae1f15ded10a",
+            "input_file": "al05sf_16.mp4",
+            "output_format": "Unknown",
+            "result": "3e17aa815d1dfbb8228c0723179d9840"
+        },
+        {
+            "name": "er_eld1000np_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1000np_44_ep0.mp4",
+            "source_checksum": "2127f4f7467d675409fe679ec9f491a7",
+            "input_file": "er_eld1000np_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "er_al10_88_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al10_88_ep0.mp4",
+            "source_checksum": "62da442ed736926d88f7af378a9c922c",
+            "input_file": "er_al10_88_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al06sf_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06sf_32.mp4",
+            "source_checksum": "ab3c740849c8cec23218e417a4b9bd56",
+            "input_file": "al06sf_32.mp4",
+            "output_format": "Unknown",
+            "result": "cf08b3b58787797ff394d5b8d3718ba8"
+        },
+        {
+            "name": "as14_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as14_96.mp4",
+            "source_checksum": "2b764f0e8828add1f6736c5c1a249172",
+            "input_file": "as14_96.mp4",
+            "output_format": "Unknown",
+            "result": "cb972cdb4e5c63d467f7776fa3828699"
+        },
+        {
+            "name": "al01_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01_44.mp4",
+            "source_checksum": "fc2477b9c8693987462e68503a57f524",
+            "input_file": "al01_44.mp4",
+            "output_format": "Unknown",
+            "result": "0ac8f10d9023e838fd99b79fbd158eab"
+        },
+        {
+            "name": "as12_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as12_48.mp4",
+            "source_checksum": "7569dc5069402d65e6e9f543998d9fce",
+            "input_file": "as12_48.mp4",
+            "output_format": "Unknown",
+            "result": "4dc47947189b4cf08e4f5feee6b2ea48"
+        },
+        {
+            "name": "al07_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07_24.mp4",
+            "source_checksum": "8828cf3fff7152de0cb58c353956e8f8",
+            "input_file": "al07_24.mp4",
+            "output_format": "Unknown",
+            "result": "3b76ec8fd5fa3d75b1ed903b712a8cad"
+        },
+        {
+            "name": "al01_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01_64.mp4",
+            "source_checksum": "85ff11e5d033e04b589a6f290313ebfb",
+            "input_file": "al01_64.mp4",
+            "output_format": "Unknown",
+            "result": "567affc7a30b2b05804877c986b93849"
+        },
+        {
+            "name": "al18sf_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18sf_08.mp4",
+            "source_checksum": "ff8d29574a48d6b33393b304b50a153c",
+            "input_file": "al18sf_08.mp4",
+            "output_format": "Unknown",
+            "result": "ce99bac5016f9d4393d9441749ef5a09"
+        },
+        {
+            "name": "as15_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as15_88.mp4",
+            "source_checksum": "bfa9fc76491cb88407be3f7116ed9854",
+            "input_file": "as15_88.mp4",
+            "output_format": "Unknown",
+            "result": "6b658a186b7b45033d2ec0fce12379cd"
+        },
+        {
+            "name": "as00_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as00_44.mp4",
+            "source_checksum": "b2af48ef829071a0f0a6e8e22126798e",
+            "input_file": "as00_44.mp4",
+            "output_format": "Unknown",
+            "result": "b54c4156d525170f40cff12eb4f0afd8"
+        },
+        {
+            "name": "as12_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as12_11.mp4",
+            "source_checksum": "bf84cefb4e4a25e57e902b9f8be3df3f",
+            "input_file": "as12_11.mp4",
+            "output_format": "Unknown",
+            "result": "78df5d5b0f389a36d0965568e053b126"
+        },
+        {
+            "name": "as13_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as13_11.mp4",
+            "source_checksum": "5f10302a00fe14bd48c6628101791be0",
+            "input_file": "as13_11.mp4",
+            "output_format": "Unknown",
+            "result": "6c6115066d647d5409a2c2fa9d6f6329"
+        },
+        {
+            "name": "as06_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as06_48.mp4",
+            "source_checksum": "fe62582fc51dc3a15b3f62344fd171a3",
+            "input_file": "as06_48.mp4",
+            "output_format": "Unknown",
+            "result": "b244b4e92cad9813cd100e1dd92ae8a4"
+        },
+        {
+            "name": "as09_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as09_64.mp4",
+            "source_checksum": "8692177f9fd762f2e7536f99c5fec8c6",
+            "input_file": "as09_64.mp4",
+            "output_format": "Unknown",
+            "result": "eaf17ab6b54acc45bd1bf4a0c50b99a1"
+        },
+        {
+            "name": "al06sf_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06sf_64.mp4",
+            "source_checksum": "9981baec8b18dda2da3d8bccb36c8bb2",
+            "input_file": "al06sf_64.mp4",
+            "output_format": "Unknown",
+            "result": "2680ff601df3c7a330656ef0d6d76f6b"
+        },
+        {
+            "name": "al04_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04_24.mp4",
+            "source_checksum": "ddc0b85f3a116e5db4c42ad9be6ef43e",
+            "input_file": "al04_24.mp4",
+            "output_format": "Unknown",
+            "result": "9bfbda2644d94dca52dd3b7b5b6a49b6"
+        },
+        {
+            "name": "al960_sbr_qmf_48_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_qmf_48_1.mp4",
+            "source_checksum": "93015e1b60d77a4b3afb8d3363440802",
+            "input_file": "al960_sbr_qmf_48_1.mp4",
+            "output_format": "Unknown",
+            "result": "5802faa90bace6b2ba0e789239aae1f8"
+        },
+        {
+            "name": "al02_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02_32.mp4",
+            "source_checksum": "17e7376ca9a29bcc39c0bf4a56812bbe",
+            "input_file": "al02_32.mp4",
+            "output_format": "Unknown",
+            "result": "6ba7ac6c9ce17617f2b8e192d64111ca"
+        },
+        {
+            "name": "al960_sbr_gh_32_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_gh_32_2.mp4",
+            "source_checksum": "f7af30cef839d1f47ede544dcf3e192d",
+            "input_file": "al960_sbr_gh_32_2.mp4",
+            "output_format": "Unknown",
+            "result": "e8655911196e735dba831a0ac9fcc6a5"
+        },
+        {
+            "name": "as02_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as02_16.mp4",
+            "source_checksum": "df64cb15f4c2a84bedebd246f2a2648c",
+            "input_file": "as02_16.mp4",
+            "output_format": "Unknown",
+            "result": "21842cc363c6ba31f829806c76c0d488"
+        },
+        {
+            "name": "al00sf_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00sf_22.mp4",
+            "source_checksum": "8476cc13bdd8508fba5f4973b3e7883d",
+            "input_file": "al00sf_22.mp4",
+            "output_format": "Unknown",
+            "result": "fc7d20249eb3f883c9244e88986eebb9"
+        },
+        {
+            "name": "am02_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am02_08.mp4",
+            "source_checksum": "6fd2f5f0ea81d34f18d94938fa3f5327",
+            "input_file": "am02_08.mp4",
+            "output_format": "Unknown",
+            "result": "e001887b6c2ea4a9b41aecfa4935f5e0"
+        },
+        {
+            "name": "al_sbr_i_44_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_i_44_2.mp4",
+            "source_checksum": "9d0f30275823c332843caca31444c9d6",
+            "input_file": "al_sbr_i_44_2.mp4",
+            "output_format": "Unknown",
+            "result": "101c63734a606afc7c49e7092be57db3"
+        },
+        {
+            "name": "as11_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as11_44.mp4",
+            "source_checksum": "60d5a3f7e27c73cf9c079cd9d5570337",
+            "input_file": "as11_44.mp4",
+            "output_format": "Unknown",
+            "result": "6faa8f6cad155d54f232fdfcc1c1a001"
+        },
+        {
+            "name": "as10_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as10_08.mp4",
+            "source_checksum": "33adad923f6faedb1b61f576e902e0b7",
+            "input_file": "as10_08.mp4",
+            "output_format": "Unknown",
+            "result": "4e6e445af75a79b600f4759c45dca3c8"
+        },
+        {
+            "name": "as07_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as07_08.mp4",
+            "source_checksum": "720a1220dab2cd0390327a9fd5110b33",
+            "input_file": "as07_08.mp4",
+            "output_format": "Unknown",
+            "result": "4374f44fca297d68a85e64e1c2ad591d"
+        },
+        {
+            "name": "as05_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as05_32.mp4",
+            "source_checksum": "a530c6edbd8d17f4672a06863f6bf52c",
+            "input_file": "as05_32.mp4",
+            "output_format": "Unknown",
+            "result": "81c8e7279518789f3aca4218330f3dc3"
+        },
+        {
+            "name": "al_sbr_s_32_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_s_32_1.mp4",
+            "source_checksum": "a25d3d069293475099adc2155118a938",
+            "input_file": "al_sbr_s_32_1.mp4",
+            "output_format": "Unknown",
+            "result": "2f1957eebd0d162d11f8c5a18cfd84ee"
+        },
+        {
+            "name": "al_sbr_sr_24_2_fsaac12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sr_24_2_fsaac12.mp4",
+            "source_checksum": "2ef2f7426b467ab151accad0b3942b42",
+            "input_file": "al_sbr_sr_24_2_fsaac12.mp4",
+            "output_format": "Unknown",
+            "result": "c8d2337a7037c0059eeb7193d1274879"
+        },
+        {
+            "name": "al03_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03_96.mp4",
+            "source_checksum": "15f412827be9c2e7b091a99a79ab15c7",
+            "input_file": "al03_96.mp4",
+            "output_format": "Unknown",
+            "result": "c07660b161c8bf333f7703d39cd7829c"
+        },
+        {
+            "name": "er_ad1000np_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1000np_22_ep0.mp4",
+            "source_checksum": "525f1126aadb37b89204150171242d8c",
+            "input_file": "er_ad1000np_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "er_al21_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al21_32_ep0.mp4",
+            "source_checksum": "e984cddfafd7abf9a80fbcbee5489915",
+            "input_file": "er_al21_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al17_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17_24.mp4",
+            "source_checksum": "0c78e0ab65aff7287ead3eadde0525a7",
+            "input_file": "al17_24.mp4",
+            "output_format": "Unknown",
+            "result": "81e7f63e34e349fd6138172552c55936"
+        },
+        {
+            "name": "er_ad1000np_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1000np_24_ep0.mp4",
+            "source_checksum": "adcb13b40d0a4686a235380ff09cdccf",
+            "input_file": "er_ad1000np_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al02sf_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02sf_48.mp4",
+            "source_checksum": "b33e215efd14ed1b3cb09b784bf6e64c",
+            "input_file": "al02sf_48.mp4",
+            "output_format": "Unknown",
+            "result": "efce3a472bba51ef2c22a68981f7bd40"
+        },
+        {
+            "name": "am02_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am02_12.mp4",
+            "source_checksum": "de5c8857a7ce80aed2c78e17a576ea76",
+            "input_file": "am02_12.mp4",
+            "output_format": "Unknown",
+            "result": "8b4b95a3e7848157de9e85922b0dd2df"
+        },
+        {
+            "name": "al19_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19_96.mp4",
+            "source_checksum": "549228680311d19f4493381f2fd38b40",
+            "input_file": "al19_96.mp4",
+            "output_format": "Unknown",
+            "result": "b9601c4648ba1e8dab602dbcd3259fbd"
+        },
+        {
+            "name": "al_sbr_ps_05",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_ps_05.mp4",
+            "source_checksum": "89f3427b347c3bb08cd15aab74ba4690",
+            "input_file": "al_sbr_ps_05.mp4",
+            "output_format": "Unknown",
+            "result": "f38b1d310dcd66da9b88ad276dbe32f1"
+        },
+        {
+            "name": "al05_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05_12.mp4",
+            "source_checksum": "95799d0dc3d9e6ff8d97085c0b51b7f3",
+            "input_file": "al05_12.mp4",
+            "output_format": "Unknown",
+            "result": "afbc1483e6a4a6dc56901b63b047969f"
+        },
+        {
+            "name": "am06_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am06_24.mp4",
+            "source_checksum": "b5d0a8f8df76df8103c60243c6d3f032",
+            "input_file": "am06_24.mp4",
+            "output_format": "Unknown",
+            "result": "91499d27cccdf5dff7464ade88d7a0f4"
+        },
+        {
+            "name": "al19_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19_32.mp4",
+            "source_checksum": "7e6b41f815260fd550cbbae0b7060dcd",
+            "input_file": "al19_32.mp4",
+            "output_format": "Unknown",
+            "result": "c71aa3b9ac1c80c4874b8387bc7f0bc3"
+        },
+        {
+            "name": "al_sbr_s_44_2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_s_44_2.mp4",
+            "source_checksum": "4872d7a24570b10a781f562cf88d2979",
+            "input_file": "al_sbr_s_44_2.mp4",
+            "output_format": "Unknown",
+            "result": "c8e650105706db1c9013ed39d8fb23ca"
+        },
+        {
+            "name": "am04_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am04_24.mp4",
+            "source_checksum": "ee4b195cab29208e054824e6fe09b199",
+            "input_file": "am04_24.mp4",
+            "output_format": "Unknown",
+            "result": "2ea351471a0ccd542a6a7c83794c6013"
+        },
+        {
+            "name": "ap04_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/ap04_48.mp4",
+            "source_checksum": "1685bce2f8b43d087ecda3b3cb898fc5",
+            "input_file": "ap04_48.mp4",
+            "output_format": "Unknown",
+            "result": "6e1767241de43646691c21587ccbab9f"
+        },
+        {
+            "name": "am07_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am07_44.mp4",
+            "source_checksum": "95bb437a67e41b2bf143c519692e9034",
+            "input_file": "am07_44.mp4",
+            "output_format": "Unknown",
+            "result": "f786f8ed8c5a50c4d8077ab6b82e9485"
+        },
+        {
+            "name": "as06_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as06_64.mp4",
+            "source_checksum": "75962cd05633d36059a3b351e845034c",
+            "input_file": "as06_64.mp4",
+            "output_format": "Unknown",
+            "result": "b269ccbec78278261e9f9d829366b686"
+        },
+        {
+            "name": "al05_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05_96.mp4",
+            "source_checksum": "9629d251249f29c2407abaf2b7de9d19",
+            "input_file": "al05_96.mp4",
+            "output_format": "Unknown",
+            "result": "d4dfff5dbf498aabb7ab71ebf71fc6de"
+        },
+        {
+            "name": "as16_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as16_44.mp4",
+            "source_checksum": "3d03997cdbff1141edef3562b308c472",
+            "input_file": "as16_44.mp4",
+            "output_format": "Unknown",
+            "result": "e9ede9a5a4dad2a4c35d239aec4889fc"
+        },
+        {
+            "name": "as04_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as04_12.mp4",
+            "source_checksum": "74051cb1078a7153aaa2469197224ba6",
+            "input_file": "as04_12.mp4",
+            "output_format": "Unknown",
+            "result": "1f56b8ef778b40628b873e55c03dba60"
+        },
+        {
+            "name": "al960_sbr_gh_44_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_gh_44_1.mp4",
+            "source_checksum": "d5775ae5845e06664f8876d10365f506",
+            "input_file": "al960_sbr_gh_44_1.mp4",
+            "output_format": "Unknown",
+            "result": "70f5de5fca88432056f0e12049e025e6"
+        },
+        {
+            "name": "as06_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as06_12.mp4",
+            "source_checksum": "50b95774a0599097d944377680e1620c",
+            "input_file": "as06_12.mp4",
+            "output_format": "Unknown",
+            "result": "adaa0667e7581ff3d6f56ba40bb1c457"
+        },
+        {
+            "name": "al06_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06_88.mp4",
+            "source_checksum": "f6ac207e454eac1355fb4082d7b55a75",
+            "input_file": "al06_88.mp4",
+            "output_format": "Unknown",
+            "result": "4f1c2fd36e30363132d8ed96360e3b29"
+        },
+        {
+            "name": "al02sf_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02sf_11.mp4",
+            "source_checksum": "28821fae7b0e4528d0618dd2953499d5",
+            "input_file": "al02sf_11.mp4",
+            "output_format": "Unknown",
+            "result": "6919665a2023157452cff79d0ea54f4c"
+        },
+        {
+            "name": "am07_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am07_32.mp4",
+            "source_checksum": "e89dc90593dc336542f94828fea8155e",
+            "input_file": "am07_32.mp4",
+            "output_format": "Unknown",
+            "result": "aefb6f3ee8f563a1fc867b460ce7fb7e"
+        },
+        {
+            "name": "er_ad1100np_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1100np_32_ep0.mp4",
+            "source_checksum": "afa31e4a93936aa60be7b06fd2e29356",
+            "input_file": "er_ad1100np_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "er_eld1002np_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1002np_24_ep0.mp4",
+            "source_checksum": "c693ad02acaca5c457b6ea90f430bf3c",
+            "input_file": "er_eld1002np_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al16sf_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16sf_11.mp4",
+            "source_checksum": "2f4a475e056d5045cf7f2be78cbd443d",
+            "input_file": "al16sf_11.mp4",
+            "output_format": "Unknown",
+            "result": "db12a7bd65b38be3c2483a85f38e2247"
+        },
+        {
+            "name": "al03_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03_44.mp4",
+            "source_checksum": "934aa14759dabc0a715ce5a670bec955",
+            "input_file": "al03_44.mp4",
+            "output_format": "Unknown",
+            "result": "bc6428f68eeac99961b07928d5efb76f"
+        },
+        {
+            "name": "am04_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am04_16.mp4",
+            "source_checksum": "ed5cd142eef23c2effc2e995ec54e435",
+            "input_file": "am04_16.mp4",
+            "output_format": "Unknown",
+            "result": "97e01cc29ed85f086b461143650a5929"
+        },
+        {
+            "name": "am04_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am04_12.mp4",
+            "source_checksum": "3c501a6e413aa94d4114523836f71dd5",
+            "input_file": "am04_12.mp4",
+            "output_format": "Unknown",
+            "result": "471f36c8ae39f7e6223892906910249a"
+        },
+        {
+            "name": "al02sf_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02sf_16.mp4",
+            "source_checksum": "856dbfceac4acb9527a76297ec736848",
+            "input_file": "al02sf_16.mp4",
+            "output_format": "Unknown",
+            "result": "3895a8eb4c3f795f621c0591dac9e076"
+        },
+        {
+            "name": "al16_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16_48.mp4",
+            "source_checksum": "3c7639c849340d5054b9a5a8ddbde0cd",
+            "input_file": "al16_48.mp4",
+            "output_format": "Unknown",
+            "result": "70f8ed0d2b593456e6e47df002fba53e"
+        },
+        {
+            "name": "as17_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as17_32.mp4",
+            "source_checksum": "bd066fba4f0a2f4d28af2bac7050ff0e",
+            "input_file": "as17_32.mp4",
+            "output_format": "Unknown",
+            "result": "f905cf951369cd78ff5dbc5fc03b82a7"
+        },
+        {
+            "name": "al07_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07_48.mp4",
+            "source_checksum": "f481a380e70ac8c5f5f1727f9adbfbc6",
+            "input_file": "al07_48.mp4",
+            "output_format": "Unknown",
+            "result": "70d924177e92b84d441cc00df378b2c0"
+        },
+        {
+            "name": "as07_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as07_44.mp4",
+            "source_checksum": "9755c4e65dcccb29ce8aa40c2ef6a933",
+            "input_file": "as07_44.mp4",
+            "output_format": "Unknown",
+            "result": "085350565881a963a3ad4cae99a91f02"
+        },
+        {
+            "name": "er_al21_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al21_22_ep0.mp4",
+            "source_checksum": "f32d5d02377bec66dfc4de4c95781f19",
+            "input_file": "er_al21_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al00sf_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00sf_11.mp4",
+            "source_checksum": "9e14703e5d6ca502d0392cc336eea58d",
+            "input_file": "al00sf_11.mp4",
+            "output_format": "Unknown",
+            "result": "6eb23f7d1b322d167f0c075234ad66ec"
+        },
+        {
+            "name": "al14sf_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14sf_64.mp4",
+            "source_checksum": "c1c8e745ecf4536a670a3cdc2e31765e",
+            "input_file": "al14sf_64.mp4",
+            "output_format": "Unknown",
+            "result": "fee87c426ffe310d83008121fa592bd9"
+        },
+        {
+            "name": "am00_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am00_22.mp4",
+            "source_checksum": "fdd42f1a02870adf56a5983fb0f4b6b2",
+            "input_file": "am00_22.mp4",
+            "output_format": "Unknown",
+            "result": "eb0b98927548766c4255669f3e3ce9b8"
+        },
+        {
+            "name": "al19sf_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19sf_88.mp4",
+            "source_checksum": "d5528eb7c85a4ef86170dbf0aa6d88db",
+            "input_file": "al19sf_88.mp4",
+            "output_format": "Unknown",
+            "result": "b9601c4648ba1e8dab602dbcd3259fbd"
+        },
+        {
+            "name": "al18sf_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18sf_16.mp4",
+            "source_checksum": "25545fca7e53e7f376f0f51db996eab6",
+            "input_file": "al18sf_16.mp4",
+            "output_format": "Unknown",
+            "result": "448234b88743b1d98d68130810f33293"
+        },
+        {
+            "name": "as09_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as09_96.mp4",
+            "source_checksum": "8961951f1801a2fe980bf85f11e2cfda",
+            "input_file": "as09_96.mp4",
+            "output_format": "Unknown",
+            "result": "dacba353af93ca1befcabcc4e4d28e0a"
+        },
+        {
+            "name": "as01_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as01_16.mp4",
+            "source_checksum": "b82246c7b0b70847ea7922aed65c169b",
+            "input_file": "as01_16.mp4",
+            "output_format": "Unknown",
+            "result": "0bda27fe86e947592e92ec47c050621a"
+        },
+        {
+            "name": "am07_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am07_64.mp4",
+            "source_checksum": "7d2d9fbbeb05d943c1342730300fb0d7",
+            "input_file": "am07_64.mp4",
+            "output_format": "Unknown",
+            "result": "16c74c24d70ff2f1a33da9bd80ee8890"
+        },
+        {
+            "name": "al04_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04_11.mp4",
+            "source_checksum": "509a2f176345dae30423c4422a986f35",
+            "input_file": "al04_11.mp4",
+            "output_format": "Unknown",
+            "result": "ce01170c4b3bbadfb22580879745bb79"
+        },
+        {
+            "name": "al_sbr_ps_05_new",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_ps_05_new.mp4",
+            "source_checksum": "f004d4605bfe881b4edbd437d9f69de5",
+            "input_file": "al_sbr_ps_05_new.mp4",
+            "output_format": "Unknown",
+            "result": "f38b1d310dcd66da9b88ad276dbe32f1"
+        },
+        {
+            "name": "al07_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al07_22.mp4",
+            "source_checksum": "6e4ed3bd7e215e39f36d8ef4e35dcd8b",
+            "input_file": "al07_22.mp4",
+            "output_format": "Unknown",
+            "result": "3b76ec8fd5fa3d75b1ed903b712a8cad"
+        },
+        {
+            "name": "am02_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am02_64.mp4",
+            "source_checksum": "aa4cc87e2c7d43bce9c8e9ebc38477e8",
+            "input_file": "am02_64.mp4",
+            "output_format": "Unknown",
+            "result": "66d2d78003904501367c8814dd051705"
+        },
+        {
+            "name": "er_al21_44_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al21_44_ep0.mp4",
+            "source_checksum": "6623ca641a3fd61f8dc34a6513908c20",
+            "input_file": "er_al21_44_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al_sbr_ps_02_new",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_ps_02_new.mp4",
+            "source_checksum": "07842048def7e7e28530d5a4b5b6288b",
+            "input_file": "al_sbr_ps_02_new.mp4",
+            "output_format": "Unknown",
+            "result": "78a6feba4604a401af55987d7cc2de1e"
+        },
+        {
+            "name": "er_eld1002np_48_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1002np_48_ep0.mp4",
+            "source_checksum": "f60324013b319f697a61d156d513f0f4",
+            "input_file": "er_eld1002np_48_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as15_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as15_11.mp4",
+            "source_checksum": "132d6833103d95527f19960012d32606",
+            "input_file": "as15_11.mp4",
+            "output_format": "Unknown",
+            "result": "6c6115066d647d5409a2c2fa9d6f6329"
+        },
+        {
+            "name": "al06_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06_24.mp4",
+            "source_checksum": "7cb02b9a95492c05a00ec031458e8324",
+            "input_file": "al06_24.mp4",
+            "output_format": "Unknown",
+            "result": "7608666b6e0dfeca71883389302f2fe0"
+        },
+        {
+            "name": "as02_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as02_64.mp4",
+            "source_checksum": "171674973fda6604689f4f81d7cfa607",
+            "input_file": "as02_64.mp4",
+            "output_format": "Unknown",
+            "result": "251ea0e1b3821235909aba69892ad7d8"
+        },
+        {
+            "name": "tts1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/tts1.mp4",
+            "source_checksum": "ec49cffff239a25bd18e27a90e5c3f9e",
+            "input_file": "tts1.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al08sf_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08sf_96.mp4",
+            "source_checksum": "12c6ae01d190190b08f3c179e4a3b646",
+            "input_file": "al08sf_96.mp4",
+            "output_format": "Unknown",
+            "result": "4677b93aa04c55103ebd1dce77c6f4c8"
+        },
+        {
+            "name": "al05_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05_32.mp4",
+            "source_checksum": "69aa2c2fa85a7ae9a50c04ce36d57aa9",
+            "input_file": "al05_32.mp4",
+            "output_format": "Unknown",
+            "result": "d8fd8cbd4707458c7dbc2331ad792e67"
+        },
+        {
+            "name": "al00_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00_88.mp4",
+            "source_checksum": "b2105985d63491c7d61f964f5ac667cb",
+            "input_file": "al00_88.mp4",
+            "output_format": "Unknown",
+            "result": "70118d5e3c508f4709d4944e098c1c9b"
+        },
+        {
+            "name": "al04_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04_08.mp4",
+            "source_checksum": "9f81fb01b172e8adafdda6d0cf590649",
+            "input_file": "al04_08.mp4",
+            "output_format": "Unknown",
+            "result": "19d650af57f6baa32202f3100aeb1eda"
+        },
+        {
+            "name": "er_ad1100np_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_ad1100np_22_ep0.mp4",
+            "source_checksum": "ed8e08dcc785bf654cb369d838e71d2a",
+            "input_file": "er_ad1100np_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as02_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as02_48.mp4",
+            "source_checksum": "8b29b73ffe0f759f77b7be3c36c75e57",
+            "input_file": "as02_48.mp4",
+            "output_format": "Unknown",
+            "result": "8f0fec654f8b846b229f8a656c6aca0d"
+        },
+        {
+            "name": "as07_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as07_24.mp4",
+            "source_checksum": "6cf402f95d4b8943f8af1b51b7eae8fd",
+            "input_file": "as07_24.mp4",
+            "output_format": "Unknown",
+            "result": "8a6f5b90e5fdd48feb04a0d7bbe10b73"
+        },
+        {
+            "name": "as02_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as02_08.mp4",
+            "source_checksum": "1fc4419d127e4135412260188231c061",
+            "input_file": "as02_08.mp4",
+            "output_format": "Unknown",
+            "result": "19b5d8f467aac0f0f9c3cd5b841f392e"
+        },
+        {
+            "name": "al03_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03_16.mp4",
+            "source_checksum": "230531de8dbda73a7da30ff86c5cf8bc",
+            "input_file": "al03_16.mp4",
+            "output_format": "Unknown",
+            "result": "98b5f0df41b303b02037224f09cf45ea"
+        },
+        {
+            "name": "as09_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as09_88.mp4",
+            "source_checksum": "9997aa77a0f8eb314bfe85e008b2b5a8",
+            "input_file": "as09_88.mp4",
+            "output_format": "Unknown",
+            "result": "3c45cb22edbf1ffbd69471f1f9e3057e"
+        },
+        {
+            "name": "al00_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al00_32.mp4",
+            "source_checksum": "ec1c0cb294f8b99a3bf6770d155eee47",
+            "input_file": "al00_32.mp4",
+            "output_format": "Unknown",
+            "result": "9379f05a63dbbf78e458e88f8b36a4bc"
+        },
+        {
+            "name": "al_sbr_qmf_48_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_qmf_48_1.mp4",
+            "source_checksum": "4368a1fa14067f2495975cbba2db59b3",
+            "input_file": "al_sbr_qmf_48_1.mp4",
+            "output_format": "Unknown",
+            "result": "8731ce0e59168fadef4beaa401f7e473"
+        },
+        {
+            "name": "er_al21_88_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al21_88_ep0.mp4",
+            "source_checksum": "ac96fbdf43f9935ee0e0500b9aac32de",
+            "input_file": "er_al21_88_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al_sbr_ps_06_new",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_ps_06_new.mp4",
+            "source_checksum": "0295396fe1a25bdea14371c764b7dd96",
+            "input_file": "al_sbr_ps_06_new.mp4",
+            "output_format": "Unknown",
+            "result": "03982f54e327665761f07b4fa6f99d1a"
+        },
+        {
+            "name": "er_eld1001np_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1001np_24_ep0.mp4",
+            "source_checksum": "9997147edfadfc1fbe119d77eb57d292",
+            "input_file": "er_eld1001np_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "er_eld2100np_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld2100np_22_ep0.mp4",
+            "source_checksum": "04b92fbc3efe9db520ff1dd7cc862a5e",
+            "input_file": "er_eld2100np_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "am05_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am05_22.mp4",
+            "source_checksum": "8fe188aef595f0c3eb7d144b43ddc600",
+            "input_file": "am05_22.mp4",
+            "output_format": "Unknown",
+            "result": "0a8a4412f335d3c3eb55dcb339c0fda2"
+        },
+        {
+            "name": "al18sf_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18sf_24.mp4",
+            "source_checksum": "2af3fb950ddc1194758be71479e2e0c8",
+            "input_file": "al18sf_24.mp4",
+            "output_format": "Unknown",
+            "result": "e63eb113224e3a9e911d2d6905cf8a84"
+        },
+        {
+            "name": "al08_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08_48.mp4",
+            "source_checksum": "28d137e459204dcab7f0c146ac1bcee6",
+            "input_file": "al08_48.mp4",
+            "output_format": "Unknown",
+            "result": "97e049c5ca237411214a5ba9f0733dbc"
+        },
+        {
+            "name": "am00_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am00_08.mp4",
+            "source_checksum": "7cc0c1d913ff6b45448c17d25c75b4fd",
+            "input_file": "am00_08.mp4",
+            "output_format": "Unknown",
+            "result": "c083f24c1dbb71fd59b15ee003627a81"
+        },
+        {
+            "name": "al05sf_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05sf_96.mp4",
+            "source_checksum": "c3890c593bd7ecd6124d26b41f42f9ed",
+            "input_file": "al05sf_96.mp4",
+            "output_format": "Unknown",
+            "result": "d4dfff5dbf498aabb7ab71ebf71fc6de"
+        },
+        {
+            "name": "al960_sbr_qmf_32_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al960_sbr_qmf_32_1.mp4",
+            "source_checksum": "ca210bc14cecc57e2dfb7032ce7dfe44",
+            "input_file": "al960_sbr_qmf_32_1.mp4",
+            "output_format": "Unknown",
+            "result": "8323b5c0cb9b9ee974cf3da570fe4811"
+        },
+        {
+            "name": "as10_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as10_22.mp4",
+            "source_checksum": "d0b2b46f6789c10199f39f67d3c20344",
+            "input_file": "as10_22.mp4",
+            "output_format": "Unknown",
+            "result": "bc7e903ad7664ee5e0fbbb655e1e32ee"
+        },
+        {
+            "name": "as05_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as05_16.mp4",
+            "source_checksum": "36cac1a34f87661c1730e4752c3f7510",
+            "input_file": "as05_16.mp4",
+            "output_format": "Unknown",
+            "result": "748cfa097ad0e6fce489f0a44a788742"
+        },
+        {
+            "name": "al02_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02_16.mp4",
+            "source_checksum": "8b2c7401d460e07ef55c2e584a16c6d8",
+            "input_file": "al02_16.mp4",
+            "output_format": "Unknown",
+            "result": "3895a8eb4c3f795f621c0591dac9e076"
+        },
+        {
+            "name": "as06_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as06_96.mp4",
+            "source_checksum": "a15a830e07343c1faa03406c117c11d1",
+            "input_file": "as06_96.mp4",
+            "output_format": "Unknown",
+            "result": "186d598b2d6798f3e41cdb3fe57f4469"
+        },
+        {
+            "name": "al04sf_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al04sf_88.mp4",
+            "source_checksum": "f41d17fb49944916b40974291c5af4d2",
+            "input_file": "al04sf_88.mp4",
+            "output_format": "Unknown",
+            "result": "854a65ea3d37c7357482d415acaf826e"
+        },
+        {
+            "name": "al08_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08_44.mp4",
+            "source_checksum": "4e3a6fd07dae11080baca60bf1166fa8",
+            "input_file": "al08_44.mp4",
+            "output_format": "Unknown",
+            "result": "ac48dbb44e76757732c7060fce50b773"
+        },
+        {
+            "name": "al03sf_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03sf_64.mp4",
+            "source_checksum": "ca24621d192afcca928a90def9055fca",
+            "input_file": "al03sf_64.mp4",
+            "output_format": "Unknown",
+            "result": "352d2c45ae42514dde7d018bbcdd538c"
+        },
+        {
+            "name": "am01_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am01_11.mp4",
+            "source_checksum": "8d92bbdb390bc11486845da4a952874a",
+            "input_file": "am01_11.mp4",
+            "output_format": "Unknown",
+            "result": "fd1acc7277a3e121693ccbd422fa9b54"
+        },
+        {
+            "name": "er_eld2000np_24_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld2000np_24_ep0.mp4",
+            "source_checksum": "8719cec076eb9d08d455c1d68e2135f4",
+            "input_file": "er_eld2000np_24_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "am05_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am05_16.mp4",
+            "source_checksum": "b436103b97fc6bfe1261c7247b60ed4d",
+            "input_file": "am05_16.mp4",
+            "output_format": "Unknown",
+            "result": "ede190add5ed7fabdca40105b716a244"
+        },
+        {
+            "name": "al19_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19_48.mp4",
+            "source_checksum": "f3ccd8d5882daab6254202a7cbd1d7c2",
+            "input_file": "al19_48.mp4",
+            "output_format": "Unknown",
+            "result": "c71aa3b9ac1c80c4874b8387bc7f0bc3"
+        },
+        {
+            "name": "al08_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08_24.mp4",
+            "source_checksum": "567b25a72bf32316d3885abd6c133e7d",
+            "input_file": "al08_24.mp4",
+            "output_format": "Unknown",
+            "result": "25e9f186f207c855879a5f4a18686110"
+        },
+        {
+            "name": "al19sf_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19sf_12.mp4",
+            "source_checksum": "81954dfe604caef2b636199083dc014f",
+            "input_file": "al19sf_12.mp4",
+            "output_format": "Unknown",
+            "result": "aee47ab6ccb523949594610942a8f47b"
+        },
+        {
+            "name": "am05_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am05_11.mp4",
+            "source_checksum": "e61544bfef837da898e51751fc0c5305",
+            "input_file": "am05_11.mp4",
+            "output_format": "Unknown",
+            "result": "8c50713c2b4441b86eb6cdf337790a63"
+        },
+        {
+            "name": "am06_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am06_88.mp4",
+            "source_checksum": "dded0d940875e799e61cfb499c5836bd",
+            "input_file": "am06_88.mp4",
+            "output_format": "Unknown",
+            "result": "a14e628165c352143d14b0b554971e48"
+        },
+        {
+            "name": "al01_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01_88.mp4",
+            "source_checksum": "621f16a9d07cfb20b5248894f047f944",
+            "input_file": "al01_88.mp4",
+            "output_format": "Unknown",
+            "result": "444692a2f66a9e51e07daec8a1d1a584"
+        },
+        {
+            "name": "al06_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06_64.mp4",
+            "source_checksum": "369b34adb97f8c85ef4e67af4bccff15",
+            "input_file": "al06_64.mp4",
+            "output_format": "Unknown",
+            "result": "2680ff601df3c7a330656ef0d6d76f6b"
+        },
+        {
+            "name": "er_eld1101np_32_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1101np_32_ep0.mp4",
+            "source_checksum": "ddbff36d1c9534c76d28ef5f4f5c9e7e",
+            "input_file": "er_eld1101np_32_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "as03_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as03_32.mp4",
+            "source_checksum": "6a5f734b70df98ae706efe583eceb6c3",
+            "input_file": "as03_32.mp4",
+            "output_format": "Unknown",
+            "result": "920794a07f55ca188bb2fdcc09dd990a"
+        },
+        {
+            "name": "al16sf_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16sf_88.mp4",
+            "source_checksum": "620f949437596e0f0f2b020f53e03c3c",
+            "input_file": "al16sf_88.mp4",
+            "output_format": "Unknown",
+            "result": "55c563d8df797e4c8d308796fb511311"
+        },
+        {
+            "name": "er_al21_96_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_al21_96_ep0.mp4",
+            "source_checksum": "b029d8cd0902a45ba704a2b7c65ec84c",
+            "input_file": "er_al21_96_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "al18_48",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18_48.mp4",
+            "source_checksum": "cbed89713df6e571762af22e86da5cf7",
+            "input_file": "al18_48.mp4",
+            "output_format": "Unknown",
+            "result": "3c0cd6c01907f6824492b19ee068ddd7"
+        },
+        {
+            "name": "as02_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as02_88.mp4",
+            "source_checksum": "0566eeb208b4b3bf6d7ae75bebf839ed",
+            "input_file": "as02_88.mp4",
+            "output_format": "Unknown",
+            "result": "f669b471bf5bfd82e5a24f6715ca5e8b"
+        },
+        {
+            "name": "al17sf_16",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al17sf_16.mp4",
+            "source_checksum": "8c304df96141fc9e3da3b8c1a283960a",
+            "input_file": "al17sf_16.mp4",
+            "output_format": "Unknown",
+            "result": "578f691643c105bc6e12665c4f595a0a"
+        },
+        {
+            "name": "as09_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as09_08.mp4",
+            "source_checksum": "4de70a91518c6a991537769b9881e3fa",
+            "input_file": "as09_08.mp4",
+            "output_format": "Unknown",
+            "result": "c90abb148c09f3fe5eb768fcd283213b"
+        },
+        {
+            "name": "as06_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as06_11.mp4",
+            "source_checksum": "b7a0674054d0dc7943aa77d159632290",
+            "input_file": "as06_11.mp4",
+            "output_format": "Unknown",
+            "result": "64d28b9d388a06953a33cc5b556f41ab"
+        },
+        {
+            "name": "al05sf_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05sf_44.mp4",
+            "source_checksum": "c636b8b15a4ca9660a1fc0706fac0248",
+            "input_file": "al05sf_44.mp4",
+            "output_format": "Unknown",
+            "result": "33f981c92cde037b3941040e2ae8bafa"
+        },
+        {
+            "name": "al18_88",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al18_88.mp4",
+            "source_checksum": "a4599ffedd2c4561b5ff42f5cd68e9d6",
+            "input_file": "al18_88.mp4",
+            "output_format": "Unknown",
+            "result": "21fd073e1f200cf55f9ec3d2e3f9cb3c"
+        },
+        {
+            "name": "al19sf_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19sf_96.mp4",
+            "source_checksum": "a3cbd72178c0d2d09bffd82d7359422c",
+            "input_file": "al19sf_96.mp4",
+            "output_format": "Unknown",
+            "result": "b9601c4648ba1e8dab602dbcd3259fbd"
+        },
+        {
+            "name": "al05sf_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05sf_22.mp4",
+            "source_checksum": "d3060da435a7b1484762461840ab0788",
+            "input_file": "al05sf_22.mp4",
+            "output_format": "Unknown",
+            "result": "c297fd5aba3dbe1b55f41757e0ad518d"
+        },
+        {
+            "name": "am05_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am05_96.mp4",
+            "source_checksum": "14cdc53ff9c55582eb2b2a00dabd4cf8",
+            "input_file": "am05_96.mp4",
+            "output_format": "Unknown",
+            "result": "4b1f764f8a1e1c3656fe5ef38e1d1295"
+        },
+        {
+            "name": "al19_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19_11.mp4",
+            "source_checksum": "c058684333938aa1ad45a9070aeeb25f",
+            "input_file": "al19_11.mp4",
+            "output_format": "Unknown",
+            "result": "aee47ab6ccb523949594610942a8f47b"
+        },
+        {
+            "name": "al08_96",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al08_96.mp4",
+            "source_checksum": "89675c09826b6dedae2650ba2f6647dc",
+            "input_file": "al08_96.mp4",
+            "output_format": "Unknown",
+            "result": "4677b93aa04c55103ebd1dce77c6f4c8"
+        },
+        {
+            "name": "as06_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as06_44.mp4",
+            "source_checksum": "d5d5cc065ca0b9aebc354bcfcff75fb9",
+            "input_file": "as06_44.mp4",
+            "output_format": "Unknown",
+            "result": "23f4438eb7a24465d9c1ad6b18d3fe94"
+        },
+        {
+            "name": "as15_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as15_64.mp4",
+            "source_checksum": "a6ae9ba18931b259a0be53189af9966b",
+            "input_file": "as15_64.mp4",
+            "output_format": "Unknown",
+            "result": "9f960c8f0636c7a90bba45ca0cb95de0"
+        },
+        {
+            "name": "er_eld1000np_22_ep0",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/er_eld1000np_22_ep0.mp4",
+            "source_checksum": "2686571b1052156f59b97620c3982001",
+            "input_file": "er_eld1000np_22_ep0.mp4",
+            "output_format": "Unknown",
+            "result": ""
+        },
+        {
+            "name": "am01_32",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am01_32.mp4",
+            "source_checksum": "156ded4135ecdf086ea7024deb33968e",
+            "input_file": "am01_32.mp4",
+            "output_format": "Unknown",
+            "result": "40e08c874b6ce277ca8da3061aa170bd"
+        },
+        {
+            "name": "al05_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05_24.mp4",
+            "source_checksum": "fff8204fefdfa1fc29c54851911589e1",
+            "input_file": "al05_24.mp4",
+            "output_format": "Unknown",
+            "result": "6420d66039cd4cef3ff15fbbbe94459b"
+        },
+        {
+            "name": "am06_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am06_11.mp4",
+            "source_checksum": "830a4c37e4371ff155e8a7ce18c526b8",
+            "input_file": "am06_11.mp4",
+            "output_format": "Unknown",
+            "result": "afdd70fe093061dfeab43b2f2733eb12"
+        },
+        {
+            "name": "al05sf_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al05sf_64.mp4",
+            "source_checksum": "2bc15245a657d9d3f25214409e1a4c29",
+            "input_file": "al05sf_64.mp4",
+            "output_format": "Unknown",
+            "result": "fd32fac5c93040674baf30e5ebf57c52"
+        },
+        {
+            "name": "al02sf_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al02sf_08.mp4",
+            "source_checksum": "a7841041e01f69824ac81d451c24e911",
+            "input_file": "al02sf_08.mp4",
+            "output_format": "Unknown",
+            "result": "48e6870f8ccdcaefacd80036e6971aa4"
+        },
+        {
+            "name": "al16_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16_12.mp4",
+            "source_checksum": "882e1e515ccc08659e6342732b017ca8",
+            "input_file": "al16_12.mp4",
+            "output_format": "Unknown",
+            "result": "740c6812e891a78b7780e52da56ac901"
+        },
+        {
+            "name": "as16_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as16_22.mp4",
+            "source_checksum": "d1a21fed4a49b321ac17b8962bc9b73f",
+            "input_file": "as16_22.mp4",
+            "output_format": "Unknown",
+            "result": "02856cceb12e9637bb98fc210daf193b"
+        },
+        {
+            "name": "al_sbr_sig_48_2_sig2",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_sig_48_2_sig2.mp4",
+            "source_checksum": "2ac3609efdad0216db32471807e8a161",
+            "input_file": "al_sbr_sig_48_2_sig2.mp4",
+            "output_format": "Unknown",
+            "result": "c010b74a09891368ab5db14471f8a732"
+        },
+        {
+            "name": "am00_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am00_12.mp4",
+            "source_checksum": "60ec3e557d14fed71d084618a972e773",
+            "input_file": "am00_12.mp4",
+            "output_format": "Unknown",
+            "result": "ed6315a5d24d5bd43f42c31f38653ea5"
+        },
+        {
+            "name": "al19sf_64",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al19sf_64.mp4",
+            "source_checksum": "347fe4f72686b55b60f032ac76a70029",
+            "input_file": "al19sf_64.mp4",
+            "output_format": "Unknown",
+            "result": "b9601c4648ba1e8dab602dbcd3259fbd"
+        },
+        {
+            "name": "as05_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as05_12.mp4",
+            "source_checksum": "76bc1150ba5d114b69b151f89e3aff56",
+            "input_file": "as05_12.mp4",
+            "output_format": "Unknown",
+            "result": "5f962095c6a282b2d1de1628b91ff623"
+        },
+        {
+            "name": "as13_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as13_12.mp4",
+            "source_checksum": "e7547dc84ea2b36f0426538151dbbcf6",
+            "input_file": "as13_12.mp4",
+            "output_format": "Unknown",
+            "result": "971a2bff11d06bc3c578efda34aefa4b"
+        },
+        {
+            "name": "al_sbr_e_48_1",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al_sbr_e_48_1.mp4",
+            "source_checksum": "296887bd47894666680d5304737d7526",
+            "input_file": "al_sbr_e_48_1.mp4",
+            "output_format": "Unknown",
+            "result": "502cdb26fc771f1828d0c94ebd1dc07a"
+        },
+        {
+            "name": "al16sf_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al16sf_22.mp4",
+            "source_checksum": "094231e579001698ab8cbcf7a7b0d929",
+            "input_file": "al16sf_22.mp4",
+            "output_format": "Unknown",
+            "result": "d764858d2fa96357a3214bbb34d75224"
+        },
+        {
+            "name": "am05_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am05_12.mp4",
+            "source_checksum": "84c419e39f351dc6d6e77dc276948049",
+            "input_file": "am05_12.mp4",
+            "output_format": "Unknown",
+            "result": "c0acc317ad68ea35202e995e36934aeb"
+        },
+        {
+            "name": "al01_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al01_12.mp4",
+            "source_checksum": "8d7294f69b279cf56d3a78a793465efa",
+            "input_file": "al01_12.mp4",
+            "output_format": "Unknown",
+            "result": "1bf3c602a298c1b7b2f65080c83d4b49"
+        },
+        {
+            "name": "as09_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as09_11.mp4",
+            "source_checksum": "f560df5ef1b035091b2fef9791189d2b",
+            "input_file": "as09_11.mp4",
+            "output_format": "Unknown",
+            "result": "f1e414104151e770be3a8de90fae8b7e"
+        },
+        {
+            "name": "al14_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al14_44.mp4",
+            "source_checksum": "5879ca971cc5a7d853139cd5520db2e2",
+            "input_file": "al14_44.mp4",
+            "output_format": "Unknown",
+            "result": "1ea3fc56401dc70963f7a6d7897a7377"
+        },
+        {
+            "name": "as05_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as05_22.mp4",
+            "source_checksum": "a9fdb2ac70b7deb02baf4ac188288ae5",
+            "input_file": "as05_22.mp4",
+            "output_format": "Unknown",
+            "result": "bbd39cff4466d45eb47427488d5332db"
+        },
+        {
+            "name": "as07_22",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as07_22.mp4",
+            "source_checksum": "47e4b06158704bea075539d3e80b6fe8",
+            "input_file": "as07_22.mp4",
+            "output_format": "Unknown",
+            "result": "ab4981a6ac7a37d903277c886a14b893"
+        },
+        {
+            "name": "al03_12",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al03_12.mp4",
+            "source_checksum": "11269901077bcb44e252773196481931",
+            "input_file": "al03_12.mp4",
+            "output_format": "Unknown",
+            "result": "97c9a4a96818ef0c03dc1c8797aa7279"
+        },
+        {
+            "name": "as02_11",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as02_11.mp4",
+            "source_checksum": "98b2a869df71fcbe96dd5196608a6cfc",
+            "input_file": "as02_11.mp4",
+            "output_format": "Unknown",
+            "result": "a9dbc7369832bc9ce70391719891fb98"
+        },
+        {
+            "name": "as00_08",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as00_08.mp4",
+            "source_checksum": "aa1fbefff39fc500d500017d818c0a5d",
+            "input_file": "as00_08.mp4",
+            "output_format": "Unknown",
+            "result": "f852727b02e8195bc975fe7342821cb3"
+        },
+        {
+            "name": "am02_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/am02_44.mp4",
+            "source_checksum": "4390510d57278631ee031a0050b66cdf",
+            "input_file": "am02_44.mp4",
+            "output_format": "Unknown",
+            "result": "c4b11daafb3e163bcca28cb49051ac21"
+        },
+        {
+            "name": "al06_44",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/al06_44.mp4",
+            "source_checksum": "19903817fa98764385f393c3734c1d7c",
+            "input_file": "al06_44.mp4",
+            "output_format": "Unknown",
+            "result": "c908646e2162876f19d0cdf958ddc156"
+        },
+        {
+            "name": "as12_24",
+            "source": "https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/compressedMp4/as12_24.mp4",
+            "source_checksum": "30ab81336a4dab8a6287178ca27866c7",
+            "input_file": "as12_24.mp4",
+            "output_format": "Unknown",
+            "result": "cfabdc64e2e652806354ed8b821690c5"
+        }
+    ]
+}


### PR DESCRIPTION
MPEG-4 AAC mp4
modified:   scripts/gen_aac.py

- Modified Regex for MPEG2_AAC_ADIF
- Different parsers were added, one for each kind of file (compressed, raw and checksum)
- DVD3 Wav files were added
- Validation logic for audio files was added