### PR TITLE
ffmpeg: Detect and fail on software decoder fallback

### DIFF
--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -88,9 +88,12 @@ def run_command_with_output(
     verbose: bool = False,
     check: bool = True,
     timeout: Optional[int] = None,
+    keep_stderr: bool = False,
 ) -> str:
     """Runs a command and returns std output trace"""
-    serr = subprocess.DEVNULL if not verbose else subprocess.STDOUT
+    serr = subprocess.DEVNULL
+    if verbose or keep_stderr:
+        serr = subprocess.STDOUT
     if verbose:
         print(f'\nRunning command "{" ".join(command)}"')
 


### PR DESCRIPTION
The goal of fluster is to test one specific implementation, allowing software fallback hides possible integration issues.