### PR TITLE
COM-12617: Add basic AV1 tests for Makefile check target

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         make install_deps
-        sudo apt update && sudo apt install gstreamer1.0-tools gstreamer1.0-libav gstreamer1.0-plugins-bad ffmpeg vpx-tools
+        sudo apt update && sudo apt install gstreamer1.0-tools gstreamer1.0-libav gstreamer1.0-plugins-bad ffmpeg vpx-tools aom-tools
     - name: Check
       run: |
         make check
@@ -45,7 +45,7 @@ jobs:
     - name: Install dependencies
       run: |
         make install_deps
-        sudo apt update && sudo apt install gstreamer1.0-tools gstreamer1.0-libav gstreamer1.0-plugins-bad ffmpeg vpx-tools
+        sudo apt update && sudo apt install gstreamer1.0-tools gstreamer1.0-libav gstreamer1.0-plugins-bad ffmpeg vpx-tools aom-tools
     - name: Check
       run: |
         make check

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ ifneq ($(OS),Windows_NT)
 	$(FLUSTER) run -ts dummy_fail -j1 -ff -s; test $$? -ne 0
 	$(FLUSTER) download dummy non_existing_test_suite -k; test $$? -ne 0
 	$(FLUSTER) download dummy dummy_download_fail -k; test $$? -ne 0
-	$(FLUSTER) download H264-min H265-min VP8-min VP9-min -k
+	$(FLUSTER) download AV1-min H264-min H265-min VP8-min VP9-min -k
+	$(FLUSTER) run -ts AV1-min -d libaom-AV1 -s
 	$(FLUSTER) run -ts H264-min -d GStreamer-H.264-Libav-Gst1.0 FFmpeg-H.264 -s
 	$(FLUSTER) run -ts H265-min -d GStreamer-H.265-Libav-Gst1.0 FFmpeg-H.265 -s
 	$(FLUSTER) run -ts VP8-min -d libvpx-VP8 -s

--- a/check/AV1.json
+++ b/check/AV1.json
@@ -1,0 +1,15 @@
+{
+    "name": "AV1-min",
+    "codec": "AV1",
+    "description": "AV1 Test Vector Catalogue from https://storage.googleapis.com/aom-test-data",
+    "test_vectors": [
+        {
+            "name": "av1-1-b8-01-size-200x226",
+            "source": "https://storage.googleapis.com/aom-test-data/av1-1-b8-01-size-200x226.ivf",
+            "source_checksum": "b5597b4ee41c15ccc323406ad7618c55",
+            "input_file": "av1-1-b8-01-size-200x226.ivf",
+            "output_format": "yuv420p",
+            "result": "dd58cb951625357094575a2b591781ee"
+        }
+    ]
+}


### PR DESCRIPTION
We want to add some basic test suites and tests for AV1 in target check of Makefile