### PR TITLE
COM-12567

### DIFF
--- a/scripts/gen_aac.py
+++ b/scripts/gen_aac.py
@@ -88,10 +88,12 @@ class AACGenerator:
 
     def generate(self, download: bool, jobs: int) -> None:
         """Generates the test suite and saves it to a file"""
+        absolut_dest_dir = os.path.dirname(os.path.abspath(__file__))
+        absolut_resources_dir = os.path.join(absolut_dest_dir, "resources")
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
-            "resources",
+            absolut_resources_dir,
             self.suite_name,
             self.codec,
             self.description,
@@ -209,7 +211,8 @@ class AACGenerator:
                 except KeyError as key_err:
                     raise key_err
 
-        test_suite.to_json_file(output_filepath)
+        absolut_output_filepath = os.path.join(absolut_dest_dir, output_filepath)
+        test_suite.to_json_file(absolut_output_filepath)
         print("Generate new test suite: " + test_suite.name + ".json")
 
 

--- a/scripts/gen_aac.py
+++ b/scripts/gen_aac.py
@@ -88,12 +88,12 @@ class AACGenerator:
 
     def generate(self, download: bool, jobs: int) -> None:
         """Generates the test suite and saves it to a file"""
-        absolut_dest_dir = os.path.dirname(os.path.abspath(__file__))
-        absolut_resources_dir = os.path.join(absolut_dest_dir, "resources")
+        absolute_dest_dir = os.path.dirname(os.path.abspath(__file__))
+        absolute_resources_dir = os.path.join(absolute_dest_dir, "resources")
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
-            absolut_resources_dir,
+            absolute_resources_dir,
             self.suite_name,
             self.codec,
             self.description,
@@ -211,8 +211,8 @@ class AACGenerator:
                 except KeyError as key_err:
                     raise key_err
 
-        absolut_output_filepath = os.path.join(absolut_dest_dir, output_filepath)
-        test_suite.to_json_file(absolut_output_filepath)
+        absolute_output_filepath = os.path.join(absolute_dest_dir, output_filepath)
+        test_suite.to_json_file(absolute_output_filepath)
         print("Generate new test suite: " + test_suite.name + ".json")
 
 

--- a/scripts/gen_av1_aom.py
+++ b/scripts/gen_av1_aom.py
@@ -59,6 +59,8 @@ class AOMGenerator:
 
     def generate(self, download: bool, jobs: int) -> None:
         """Generates the test suite and saves it to a file"""
+        absolut_dest_dir = os.path.dirname(os.path.abspath(__file__))
+        absolut_resources_dir = os.path.join(absolut_dest_dir, "resources")
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
@@ -142,7 +144,8 @@ class AOMGenerator:
             test_vector.result = self.decoder.decode(dest_path, out420, test_vector.output_format, 30, False, False)
             os.remove(out420)
 
-        test_suite.to_json_file(output_filepath)
+        absolut_output_filepath = os.path.join(absolut_dest_dir, output_filepath)
+        test_suite.to_json_file(absolut_output_filepath)
         print("Generate new test suite: " + test_suite.name + ".json")
 
 

--- a/scripts/gen_av1_aom.py
+++ b/scripts/gen_av1_aom.py
@@ -64,7 +64,7 @@ class AOMGenerator:
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
-            "resources",
+            absolut_resources_dir,
             self.suite_name,
             self.codec,
             self.description,

--- a/scripts/gen_av1_aom.py
+++ b/scripts/gen_av1_aom.py
@@ -59,12 +59,12 @@ class AOMGenerator:
 
     def generate(self, download: bool, jobs: int) -> None:
         """Generates the test suite and saves it to a file"""
-        absolut_dest_dir = os.path.dirname(os.path.abspath(__file__))
-        absolut_resources_dir = os.path.join(absolut_dest_dir, "resources")
+        absolute_dest_dir = os.path.dirname(os.path.abspath(__file__))
+        absolute_resources_dir = os.path.join(absolute_dest_dir, "resources")
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
-            absolut_resources_dir,
+            absolute_resources_dir,
             self.suite_name,
             self.codec,
             self.description,
