### PR TITLE
Test vectors in suites for MPEG4 video and H.266 have undetermined output format

### DIFF
--- a/scripts/gen_jvet.py
+++ b/scripts/gen_jvet.py
@@ -147,11 +147,7 @@ class JVETGenerator:
                     pix_fmt = result[0]
                     test_vector.output_format = OutputFormat[pix_fmt.upper()]
                 except KeyError as key_err:
-                    exceptions = {
-                        # All below test vectors need to be analysed with respect
-                        # to output format, for now remains undetermined
-                        "VPS_C_ERICSSON_1": OutputFormat.NONE
-                    }
+                    exceptions = {"VPS_C_ERICSSON_1": OutputFormat.YUV420P10LE}
                     if test_vector.name in exceptions.keys():
                         test_vector.output_format = exceptions[test_vector.name]
                     else:
@@ -159,10 +155,11 @@ class JVETGenerator:
                 except CalledProcessError as proc_err:
                     exceptions = {
                         # All below test vectors cause ffprobe to crash
-                        "MNUT_A_Nokia_3": OutputFormat.NONE,
-                        "MNUT_B_Nokia_2": OutputFormat.NONE,
-                        "SUBPIC_C_ERICSSON_1": OutputFormat.NONE,
-                        "SUBPIC_D_ERICSSON_1": OutputFormat.NONE,
+                        # Values taken from doc, .txt from (.zip)
+                        "MNUT_A_Nokia_3": OutputFormat.YUV420P10LE,
+                        "MNUT_B_Nokia_2": OutputFormat.YUV420P10LE,
+                        "SUBPIC_C_ERICSSON_1": OutputFormat.YUV420P10LE,
+                        "SUBPIC_D_ERICSSON_1": OutputFormat.YUV420P10LE,
                     }
                     if test_vector.name in exceptions.keys():
                         test_vector.output_format = exceptions[test_vector.name]

--- a/scripts/gen_mpeg4_video.py
+++ b/scripts/gen_mpeg4_video.py
@@ -210,12 +210,12 @@ class MPEG4VIDEOGenerator:
                                         # All information taken from mediainfo
                                         "vcon-stp5L1": OutputFormat.YUV420P,
                                         "ibm_tempete_e": OutputFormat.YUV420P,
-                                        # Simple Studio Profile unknown formats
-                                        "vcon-stp13L2": OutputFormat.UNKNOWN,
-                                        "vcon-stp12L2": OutputFormat.UNKNOWN,
-                                        "vcon-stpsh2L1": OutputFormat.UNKNOWN,
-                                        "vcon-stpsh1L1": OutputFormat.UNKNOWN,
-                                        "vcon-stpsp1L1": OutputFormat.UNKNOWN,
+                                        # Simple Studio Profile taken from ffmpeg and doc
+                                        "vcon-stp13L2": OutputFormat.YUV444P,
+                                        "vcon-stp12L2": OutputFormat.YUV444P,
+                                        "vcon-stpsh2L1": OutputFormat.YUV422P,
+                                        "vcon-stpsh1L1": OutputFormat.YUV422P,
+                                        "vcon-stpsp1L1": OutputFormat.YUV422P,
                                     }
                                     if test_vector.name in exceptions_output_format:
                                         test_vector.output_format = exceptions_output_format[test_vector.name]

--- a/test_suites/h.266/JVET-VVC_draft6.json
+++ b/test_suites/h.266/JVET-VVC_draft6.json
@@ -1344,7 +1344,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MNUT_A_Nokia_3.zip",
             "source_checksum": "e26d46c79970021742f0696016220a3a",
             "input_file": "MNUT_A_Nokia_3.bit",
