### PR TITLE
fix: Add pixel method to generators for mpeg2/4 video

### DIFF
--- a/scripts/gen_mpeg2_video.py
+++ b/scripts/gen_mpeg2_video.py
@@ -29,7 +29,7 @@ from urllib.parse import urljoin
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from fluster import utils
 from fluster.codec import Codec, OutputFormat
-from fluster.test_suite import TestSuite
+from fluster.test_suite import TestMethod, TestSuite
 from fluster.test_vector import TestVector
 
 BASE_URL = "https://standards.iso.org/"
@@ -83,6 +83,7 @@ class MPEG2VIDEOGenerator:
         self.description = description
         self.site = site
         self.use_ffprobe = use_ffprobe
+        self.test_method = TestMethod.PIXEL
 
     def generate(self, download: bool, jobs: int) -> None:
         """Generates the test suite and downloads bitstreams"""
@@ -96,6 +97,7 @@ class MPEG2VIDEOGenerator:
             self.codec,
             self.description,
             {},
+            test_method=self.test_method,
         )
 
         print(f"Download list of bitstreams from {self.site + self.name}")

--- a/scripts/gen_mpeg4_video.py
+++ b/scripts/gen_mpeg4_video.py
@@ -28,7 +28,7 @@ from urllib.parse import urljoin
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from fluster import utils
 from fluster.codec import Codec, OutputFormat, Profile
-from fluster.test_suite import TestSuite
+from fluster.test_suite import TestMethod, TestSuite
 from fluster.test_vector import TestVector
 from fluster.utils import create_enhanced_opener
 
@@ -88,6 +88,7 @@ class MPEG4VIDEOGenerator:
         description: str,
         resources: List[str],
         use_ffprobe: bool = False,
+        test_method: TestMethod = TestMethod.PIXEL,
     ):
         self.name = name
         self.suite_name = suite_name
@@ -95,6 +96,7 @@ class MPEG4VIDEOGenerator:
         self.description = description
         self.resources = resources
         self.use_ffprobe = use_ffprobe
+        self.test_method = test_method
 
     def generate(self, download: bool, jobs: int) -> None:
         absolute_dest_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Add pixel method for JSON generation of MPEG2/4 video test suites.