@@ -144,8 +144,8 @@ class AOMGenerator:
             test_vector.result = self.decoder.decode(dest_path, out420, test_vector.output_format, 30, False, False)
             os.remove(out420)
 
-        absolut_output_filepath = os.path.join(absolut_dest_dir, output_filepath)
-        test_suite.to_json_file(absolut_output_filepath)
+        absolute_output_filepath = os.path.join(absolute_dest_dir, output_filepath)
+        test_suite.to_json_file(absolute_output_filepath)
         print("Generate new test suite: " + test_suite.name + ".json")
 
 

--- a/scripts/gen_av1_argon.py
+++ b/scripts/gen_av1_argon.py
@@ -58,8 +58,8 @@ class AV1ArgonGenerator:
     def generate(self, download: bool) -> None:
         """Generates the test suite and saves it to a file"""
         output_filepath = os.path.join(self.suite_name + ".json")
-        absolut_dest_dir = os.path.dirname(os.path.abspath(__file__))
-        extract_folder = os.path.join(absolut_dest_dir, "resources")
+        absolute_dest_dir = os.path.dirname(os.path.abspath(__file__))
+        extract_folder = os.path.join(absolute_dest_dir, "resources")
         test_suite = TestSuite(
             output_filepath,
             extract_folder,
@@ -158,8 +158,8 @@ class AV1ArgonGenerator:
             )
             test_suite.test_vectors[filename] = test_vector
 
-        absolut_output_filepath = os.path.join(absolut_dest_dir, output_filepath)
-        test_suite.to_json_file(absolut_output_filepath)
+        absolute_output_filepath = os.path.join(absolute_dest_dir, output_filepath)
+        test_suite.to_json_file(absolute_output_filepath)
         print("Generate new test suite: " + test_suite.name + ".json")
 
     @staticmethod

--- a/scripts/gen_av1_argon.py
+++ b/scripts/gen_av1_argon.py
@@ -58,7 +58,8 @@ class AV1ArgonGenerator:
     def generate(self, download: bool) -> None:
         """Generates the test suite and saves it to a file"""
         output_filepath = os.path.join(self.suite_name + ".json")
-        extract_folder = "resources"
+        absolut_dest_dir = os.path.dirname(os.path.abspath(__file__))
+        extract_folder = os.path.join(absolut_dest_dir, "resources")
         test_suite = TestSuite(
             output_filepath,
             extract_folder,
@@ -157,7 +158,8 @@ class AV1ArgonGenerator:
             )
             test_suite.test_vectors[filename] = test_vector
 
-        test_suite.to_json_file(output_filepath)
+        absolut_output_filepath = os.path.join(absolut_dest_dir, output_filepath)
+        test_suite.to_json_file(absolut_output_filepath)
         print("Generate new test suite: " + test_suite.name + ".json")
 
     @staticmethod

--- a/scripts/gen_av1_chromium.py
+++ b/scripts/gen_av1_chromium.py
@@ -96,6 +96,8 @@ class ChromiumAV1Generator:
 
     def generate(self, download: bool, jobs: int) -> Any:
         """Generates the test suite and saves it to a file"""
+        absolut_dest_dir = os.path.dirname(os.path.abspath(__file__))
+        absolut_resources_dir = os.path.join(absolut_dest_dir, "resources")
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
@@ -149,7 +151,8 @@ class ChromiumAV1Generator:
             test_vector.result = self.decoder.decode(dest_path, out420, test_vector.output_format, 30, False, False)
             os.remove(out420)
 
-        test_suite.to_json_file(output_filepath)
+        absolut_output_filepath = os.path.join(absolut_dest_dir, output_filepath)
+        test_suite.to_json_file(absolut_output_filepath)
         print("Generate new test suite: " + test_suite.name + ".json")
 
 

--- a/scripts/gen_av1_chromium.py
+++ b/scripts/gen_av1_chromium.py
@@ -96,12 +96,12 @@ class ChromiumAV1Generator:
 
     def generate(self, download: bool, jobs: int) -> Any:
         """Generates the test suite and saves it to a file"""
-        absolut_dest_dir = os.path.dirname(os.path.abspath(__file__))
-        absolut_resources_dir = os.path.join(absolut_dest_dir, "resources")
+        absolute_dest_dir = os.path.dirname(os.path.abspath(__file__))
+        absolute_resources_dir = os.path.join(absolute_dest_dir, "resources")
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
-            "resources",
+            absolute_resources_dir,
             self.suite_name,
             self.codec,
             self.description,