-            "output_format": "None",
+            "output_format": "yuv420p10le",
             "result": "9efb8eeb6095c361bf6f092e4bb145f8"
         },
         {
@@ -1352,7 +1352,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/MNUT_B_Nokia_2.zip",
             "source_checksum": "2b6394fdefdf620245daf84a514d6867",
             "input_file": "MNUT_B_Nokia_2.bit",
-            "output_format": "None",
+            "output_format": "yuv420p10le",
             "result": "e90ab172fc157094ef4c78f80a3771da"
         },
         {
@@ -1960,7 +1960,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SUBPIC_C_ERICSSON_1.zip",
             "source_checksum": "c7f52bfadc93cc418b6f426669541cbb",
             "input_file": "SUBPIC_C_ERICSSON_1.bit",
-            "output_format": "None",
+            "output_format": "yuv420p10le",
             "result": "cab9bc6ae7f0bb6045b4b4d533a97495"
         },
         {
@@ -1968,7 +1968,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/SUBPIC_D_ERICSSON_1.zip",
             "source_checksum": "2a42772ab65ac31fb84cd370eaa571cd",
             "input_file": "SUBPIC_D_ERICSSON_1.bit",
-            "output_format": "None",
+            "output_format": "yuv420p10le",
             "result": "4b7461f334c4711fa2f5e8b60a3c31c8"
         },
         {
@@ -2192,7 +2192,7 @@
             "source": "https://www.itu.int/wftp3/av-arch/jvet-site/bitstream_exchange/VVC/draft_conformance/draft6/VPS_C_ERICSSON_1.zip",
             "source_checksum": "4a7a2f3a42ed96e0f313ad17bcedc1b7",
             "input_file": "VPS_C_ERICSSON_1.bit",
-            "output_format": "None",
+            "output_format": "yuv420p10le",
             "result": "10f5abbddce19b9290ff73567757f0a0"
         },
         {

--- a/test_suites/mpeg4v/MPEG4_VIDEO-SimpleStudioProfile.json
+++ b/test_suites/mpeg4v/MPEG4_VIDEO-SimpleStudioProfile.json
@@ -27,7 +27,7 @@
             "source_checksum": "d41d85201257d45d87f86c4708fc9c37",
             "input_file": "vcon-stp13L2.bits",
             "profile": "Simple Studio Profile",
-            "output_format": "Unknown",
+            "output_format": "yuv444p",
             "result": ""
         },
         {
@@ -72,7 +72,7 @@
             "source_checksum": "96a953fd5ca2ab8724c33441dbfe0b9c",
             "input_file": "C051232e_Electronic inserts/studio/vcon-stpsh2L1.bits",
             "profile": "Simple Studio Profile",
-            "output_format": "Unknown",
+            "output_format": "yuv422p",
             "result": ""
         },
         {
@@ -90,7 +90,7 @@
             "source_checksum": "96a953fd5ca2ab8724c33441dbfe0b9c",
             "input_file": "C051232e_Electronic inserts/studio/vcon-stpsh1L1.bits",
             "profile": "Simple Studio Profile",
-            "output_format": "Unknown",
+            "output_format": "yuv422p",
             "result": ""
         },
         {
@@ -117,7 +117,7 @@
             "source_checksum": "96a953fd5ca2ab8724c33441dbfe0b9c",
             "input_file": "C051232e_Electronic inserts/studio/vcon-stpsp1L1.bits",
             "profile": "Simple Studio Profile",
-            "output_format": "Unknown",
+            "output_format": "yuv422p",
             "result": ""
         },
         {
@@ -189,7 +189,7 @@
             "source_checksum": "76871b4a631964344300bc70978b30a6",
             "input_file": "vcon-stp12L2.bits",
             "profile": "Simple Studio Profile",
-            "output_format": "Unknown",
+            "output_format": "yuv444p",
             "result": ""
         },
         {


### PR DESCRIPTION
**H.266 test vectors None → yuv420p10le**

seeing downloaded txt files attached in the zip file:

e.g.
The purpose of this bitstream is to test decoding of a bitstream that contains mixed NAL unit types in some of the pictures.

```
Bitstream file:         MNUT_A_Nokia_3.bit
Profile:                Main 10
Tier:                   Main
Level:                  3
Format:                 YUV 420
Picture size:           704x576
Picture rate:           30
CTU size:               32x32
GOP length:             16
Number of pictures:     65
```

**MPEG4 Studio Profile Test Vectors:**

Used FFmpeg to analyze bitstream characteristics and determine bit depth, e.g.:

`ffmpeg -i "vcon-stp12L2" -frames:v 1 test_output.yuv -v verbose 2>&1`

FFmpeg reports specific error messages for 8-bit vs 10-bit Studio Profile streams:

`    8-bit: "MPEG-4 Studio profile bit-depth 8 is not implemented"`

Results:

`Test VectorLevelConfirmed FormatMethodvcon-stp13L2L2yuv444pFFmpeg confirmed 8-bitvcon-stp12L2L2yuv444pFFmpeg confirmed 8-bitvcon-stpsh1L1L1yuv422pPattern inference (shape test)vcon-stpsh2L1L1yuv422pPattern inference (shape test)vcon-stpsp1L1L1yuv422pPattern inference (sprite test)`

Pattern Identified:

    Level 1: yuv422p (8-bit) or yuv422p10le (10-bit)
    Level 2+: yuv444p (8-bit) or yuv444p10le (10-bit)