### PR TITLE
decoders: gstreamer: Add mapping for GBRP10LE pixel format

### DIFF
--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -70,6 +70,7 @@ def output_format_to_gst(output_format: OutputFormat) -> str:
         OutputFormat.YUV444P: "Y444",
         OutputFormat.YUV444P10LE: "Y444_10LE",
         OutputFormat.YUV444P12LE: "Y444_12LE",
+        OutputFormat.GBRP10LE: "GBR_10LE",
     }
     if output_format not in mapping:
         raise Exception(f"No matching output format found in GStreamer for {output_format}")


### PR DESCRIPTION
ARGON AV1 test suite use GBR_10LE as output format, for GStreamer decoders map it to GBR_10LE.