@@ -151,8 +151,8 @@ class ChromiumAV1Generator:
             test_vector.result = self.decoder.decode(dest_path, out420, test_vector.output_format, 30, False, False)
             os.remove(out420)
 
-        absolut_output_filepath = os.path.join(absolut_dest_dir, output_filepath)
-        test_suite.to_json_file(absolut_output_filepath)
+        absolute_output_filepath = os.path.join(absolute_dest_dir, output_filepath)
+        test_suite.to_json_file(absolute_output_filepath)
         print("Generate new test suite: " + test_suite.name + ".json")
 
 

--- a/scripts/gen_jct_vc.py
+++ b/scripts/gen_jct_vc.py
@@ -77,12 +77,12 @@ class JCTVCGenerator:
 
     def generate(self, download: bool, jobs: int) -> None:
         """Generates the test suite and saves it to a file"""
-        absolut_dest_dir = os.path.dirname(os.path.abspath(__file__))
-        absolut_resources_dir = os.path.join(absolut_dest_dir, "resources")
+        absolute_dest_dir = os.path.dirname(os.path.abspath(__file__))
+        absolute_resources_dir = os.path.join(absolute_dest_dir, "resources")
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
-            absolut_resources_dir,
+            absolute_resources_dir,
             self.suite_name,
             self.codec,
             self.description,
@@ -180,8 +180,8 @@ class JCTVCGenerator:
 
             self._fill_checksum_h265(test_vector, dest_dir)
 
-        absolut_output_filepath = os.path.join(absolut_dest_dir, output_filepath)
-        test_suite.to_json_file(absolut_output_filepath)
+        absolute_output_filepath = os.path.join(absolute_dest_dir, output_filepath)
+        test_suite.to_json_file(absolute_output_filepath)
         print("Generate new test suite: " + test_suite.name + ".json")
 
     def _fill_checksum_h265(self, test_vector: TestVector, dest_dir: str) -> None:

--- a/scripts/gen_jct_vc.py
+++ b/scripts/gen_jct_vc.py
@@ -82,7 +82,7 @@ class JCTVCGenerator:
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
-            "resources",
+            absolut_resources_dir,
             self.suite_name,
             self.codec,
             self.description,

--- a/scripts/gen_jct_vc.py
+++ b/scripts/gen_jct_vc.py
@@ -77,6 +77,8 @@ class JCTVCGenerator:
 
     def generate(self, download: bool, jobs: int) -> None:
         """Generates the test suite and saves it to a file"""
+        absolut_dest_dir = os.path.dirname(os.path.abspath(__file__))
+        absolut_resources_dir = os.path.join(absolut_dest_dir, "resources")
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
@@ -178,7 +180,8 @@ class JCTVCGenerator:
 
             self._fill_checksum_h265(test_vector, dest_dir)
 
-        test_suite.to_json_file(output_filepath)
+        absolut_output_filepath = os.path.join(absolut_dest_dir, output_filepath)
+        test_suite.to_json_file(absolut_output_filepath)
         print("Generate new test suite: " + test_suite.name + ".json")
 
     def _fill_checksum_h265(self, test_vector: TestVector, dest_dir: str) -> None:

--- a/scripts/gen_jvet.py
+++ b/scripts/gen_jvet.py
@@ -78,12 +78,12 @@ class JVETGenerator:
 
     def generate(self, download: bool, jobs: int) -> None:
         """Generates the test suite and saves it to a file"""
-        absolut_dest_dir = os.path.dirname(os.path.abspath(__file__))
-        absolut_resources_dir = os.path.join(absolut_dest_dir, "resources")
+        absolute_dest_dir = os.path.dirname(os.path.abspath(__file__))
+        absolute_resources_dir = os.path.join(absolute_dest_dir, "resources")
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
-            absolut_resources_dir,
+            absolute_resources_dir,
             self.suite_name,
             self.codec,
             self.description,
@@ -171,8 +171,8 @@ class JVETGenerator:
 
             self._fill_checksum_h266(test_vector, dest_dir)
 
