### PR TITLE
COM-12616

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ ISO_IEC_13818-4_2004
     Description: ISO_IEC_13818-4_2004 ADTS conformance test suite
     Test vectors: 62
 
-ISO_IEC_14496-26_2010
+MPEG4_AAC-ADTS
     Codec: AAC
-    Description: ISO_IEC_14496-26_2010 ADTS conformance test suite
+    Description: ISO IEC 14496-26 MPEG4 AAC ADTS test suite
     Test vectors: 9
 
 JCT-VC-HEVC_V1

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Find more about how to use Fluster in the next section.
 ```bash
 List of available test suites:
 
-ISO_IEC_13818-4_2004
+MPEG2_AAC-ADTS
     Codec: AAC
-    Description: ISO_IEC_13818-4_2004 ADTS conformance test suite
+    Description:ISO IEC 13818-4 MPEG2 AAC ADTS test suite
     Test vectors: 62
 
 MPEG4_AAC-ADTS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ packages = ["fluster", "fluster.decoders"]
     "test_suites/aac/MPEG2_AAC-ADTS.json",
     "test_suites/aac/MPEG2_AAC-ADIF.json",
     "test_suites/aac/MPEG4_AAC-ADIF.json",
-    "test_suites/aac/ISO_IEC_14496-26_2010.json"
+    "test_suites/aac/MPEG4_AAC-ADTS.json"
 ]
 "share/fluster/test_suites/av1" = [
     "test_suites/av1/AV1-TEST-VECTORS.json",
@@ -57,8 +57,8 @@ packages = ["fluster", "fluster.decoders"]
     "test_suites/h264/JVT-AVC_V1.json",
     "test_suites/h264/JVT-FR-EXT.json",
     "test_suites/h264/JVT-MVC.json",
-    "test_suites/h264/JVT-Professional_profiles_V1.json",
-    "test_suites/h264/JVT-SVC_V1.json"
+    "test_suites/h264/JVT-Professional_profiles.json",
+    "test_suites/h264/JVT-SVC.json"
 ]
 "share/fluster/test_suites/h265" = [
     "test_suites/h265/JCT-VC-3D-HEVC.json",

--- a/scripts/gen_jvt.py
+++ b/scripts/gen_jvt.py
@@ -155,7 +155,7 @@ class JVTGenerator:
                     test_vector.output_format = OutputFormat[pix_fmt.upper()]
                 except KeyError as key_err:
                     exceptions = {
-                        # All below test vectors from JVT-Professional_profiles_V1
+                        # All below test vectors from JVT-Professional_profiles
                         # need to be analysed with respect to output format,
                         # for now it remains undetermined
                         "PPCV444I4_Mitsubishi_A": OutputFormat.NONE,
@@ -300,7 +300,7 @@ if __name__ == "__main__":
 
     generator = JVTGenerator(
         "Professional_profiles",
-        "JVT-Professional_profiles_V1",
+        "JVT-Professional_profiles",
         Codec.H264,
         "JVT Professional Profiles test suite",
         H264_URL,
@@ -310,7 +310,7 @@ if __name__ == "__main__":
 
     generator = JVTGenerator(
         "SVC",
-        "JVT-SVC_V1",
+        "JVT-SVC",
         Codec.H264,
         "JVT Scalable Video Coding test suite",
         H264_URL,

--- a/test_suites/aac/MPEG4_AAC-ADTS.json
+++ b/test_suites/aac/MPEG4_AAC-ADTS.json
@@ -1,7 +1,7 @@
 {
-    "name": "ISO_IEC_14496-26_2010",
+    "name": "MPEG4_AAC-ADTS",
     "codec": "AAC",
-    "description": "ISO_IEC_14496-26_2010 ADTS conformance test suite",
+    "description": "ISO IEC 14496-26 MPEG4 AAC ADTS test suite",
     "test_vectors": [
         {
             "name": "al18_08",

--- a/test_suites/h264/JVT-Professional_profiles.json
+++ b/test_suites/h264/JVT-Professional_profiles.json
@@ -1,5 +1,5 @@
 {
-    "name": "JVT-Professional_profiles_V1",
+    "name": "JVT-Professional_profiles",
     "codec": "H.264",
     "description": "JVT Professional Profiles test suite",
     "test_vectors": [

--- a/test_suites/h264/JVT-SVC.json
+++ b/test_suites/h264/JVT-SVC.json
@@ -1,5 +1,5 @@
 {
-    "name": "JVT-SVC_V1",
+    "name": "JVT-SVC",
     "codec": "H.264",
     "description": "JVT Scalable Video Coding test suite",
     "test_vectors": [


### PR DESCRIPTION
AAC:
- The ISO_IEC_14496-26_2010 name was changed by MPEG4_AAC-ADTS 

H264:
- The JVT-Professional_profiles_V1 name was changed by JVT-Professional_profiles
- The JVT-SVC_V1 name was changed by JVT-SVC

	modified:   README.md
	modified:   pyproject.toml
	modified:   scripts/gen_jvt.py
	renamed:    test_suites/aac/ISO_IEC_14496-26_2010.json -> test_suites/aac/MPEG4_AAC-ADTS.json
	renamed:    test_suites/h264/JVT-Professional_profiles_V1.json -> test_suites/h264/JVT-Professional_profiles.json
	renamed:    test_suites/h264/JVT-SVC_V1.json -> test_suites/h264/JVT-SVC.json