-        absolut_output_filepath = os.path.join(absolut_dest_dir, output_filepath)
-        test_suite.to_json_file(absolut_output_filepath)
+        absolute_output_filepath = os.path.join(absolute_dest_dir, output_filepath)
+        test_suite.to_json_file(absolute_output_filepath)
         print("Generate new test suite: " + test_suite.name + ".json")
 
     @staticmethod

--- a/scripts/gen_jvet.py
+++ b/scripts/gen_jvet.py
@@ -83,7 +83,7 @@ class JVETGenerator:
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
-            "resources",
+            absolut_resources_dir,
             self.suite_name,
             self.codec,
             self.description,

--- a/scripts/gen_jvet.py
+++ b/scripts/gen_jvet.py
@@ -78,6 +78,8 @@ class JVETGenerator:
 
     def generate(self, download: bool, jobs: int) -> None:
         """Generates the test suite and saves it to a file"""
+        absolut_dest_dir = os.path.dirname(os.path.abspath(__file__))
+        absolut_resources_dir = os.path.join(absolut_dest_dir, "resources")
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
@@ -169,7 +171,8 @@ class JVETGenerator:
 
             self._fill_checksum_h266(test_vector, dest_dir)
 
-        test_suite.to_json_file(output_filepath)
+        absolut_output_filepath = os.path.join(absolut_dest_dir, output_filepath)
+        test_suite.to_json_file(absolut_output_filepath)
         print("Generate new test suite: " + test_suite.name + ".json")
 
     @staticmethod

--- a/scripts/gen_jvt.py
+++ b/scripts/gen_jvt.py
@@ -84,6 +84,8 @@ class JVTGenerator:
     def generate(self, download: bool, jobs: int) -> None:
         """Generates the test suite and saves it to a file"""
         new_test_vectors = []
+        absolut_dest_dir = os.path.dirname(os.path.abspath(__file__))
+        absolut_resources_dir = os.path.join(absolut_dest_dir, "resources")
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
@@ -211,7 +213,8 @@ class JVTGenerator:
                 else:
                     self._fill_checksum_h264(test_vector, dest_dir)
 
-        test_suite.to_json_file(output_filepath)
+        absolut_output_filepath = os.path.join(absolut_dest_dir, output_filepath)
+        test_suite.to_json_file(absolut_output_filepath)
         print("Generate new test suite: " + test_suite.name + ".json")
 
     @staticmethod

--- a/scripts/gen_jvt.py
+++ b/scripts/gen_jvt.py
@@ -84,12 +84,12 @@ class JVTGenerator:
     def generate(self, download: bool, jobs: int) -> None:
         """Generates the test suite and saves it to a file"""
         new_test_vectors = []
-        absolut_dest_dir = os.path.dirname(os.path.abspath(__file__))
-        absolut_resources_dir = os.path.join(absolut_dest_dir, "resources")
+        absolute_dest_dir = os.path.dirname(os.path.abspath(__file__))
+        absolute_resources_dir = os.path.join(absolute_dest_dir, "resources")
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
-            absolut_resources_dir,
+            absolute_resources_dir,
             self.suite_name,
             self.codec,
             self.description,
@@ -213,8 +213,8 @@ class JVTGenerator:
                 else:
                     self._fill_checksum_h264(test_vector, dest_dir)
 
-        absolut_output_filepath = os.path.join(absolut_dest_dir, output_filepath)
-        test_suite.to_json_file(absolut_output_filepath)
+        absolute_output_filepath = os.path.join(absolute_dest_dir, output_filepath)
+        test_suite.to_json_file(absolute_output_filepath)
         print("Generate new test suite: " + test_suite.name + ".json")
 
     @staticmethod

--- a/scripts/gen_jvt.py
+++ b/scripts/gen_jvt.py
@@ -89,7 +89,7 @@ class JVTGenerator:
         output_filepath = os.path.join(self.suite_name + ".json")
         test_suite = TestSuite(
             output_filepath,
-            "resources",
+            absolut_resources_dir,
             self.suite_name,
             self.codec,
             self.description,


### PR DESCRIPTION
Refactor all test suite generators so that they always create test suites in the same relative path in relation to the script's path