### PR TITLE
fix: calculate AV1 Argon checksums based on output of reference decoder

### DIFF
--- a/fluster/decoders/av1_aom.py
+++ b/fluster/decoders/av1_aom.py
@@ -28,7 +28,6 @@ class AV1AOMDecoder(Decoder):
     description = "libaom AV1 reference decoder"
     binary = "aomdec"
     codec = Codec.AV1
-    multiple_layers = False
     annexb = False
 
     def decode(
@@ -42,14 +41,10 @@ class AV1AOMDecoder(Decoder):
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         fmt = "--rawvideo"
-        if not self.multiple_layers and not self.annexb:
-            if output_format in [OutputFormat.YUV420P, OutputFormat.YUV420P10LE]:
-                fmt = "--i420"
 
         cmd = [
             self.binary,
             "--annexb" if self.annexb else "",
-            "--all-layers" if self.multiple_layers else "",
             fmt,
             input_filepath,
             "-o",

--- a/fluster/fluster.py
+++ b/fluster/fluster.py
@@ -271,11 +271,8 @@ class Fluster:
             test_suite_results: List[Tuple[Decoder, TestSuite]] = []
             for decoder in ctx.decoders:
                 if isinstance(decoder, AV1AOMDecoder) and decoder.name == "libaom-AV1":
-                    if "NON-ANNEX-B" in test_suite.name:
-                        decoder.multiple_layers = True
-                    elif "ANNEX-B" in test_suite.name:
+                    if any(keyword in test_suite.name for keyword in ["CORE", "STRESS"]):
                         decoder.annexb = True
-                        decoder.multiple_layers = True
                 if decoder.codec != test_suite.codec:
                     continue
                 if test_suite.test_method == TestMethod.PIXEL and decoder.is_reference:

--- a/test_suites/av1/AV1-ARGON-PROFILE0-CORE-ANNEX-B.json
+++ b/test_suites/av1/AV1-ARGON-PROFILE0-CORE-ANNEX-B.json
@@ -297,7 +297,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test47.obu",
             "output_format": "gray",
-            "result": "76b057be715888c0cd578575f5ba4685"
+            "result": "c42e670939dbf64ea4b9c7dcf53a56e0"
         },
         {
             "name": "test9",
@@ -481,7 +481,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test8592_9122.obu",
             "output_format": "yuv420p10le",
-            "result": "ba787bc2f8c30adc3ed87e084b1d8662"
+            "result": "f71b6b4623a95df048d0b3551bb3c63c"
         },
         {
             "name": "test8522",
@@ -553,7 +553,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test1173.obu",
             "output_format": "yuv420p10le",
-            "result": "c88ce2a6c4d48a80531a9eb4a7e5d3d9"
+            "result": "fe559ea7ef4b59c28da8ab078d4b3be0"
         },
         {
             "name": "test5852",
@@ -569,7 +569,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7480_1508_9615.obu",
             "output_format": "gray",
-            "result": "7fd722932247da367c40f0ad530f71aa"
+            "result": "99b3b6b5eb44fd7aa68a0e4f1f04c19c"
         },
         {
             "name": "test5426",
@@ -585,7 +585,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test193_580_363.obu",
             "output_format": "yuv420p10le",
-            "result": "b713c290cff8e09387416208ea55e7a0"
+            "result": "696618ef1f9bbb0df1c3d7eed6fb54c5"
         },
         {
             "name": "test7565",
@@ -617,7 +617,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6388_83.obu",
             "output_format": "gray10le",
-            "result": "746ef8e46815a4a9077f0946232f31c1"
+            "result": "5b76375a7f79a4b66e01da279309a91e"
         },
         {
             "name": "test5457_273_8703",
@@ -625,7 +625,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5457_273_8703.obu",
             "output_format": "gray10le",
-            "result": "dd6ffb2b13c6d055c181a40cf2dc2941"
+            "result": "d6388852adc96e23a7cdd799ee177080"
         },
         {
             "name": "test11030_11013",
@@ -641,7 +641,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6553_1156_6021.obu",
             "output_format": "gray10le",
-            "result": "81d708e0b447c6893a94d9291b11f31f"
+            "result": "0e68ffbfb58e294591b8aa63003f5a31"
         },
         {
             "name": "test1734",
@@ -689,7 +689,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5787_1353_10447.obu",
             "output_format": "gray",
-            "result": "885efcd3b59f4253a3b8290ed41ea8b5"
+            "result": "e36e522f21c6f90753ebefe42beca39f"
         },
         {
             "name": "test10571_10597_10562",
@@ -713,7 +713,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test1497.obu",
             "output_format": "yuv420p10le",
-            "result": "4767550d5e6ff4627c4fcab380078503"
+            "result": "0e185a10f7eb87f1d98ce9c5aa545e05"
         },
         {
             "name": "test6509",
@@ -753,7 +753,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10373_10136.obu",
             "output_format": "gray10le",
-            "result": "ef261f6d9eda30bc53b44936007bbe21"
+            "result": "1d578b4c6f2540d666eaaf46a7821dd9"
         },
         {
             "name": "test10262",
@@ -777,7 +777,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7619_1359_7864.obu",
             "output_format": "gray",
-            "result": "2c6b95a58073cb2b4578b34218204776"
+            "result": "2cc1207a81f82657d9f1686a2bf192b1"
         },
         {
             "name": "test5226",
@@ -801,7 +801,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10265_10066_9716.obu",
             "output_format": "gray10le",
-            "result": "6bc827a49a7b0729b38d0d714bc15c6a"
+            "result": "bb084acd57aa70059a7b6145b3ffb1d1"
         },
         {
             "name": "test2617",
@@ -905,7 +905,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10072_2027.obu",
             "output_format": "yuv420p",
-            "result": "2018037293cc147a9b3cce458c9762b9"
+            "result": "bd50edd6fef6f76146fe1868ddd7e6fb"
         },
         {
             "name": "test4208",
@@ -929,7 +929,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5492_7815_9143.obu",
             "output_format": "yuv420p10le",
-            "result": "6317ebbd550b889cc43b74763f906a89"
+            "result": "fbaf2ac6e6e2d5a7228e4e8f9cc81eeb"
         },
         {
             "name": "test10202",
@@ -953,7 +953,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5435_8737_9727.obu",
             "output_format": "yuv420p10le",
-            "result": "3af6f94bb491fb60763c602749f7423d"
+            "result": "0571cfe73bdf2228771d365154670651"
         },
         {
             "name": "test5397",
@@ -1073,7 +1073,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7528.obu",
             "output_format": "gray",
-            "result": "23a023f0bfdc7629b44861fbe664acf3"
+            "result": "042c079dafe0eed3bf45d47aab4ded92"
         },
         {
             "name": "test4331_4344",
@@ -1145,7 +1145,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test8061_10522_1700.obu",
             "output_format": "gray10le",
-            "result": "97c1716643ed5e5a85ff0c6a6ff69238"
+            "result": "32a5b8b7f95c8b31d332aaae6032bcaa"
         },
         {
             "name": "test8855_6417",
@@ -1169,7 +1169,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test8732.obu",
             "output_format": "gray",
-            "result": "00849f17dae754cc22ae4a6b42770acc"
+            "result": "a3b953fedaf571276031c3898f9c8dac"
         },
         {
             "name": "test4521_7439",
@@ -1185,7 +1185,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10446_512_421.obu",
             "output_format": "yuv420p10le",
-            "result": "502df9683a4a9b28082783876a011aac"
+            "result": "302475d8b6249de73ce283e4b8b2013f"
         },
         {
             "name": "test70_5729_9835",
@@ -1369,7 +1369,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test1355_8630_8591.obu",
             "output_format": "yuv420p",
-            "result": "4f5199a502e44e854c5d44fb22f3469e"
+            "result": "1428608c75416181a1cfb5c77c8404e2"
         },
         {
             "name": "test9467_2695_8582",
@@ -1417,7 +1417,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test192_8154_5982.obu",
             "output_format": "yuv420p10le",
-            "result": "717ca35b0597222a81ca229f8cc6d774"
+            "result": "54f3cc31542ebb0c4818a093e2b8b46d"
         },
         {
             "name": "test9065_5010_10294",
@@ -1425,7 +1425,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test9065_5010_10294.obu",
             "output_format": "gray10le",
-            "result": "35cfbcfa21a4e75e3006b24455854379"
+            "result": "cb70b6648ffbc89568be91238807c0d0"
         },
         {
             "name": "test10640",
@@ -1441,7 +1441,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test20018.obu",
             "output_format": "gray",
-            "result": "f638f7ed6cb4608eccf5ab7b7f2ed463"
+            "result": "00d3a750bfb41c99e890314018b23f3f"
         },
         {
             "name": "test5395",
@@ -1497,7 +1497,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5817.obu",
             "output_format": "gray10le",
-            "result": "1977f75de4b84733c4fc14c7801aeccd"
+            "result": "083fa13fa35409fc8cf537343226d767"
         },
         {
             "name": "test2933",
@@ -1569,7 +1569,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10197_10063.obu",
             "output_format": "gray",
-            "result": "e4b809623fd99f5198e652f67db0f6e9"
+            "result": "aca51b1c11a2589b32b6dd840686cfc1"
         },
         {
             "name": "test10299",
@@ -1705,7 +1705,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5944.obu",
             "output_format": "gray",
-            "result": "9fac4a1834c2922f76e33a2d71a1360f"
+            "result": "5324160353889371ea0f830c65d5037d"
         },
         {
             "name": "test11147",
@@ -1777,7 +1777,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7227_10418_542.obu",
             "output_format": "yuv420p",
-            "result": "b3dd98ae52cb6721d99e3b432aaea03c"
+            "result": "8469624424ce9c7182fab9fef8e08039"
         },
         {
             "name": "test5619",
@@ -1785,7 +1785,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5619.obu",
             "output_format": "gray10le",
-            "result": "007bf781521c30d102efdf1243205259"
+            "result": "e5cfae06a7c4bffb3090acacfcb138f4"
         },
         {
             "name": "test5378_1087",
@@ -1801,7 +1801,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7233_448_7579.obu",
             "output_format": "yuv420p",
-            "result": "138b7b234facb7577123a5840846540b"
+            "result": "d0aede03650198b8096f21408798da36"
         },
         {
             "name": "test9536",
@@ -1841,7 +1841,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test9008.obu",
             "output_format": "yuv420p",
-            "result": "03337ab89af45b9ce8f1c1a275d3d1b4"
+            "result": "f96d5c0ae47823cb741cbff52eb34bb1"
         },
         {
             "name": "test11145",
@@ -1865,7 +1865,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10409.obu",
             "output_format": "yuv420p",
-            "result": "424ea242b7c3918a0dfd312ceac68842"
+            "result": "b33a8fc79d9e6cbe488f2664f87980c4"
         },
         {
             "name": "test6536",
@@ -1913,7 +1913,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10804.obu",
             "output_format": "yuv420p",
-            "result": "94cce5df9d3eed7be7cad219511924d7"
+            "result": "243421ae9f97ac4ef370e64339fac53c"
         },
         {
             "name": "test10561",
@@ -1961,7 +1961,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7980_6204_7930.obu",
             "output_format": "yuv420p",
-            "result": "c95f60423ca30172ddbc32cca3792226"
+            "result": "bb52cef792d853e9d12a643c7070f5d8"
         },
         {
             "name": "test1228",
@@ -2025,7 +2025,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test9994.obu",
             "output_format": "yuv420p",
-            "result": "316e65680f6f1197a6607b7c2e2e9914"
+            "result": "e120b3292f2228e49bf1b3d1eb1435c6"
         },
         {
             "name": "test3469",
@@ -2329,7 +2329,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test2686_10005.obu",
             "output_format": "yuv420p10le",
-            "result": "0ab0fa85ae6929d50d4e4a549a1d44df"
+            "result": "146a32d94197ef7560ec02b2f975522b"
         },
         {
             "name": "test6079",
@@ -2369,7 +2369,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test9000_8273.obu",
             "output_format": "gray",
-            "result": "18a735f7504cc031451df51e6257b1bc"
+            "result": "68978aece189c09164632da10d683610"
         },
         {
             "name": "test1441",
@@ -2401,7 +2401,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test8776_5417_882.obu",
             "output_format": "gray",
-            "result": "9dd026e0fad407505038b400db0dfd0a"
+            "result": "2be4a367d375d5e413cf2f8c19ae0057"
         },
         {
             "name": "test98",
@@ -2457,7 +2457,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test11098.obu",
             "output_format": "yuv420p10le",
-            "result": "7c4d9b3b71eaff0213e47c3abf981081"
+            "result": "78b4172bb2d574b8eb60c42d4b0a62ec"
         },
         {
             "name": "test8795_4795",
@@ -2497,7 +2497,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10542_7758_7677.obu",
             "output_format": "yuv420p",
-            "result": "1d587c156ba7c024451cf436a3c269b4"
+            "result": "5d7a4c416bfcb23223a5d72588b2df36"
         },
         {
             "name": "test9549_4003",
@@ -2569,7 +2569,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test1023_2838_5793.obu",
             "output_format": "yuv420p10le",
-            "result": "2cf9a769725f4efa5e5ab09a8a526a37"
+            "result": "ff5b4b0d2b2a09f6292f736ea8c560f1"
         },
         {
             "name": "test5777_7622",
@@ -2617,7 +2617,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10053_10523.obu",
             "output_format": "yuv420p",
-            "result": "e5f4da813cba6260c32c3a59a11ac736"
+            "result": "46b86b62ebb1057e802df13023ec51b1"
         },
         {
             "name": "test1283",
@@ -2665,7 +2665,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test1168_6050_9589.obu",
             "output_format": "gray10le",
-            "result": "2623ace11c0426096f75012757138c7e"
+            "result": "52f70435b2c3d49bf4e338529a6499ac"
         },
         {
             "name": "test9932",
@@ -2777,7 +2777,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test157_1186_590.obu",
             "output_format": "yuv420p",
-            "result": "f83d9f556a141185310451eb2c37ab57"
+            "result": "2d0d48f35829d05f30d20bbffc54ff93"
         },
         {
             "name": "test20011",
@@ -2785,7 +2785,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test20011.obu",
             "output_format": "gray",
-            "result": "f65b7ec2ef7d3e5b23b1ee360bf3491e"
+            "result": "3e18e2f46ea5c87c8c19ce730cb0234c"
         },
         {
             "name": "test3731_10470",
@@ -2897,7 +2897,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5304_806_10022.obu",
             "output_format": "yuv420p10le",
-            "result": "72f3745ede40e41d685fb081f844429f"
+            "result": "79ad6e0f88e2526f134f6f3b6fe93c1b"
         },
         {
             "name": "test7701",
@@ -2921,7 +2921,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test3641_10492_9882.obu",
             "output_format": "yuv420p10le",
-            "result": "8157d251f01e8b1708714a0bf4671bcc"
+            "result": "7f2b2fc07def9cd662a72852b5a36bce"
         },
         {
             "name": "test3881",
@@ -3001,7 +3001,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test3852_5617_9554.obu",
             "output_format": "gray10le",
-            "result": "d44746a3958774a614b3c91f4993f773"
+            "result": "79611f687822d95c364534fbc09a6e0b"
         },
         {
             "name": "test8653",
@@ -3081,7 +3081,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test305_1904_8462.obu",
             "output_format": "gray10le",
-            "result": "e32a45c7c2014c04a8fd2672602a25cd"
+            "result": "5a3fa4ad89a0917f1de34b7e206b26bd"
         },
         {
             "name": "test10162_8919",
@@ -3097,7 +3097,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test9960.obu",
             "output_format": "gray10le",
-            "result": "369c0280cc00b18bc0b2430fd96947fd"
+            "result": "0bb30bf3d822e1dda929caeba06b3d7f"
         },
         {
             "name": "test1105",
@@ -3121,7 +3121,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test8067.obu",
             "output_format": "yuv420p",
-            "result": "3048c0e9f0fbb596ba1c128ef30a20f8"
+            "result": "a6fc61d4c9c715a6eb0f667ee53cf84b"
         },
         {
             "name": "test577",
@@ -3137,7 +3137,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test8880.obu",
             "output_format": "gray10le",
-            "result": "95b72b2e27a1a6c3ccb423cda87e3dc7"
+            "result": "1e078f8bf372806e1cad86346b136be9"
         },
         {
             "name": "test7771",
@@ -3145,7 +3145,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7771.obu",
             "output_format": "gray",
-            "result": "41c3a527d285c35772dc4622290646a9"
+            "result": "2b5983902a8310ac82f1ae3929d9b877"
         },
         {
             "name": "test9849_1790_3936",
@@ -3153,7 +3153,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test9849_1790_3936.obu",
             "output_format": "yuv420p10le",
-            "result": "8e2c59f4e1b16d0487a1741254565212"
+            "result": "a197f41b0c73fb6677ec58fcd573d423"
         },
         {
             "name": "test10576",
@@ -3177,7 +3177,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5536_7748.obu",
             "output_format": "yuv420p",
-            "result": "d45c68f7240fec6d475ca91a69e398cb"
+            "result": "952d71fc80b6f5d92f7b81fc411e54f9"
         },
         {
             "name": "test6779_855",
@@ -3185,7 +3185,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6779_855.obu",
             "output_format": "yuv420p10le",
-            "result": "259de60058b15355bbbf993db751077c"
+            "result": "8fd2c184eedba217f8f1d3b65033c922"
         },
         {
             "name": "test3359",
@@ -3209,7 +3209,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6861_9465.obu",
             "output_format": "yuv420p10le",
-            "result": "d38bd191cc75e7a65516fbaac749a170"
+            "result": "ad56bdc72a00660ac493836a86071820"
         },
         {
             "name": "test8531",
@@ -3233,7 +3233,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7713_9306_6887.obu",
             "output_format": "yuv420p10le",
-            "result": "0696add1e4b2048aa77797417d0067de"
+            "result": "456c0a564e6a268d7a89fd62d6b70105"
         },
         {
             "name": "test4877_9401_10503",
@@ -3281,7 +3281,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6738.obu",
             "output_format": "yuv420p",
-            "result": "48fa24d3c95fc2e196bcd02497fde922"
+            "result": "4c6884ca78ef6f54f8b449cd2853d3a5"
         },
         {
             "name": "test9798_8771_9190",
@@ -3321,7 +3321,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test8002_1642_2527.obu",
             "output_format": "gray10le",
-            "result": "9f8b8f2b2200868ec3623664266057cf"
+            "result": "268059807dbd0e8b3f1e76550f387147"
         },
         {
             "name": "test7250_7665_8566",
@@ -3329,7 +3329,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7250_7665_8566.obu",
             "output_format": "gray",
-            "result": "bc9491d2031e20640901205cdca65bde"
+            "result": "03e1a49e7490a61f415f874a01034e2b"
         },
         {
             "name": "test5509_6542",
@@ -3361,7 +3361,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test9606_10246_6502.obu",
             "output_format": "gray10le",
-            "result": "d1a30976fc01c64926fc130aed405092"
+            "result": "ef3d4000dc177e989e040d1c9ea8eb9d"
         },
         {
             "name": "test9520",
@@ -3441,7 +3441,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test8541_2348_10547.obu",
             "output_format": "yuv420p10le",
-            "result": "faaeac5c38acaeeae2ad4f118a841ca0"
+            "result": "cd7b319987685aae38af623dc14d050c"
         },
         {
             "name": "test91",
@@ -3465,7 +3465,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test8103_10321_10481.obu",
             "output_format": "gray",
-            "result": "92d9953ea7309a63809048b014512d61"
+            "result": "18daecbb5b29f01ccb752ff95a7fae32"
         },
         {
             "name": "test3648_7866",
@@ -3529,7 +3529,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test9275.obu",
             "output_format": "yuv420p",
-            "result": "3cd3fabcf32aed3c8a2eb83e06c135a5"
+            "result": "871e9006eb87af87a5d8766b4583e926"
         },
         {
             "name": "test7518",
@@ -3601,7 +3601,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test1260_7100.obu",
             "output_format": "gray10le",
-            "result": "3d25572ce351841df6fb651e53ad2208"
+            "result": "e748286d5fb35720a2a8ac8a188cbbec"
         },
         {
             "name": "test3329",
@@ -3673,7 +3673,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test553_125.obu",
             "output_format": "gray10le",
-            "result": "46a77eec3ed65bf4f49bb9a487d9e2de"
+            "result": "5e588cadb71540f8e855dbf3110c24d8"
         },
         {
             "name": "test712_8887",
@@ -3697,7 +3697,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6466_277_8107.obu",
             "output_format": "yuv420p10le",
-            "result": "35585c9fcff3d155ace8bab195a92f71"
+            "result": "51aaf2274791298f353d9f49e9bebb5c"
         },
         {
             "name": "test817_869",
@@ -3769,7 +3769,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test9793.obu",
             "output_format": "gray",
-            "result": "d7df770d36886e6b8be2463a1ee43e43"
+            "result": "706ab34d5059ab7a60a14c9d43973f1e"
         },
         {
             "name": "test6491",
@@ -3857,7 +3857,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test11107_11171_11119.obu",
             "output_format": "gray10le",
-            "result": "e8e882f89aeca248149cde2f8067aea8"
+            "result": "574ffde09a3f9fddc9348f35b7758a35"
         },
         {
             "name": "test488",
@@ -3921,7 +3921,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test8183_3880_4812.obu",
             "output_format": "gray10le",
-            "result": "a4743d37b54a0a9ca1f682007217a24f"
+            "result": "308ddcf3d485587bd5add6a250d59a0d"
         },
         {
             "name": "test6392",
@@ -4057,7 +4057,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7225_8111.obu",
             "output_format": "yuv420p10le",
-            "result": "11e68f0af6664e75543078a7544d5a13"
+            "result": "5f3375ed843cf1ce7aa3e114101a814a"
         },
         {
             "name": "test7403_6623",
@@ -4097,7 +4097,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6970_5370.obu",
             "output_format": "gray",
-            "result": "ef805412d257289f3eb08fced7e4f31e"
+            "result": "5b15b342b26594c783c8e4585069ca86"
         },
         {
             "name": "test4207",
@@ -4153,7 +4153,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test20022.obu",
             "output_format": "yuv420p",
-            "result": "12f9a6bc78ed9a2514ecee04a0095fd6"
+            "result": "66876396897b20e95b3f9956473629f4"
         },
         {
             "name": "test11175_11064_11019",
@@ -4265,7 +4265,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test1302_874_120.obu",
             "output_format": "gray",
-            "result": "c6110434a25edda97f1629ce8116c901"
+            "result": "763c50fc444e10587267f1401ae37df0"
         },
         {
             "name": "test5750",
@@ -4305,7 +4305,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7352.obu",
             "output_format": "yuv420p10le",
-            "result": "3958682673e1fae468e941a5f20cf01a"
+            "result": "c8456c74bd092d6b0e9707d4b628c7f9"
         },
         {
             "name": "test6097_8804_10466",
@@ -4313,7 +4313,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6097_8804_10466.obu",
             "output_format": "yuv420p10le",
-            "result": "61face7f9b3c2ff6a6365ecda277ceeb"
+            "result": "7f7099660f6710d0375fcd5d79e69ed5"
         },
         {
             "name": "test8399_9919",
@@ -4329,7 +4329,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10803.obu",
             "output_format": "yuv420p10le",
-            "result": "4d9be0edaaafaf6bd71b678330b85174"
+            "result": "282db92909ceb9ddd7eb01b991bce540"
         },
         {
             "name": "test9281_7434_5389",
@@ -4385,7 +4385,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test20027.obu",
             "output_format": "gray",
-            "result": "c419426e8ef2d73c2ff69e1daef38fb1"
+            "result": "cdcd3451e1a1623eb6e4e03a92eb5ca2"
         },
         {
             "name": "test10485",
@@ -4417,7 +4417,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7818.obu",
             "output_format": "gray",
-            "result": "99414b45ebac9cea2613eab1a802f7d8"
+            "result": "361a5872b10a6c08ef7cffe6706b7499"
         },
         {
             "name": "test10577",
@@ -4441,7 +4441,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6836_698.obu",
             "output_format": "gray10le",
-            "result": "5c5d19957ebed13ca9a71e6ca81651b9"
+            "result": "5f93dc378594d1cfaf4a6c0df839cec3"
         },
         {
             "name": "test10963",
@@ -4449,7 +4449,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10963.obu",
             "output_format": "yuv420p",
-            "result": "62839ad7a54fa3c88b112c374299939e"
+            "result": "11f938297cf7d10ed95d47b4a4de08b6"
         },
         {
             "name": "test10297",
@@ -4521,7 +4521,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test4353_8343.obu",
             "output_format": "gray10le",
-            "result": "ace06117d216ec2582ec260611f63660"
+            "result": "8d93b353174f1814eca86831d9cefae3"
         },
         {
             "name": "test2956_1840",
@@ -4561,7 +4561,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7374.obu",
             "output_format": "yuv420p10le",
-            "result": "6b920474833a21c12df913ebb8f1a3b4"
+            "result": "15c3d33ff5064ac9bf0869fbb87dbfe2"
         },
         {
             "name": "test10455",
@@ -4601,7 +4601,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test596_7213.obu",
             "output_format": "yuv420p10le",
-            "result": "e347a24b9c56e75dc22427a6d192e92d"
+            "result": "362fb4b1db90b86d77d5d7ab9b5381c1"
         },
         {
             "name": "test1882",
@@ -4625,7 +4625,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7630_5947.obu",
             "output_format": "gray10le",
-            "result": "11fecc9e1f49befdb237084f4ee6fd47"
+            "result": "f352dfd42480918368b0e36e40dc23a4"
         },
         {
             "name": "test10103",
@@ -4673,7 +4673,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test9403.obu",
             "output_format": "gray",
-            "result": "af26e6e5795383d70c918c2a5583aadb"
+            "result": "30c1d8cf2a1c40ad2e0e3c85dec4a856"
         },
         {
             "name": "test10717",
@@ -4737,7 +4737,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6983_6205.obu",
             "output_format": "yuv420p10le",
-            "result": "18db0dde0c271a7c03314f5fd86ec2a8"
+            "result": "903b2adfcb617b1d92b13c43a7756938"
         },
         {
             "name": "test7294",
@@ -4769,7 +4769,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10411.obu",
             "output_format": "gray",
-            "result": "36b71acbd9030cdd5aca91999972eebe"
+            "result": "34bb11f978158b3a9431e51a9ae369ea"
         },
         {
             "name": "test10133",
@@ -4921,7 +4921,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test9890_780_212.obu",
             "output_format": "gray10le",
-            "result": "238bc0063b7be0285c3952cd727dafff"
+            "result": "7ab0a0f1163b2bf8a6e95c663adc8d12"
         },
         {
             "name": "test8064",
@@ -4961,7 +4961,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7905_7014.obu",
             "output_format": "yuv420p10le",
-            "result": "a7258b72ffac034e128027f0936825ba"
+            "result": "c3419dc2ba818bd95545449c6f380e83"
         },
         {
             "name": "test2768",
@@ -4985,7 +4985,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test20013.obu",
             "output_format": "gray10le",
-            "result": "adfb0e5a88db391f4bffdcddd37ba1c0"
+            "result": "751b5ec3f88a28a8b4573fa1c17c2a2f"
         },
         {
             "name": "test5406",
@@ -5057,7 +5057,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6450.obu",
             "output_format": "yuv420p",
-            "result": "64fbb3f99374d6fe74b22255b748e3c3"
+            "result": "b59ad3f811374eb27558a3e11073a014"
         },
         {
             "name": "test8181",
@@ -5121,7 +5121,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test787.obu",
             "output_format": "yuv420p10le",
-            "result": "1cb4bfcbb7ee85024f983705d077b38e"
+            "result": "b914026f656940271a8542b29060d342"
         },
         {
             "name": "test1416_312",
@@ -5137,7 +5137,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10289_9893.obu",
             "output_format": "gray",
-            "result": "2e0ae522498048ac9ece7c1158d06131"
+            "result": "8d94d7ddc3de023c0df326ae3c5e1bb9"
         },
         {
             "name": "test7606",
@@ -5249,7 +5249,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test20019.obu",
             "output_format": "yuv420p",
-            "result": "3b00cebf78aff5318b9ff656279c9bef"
+            "result": "150c75f5835b67308e4145096e3e1f52"
         },
         {
             "name": "test10644",
@@ -5313,7 +5313,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test834_9479_5959.obu",
             "output_format": "yuv420p10le",
-            "result": "35ecf63a0d290011d12a46095e2389ea"
+            "result": "ce6f70a388d83d3612d114bbe837666b"
         },
         {
             "name": "test642_128",
@@ -5441,7 +5441,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test1008.obu",
             "output_format": "gray10le",
-            "result": "9d8061b44bbf14e705a158d1536d6752"
+            "result": "d4fd8849297e370a688119b75435b951"
         },
         {
             "name": "test11106_11154_11129",
@@ -5457,7 +5457,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test1209_5887_3232.obu",
             "output_format": "gray10le",
-            "result": "a97852fd720cc96641f7989069bebba1"
+            "result": "f6e499ab224a226d0ac6a89b87c77798"
         },
         {
             "name": "test9227",
@@ -5465,7 +5465,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test9227.obu",
             "output_format": "yuv420p10le",
-            "result": "5dfd4e2bd18d58f71a2b3914d629953b"
+            "result": "67e9ebc9de9fc85806e21ba37482fd99"
         },
         {
             "name": "test3347",
@@ -5481,7 +5481,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test20021.obu",
             "output_format": "gray10le",
-            "result": "f173c0cd74f091f182652347f00c5694"
+            "result": "134a6c6f51a9e1a2873badd05872b0a2"
         },
         {
             "name": "test2602",
@@ -5569,7 +5569,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5432_1234_5036.obu",
             "output_format": "yuv420p",
-            "result": "e9d8b628a31bc3492d5232f9f03eba8f"
+            "result": "64237584c08677a4fbc629d54ece110a"
         },
         {
             "name": "test10528_3797_7975",
@@ -5633,7 +5633,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5713_7089.obu",
             "output_format": "yuv420p",
-            "result": "5af76afdb8c3082d88ce9dde98c8647a"
+            "result": "7dfe849f540280a373977b25cc439b4b"
         },
         {
             "name": "test10051",
@@ -5721,7 +5721,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test1834_746_9846.obu",
             "output_format": "gray10le",
-            "result": "a781eba10a61dfe1026a754ccf9f1c50"
+            "result": "adedb67c276bf8af3d3f22b32b7a23c4"
         },
         {
             "name": "test10406_9013_10089",
@@ -5729,7 +5729,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10406_9013_10089.obu",
             "output_format": "yuv420p",
-            "result": "f83803efa81aa4b9dee1ff210247b296"
+            "result": "b01e4c662467d6772f25c2c2602afe77"
         },
         {
             "name": "test107",
@@ -5745,7 +5745,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test7090_94_996.obu",
             "output_format": "yuv420p",
-            "result": "e435e2669bba86b9cc6976426f0fc752"
+            "result": "fc93d33370a42cd3dbeb46ad1acbebbd"
         },
         {
             "name": "test10100_579_8614",
@@ -5793,7 +5793,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5410_6603_4974.obu",
             "output_format": "gray10le",
-            "result": "7a805989cdcadf559dbeeb6833ff84a8"
+            "result": "9fc63124f28021f001df182185577695"
         },
         {
             "name": "test10046",
@@ -5817,7 +5817,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test9250_3906.obu",
             "output_format": "yuv420p10le",
-            "result": "41577e7f8ef1f0847ac344affa38ee0c"
+            "result": "3aa86778e9d02e83ee7f4a0b1f8ee1b2"
         },
         {
             "name": "test8761_5865",
@@ -5825,7 +5825,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test8761_5865.obu",
             "output_format": "yuv420p",
-            "result": "01200d09fe678e9af5a1fbdba88b7d8e"
+            "result": "9faec48ee5315e5bccc9630dcbb9c1a3"
         },
         {
             "name": "test11138_11173_11037",
@@ -5921,7 +5921,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6353_571_8708.obu",
             "output_format": "yuv420p",
-            "result": "8129e4751448cbb3f454e6c0f355e2d0"
+            "result": "cf9a796308d4bec007c7c0564aae8a7f"
         },
         {
             "name": "test10824",
@@ -5929,7 +5929,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test10824.obu",
             "output_format": "gray",
-            "result": "32cff5b824ae6be0cf9ef4a553ce7b98"
+            "result": "23bba916533de7edee048624f9deba54"
         },
         {
             "name": "test6664_10226_10061",
@@ -5945,7 +5945,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test8980_9617.obu",
             "output_format": "yuv420p10le",
-            "result": "afd8672e9098c704d05fe3b837d77183"
+            "result": "36579073e357919f56e27c569935bd60"
         },
         {
             "name": "test6562_1344_5677",
@@ -5953,7 +5953,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6562_1344_5677.obu",
             "output_format": "yuv420p10le",
-            "result": "38790f7f69766363c7b27434c965879c"
+            "result": "a8e22c569dec164d1314775b3cfd08ec"
         },
         {
             "name": "test6041",
@@ -5961,7 +5961,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6041.obu",
             "output_format": "yuv420p",
-            "result": "54e9cd89192539e810bd3e2b994f8306"
+            "result": "ad863b2a08e68f7e1dc9dd03acaa7136"
         },
         {
             "name": "test6403_5486",
@@ -5969,7 +5969,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test6403_5486.obu",
             "output_format": "yuv420p",
-            "result": "931f651e31524d74cbaea514e8635427"
+            "result": "3103ef6a76825246fbb4a91bed349e29"
         },
         {
             "name": "test1587",
@@ -5993,7 +5993,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5085_9535_9261.obu",
             "output_format": "yuv420p10le",
-            "result": "5294d10b78af2601db2a2db6a75f564e"
+            "result": "9046da74a56750216eabc0309c8acade"
         },
         {
             "name": "test10230",
@@ -6033,7 +6033,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test20017.obu",
             "output_format": "yuv420p10le",
-            "result": "026e8d716cbec3cb41ebbdd6629769c5"
+            "result": "995b79bbfdcfb9257adf18a7efef94a9"
         },
         {
             "name": "test7674_7327",
@@ -6081,7 +6081,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test8337.obu",
             "output_format": "yuv420p",
-            "result": "24b9bd7e10f0bb3256a1e6cb8f308bc4"
+            "result": "6e28af84020c7d73f3b3e1890f30942b"
         },
         {
             "name": "test5784",
@@ -6169,7 +6169,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test659_7049.obu",
             "output_format": "yuv420p",
-            "result": "e501329967ee100f944c0d2c4d73a629"
+            "result": "b896af6f473911c5e87de1f46a32bca1"
         },
         {
             "name": "test9538_2335",
@@ -6185,7 +6185,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5400_3508_9920.obu",
             "output_format": "gray",
-            "result": "7c18a2f1191d1fcbd6399ebec285a0a5"
+            "result": "daa1a36241502b43c36e5fbf2545f4d1"
         },
         {
             "name": "test9121",
@@ -6241,7 +6241,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test9678_5891.obu",
             "output_format": "gray10le",
-            "result": "7a1d307c507a9a90c7d66025039c97a9"
+            "result": "572222f9255506e300338c4935246654"
         },
         {
             "name": "test2083",
@@ -6385,7 +6385,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test11132_11109_11047.obu",
             "output_format": "yuv420p",
-            "result": "58b8974a17478ae512cc445024e6d25a"
+            "result": "a07853a9dc39c406567a359a40fde9ef"
         },
         {
             "name": "test951",
@@ -6449,7 +6449,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test3564_3676.obu",
             "output_format": "gray10le",
-            "result": "e330767f58323de85a62bd40b390e242"
+            "result": "be3773a22479a1642575d74bc34d4068"
         },
         {
             "name": "test9371",
@@ -6497,7 +6497,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test4341.obu",
             "output_format": "yuv420p10le",
-            "result": "f02507a32236408a2e6a0aa4f1a5f638"
+            "result": "37f2831f58f4c99e5a26c142437071c9"
         },
         {
             "name": "test7894",
@@ -6513,7 +6513,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_core/streams/test5379_8626_3544.obu",
             "output_format": "gray10le",
-            "result": "fcf8a3d671a9c6460dfec54bf40f888c"
+            "result": "71a55de515a991d838bb1413e6d2da22"
         },
         {
             "name": "test11050_11095",
@@ -6523,5 +6523,6 @@
             "output_format": "yuv420p",
             "result": "daf13c7ddbded0a3b4c0383bbf8ec580"
         }
-    ]
+    ],
+    "test_method": "md5"
 }

--- a/test_suites/av1/AV1-ARGON-PROFILE0-NON-ANNEX-B.json
+++ b/test_suites/av1/AV1-ARGON-PROFILE0-NON-ANNEX-B.json
@@ -33,7 +33,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test29.obu",
             "output_format": "yuv420p",
-            "result": "6a0fae44a51e4ad893b9ba3a5e95e726"
+            "result": ""
         },
         {
             "name": "test14",
@@ -57,7 +57,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test44.obu",
             "output_format": "gray10le",
-            "result": "5fa56d9744d1a84c52b120e7811a7966"
+            "result": ""
         },
         {
             "name": "test24",
@@ -65,7 +65,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test24.obu",
             "output_format": "Unknown",
-            "result": "3ce58ed3c5b9df7827d0dd98c637ec0b"
+            "result": ""
         },
         {
             "name": "test54",
@@ -81,7 +81,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test52.obu",
             "output_format": "Unknown",
-            "result": "730d9da62732d06bf48eba677198bf7a"
+            "result": ""
         },
         {
             "name": "test38",
@@ -89,7 +89,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test38.obu",
             "output_format": "Unknown",
-            "result": "c80ef66a6dd4e2e605a8a4f9ec793e44"
+            "result": ""
         },
         {
             "name": "test22",
@@ -97,7 +97,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test22.obu",
             "output_format": "Unknown",
-            "result": "35b43b7f4e7da2073f91a0a45c142dc7"
+            "result": ""
         },
         {
             "name": "test16",
@@ -121,7 +121,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test46.obu",
             "output_format": "Unknown",
-            "result": "a6af862903edd1c8a2146e2f2a3bc69d"
+            "result": ""
         },
         {
             "name": "test48",
@@ -161,7 +161,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test25.obu",
             "output_format": "Unknown",
-            "result": "56d36e472791bd61979bebe75bda222d"
+            "result": ""
         },
         {
             "name": "test55",
@@ -169,7 +169,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test55.obu",
             "output_format": "Unknown",
-            "result": "268e849e0592e5d2bb8f11b228e23429"
+            "result": ""
         },
         {
             "name": "test40",
@@ -185,7 +185,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test17.obu",
             "output_format": "Unknown",
-            "result": "dcfa03636e1556f2187c4180cc6a27cb"
+            "result": ""
         },
         {
             "name": "test26",
@@ -201,7 +201,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test8.obu",
             "output_format": "yuv420p10le",
-            "result": "784adacc05754de51124412dd8248cba"
+            "result": ""
         },
         {
             "name": "test42",
@@ -217,7 +217,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test13.obu",
             "output_format": "Unknown",
-            "result": "039644bb79bb222cc7f6e9e5edac22d5"
+            "result": ""
         },
         {
             "name": "test4",
@@ -241,7 +241,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test39.obu",
             "output_format": "Unknown",
-            "result": "914162b91b766adad7f6174168bd04e1"
+            "result": ""
         },
         {
             "name": "test45",
@@ -281,7 +281,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test50.obu",
             "output_format": "Unknown",
-            "result": "79de4e27a64e24aed9f583461f8dfde4"
+            "result": ""
         },
         {
             "name": "test31",
@@ -297,7 +297,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test47.obu",
             "output_format": "Unknown",
-            "result": "266f5f966908233515d5e249b8f01a81"
+            "result": ""
         },
         {
             "name": "test9",
@@ -321,7 +321,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test34.obu",
             "output_format": "gray",
-            "result": "ab3ab09ee7e78aca1e6020fe822c5809"
+            "result": ""
         },
         {
             "name": "test28",
@@ -337,7 +337,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test21.obu",
             "output_format": "Unknown",
-            "result": "47006d09dd3be0f92b2c4d87f25ed0a5"
+            "result": ""
         },
         {
             "name": "test3",
@@ -345,7 +345,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test3.obu",
             "output_format": "Unknown",
-            "result": "6eb8726c33afab87722568648a56cd5f"
+            "result": ""
         },
         {
             "name": "test36",
@@ -361,7 +361,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test19.obu",
             "output_format": "Unknown",
-            "result": "5a4a7ed840d90c32a280468a96a036ad"
+            "result": ""
         },
         {
             "name": "test37",
@@ -369,7 +369,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test37.obu",
             "output_format": "yuv420p10le",
-            "result": "de4a91031859a1b9cf4d41666fd3ea3b"
+            "result": ""
         },
         {
             "name": "test41",
@@ -385,7 +385,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test49.obu",
             "output_format": "Unknown",
-            "result": "6c4046a565d4232ee694d649a7d31a10"
+            "result": ""
         },
         {
             "name": "test5",
@@ -393,7 +393,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test5.obu",
             "output_format": "yuv420p",
-            "result": "5229a90825ae49ac628d6b91e06990b6"
+            "result": ""
         },
         {
             "name": "test10",
@@ -425,7 +425,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test2.obu",
             "output_format": "Unknown",
-            "result": "fe4d32f259c1459e7cff84f9953aacd3"
+            "result": ""
         },
         {
             "name": "test32",
@@ -441,7 +441,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test12.obu",
             "output_format": "None",
-            "result": "4d31de605c32d269b9e7ae46450f2beb"
+            "result": ""
         },
         {
             "name": "test12259",
@@ -457,7 +457,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_not_annexb/streams/test12297.obu",
             "output_format": "gray",
-            "result": "3aa7b9bd80fa8e8c0b8eff8bf93ebbde"
+            "result": "dabcbaf15eadf16ea945d1529f110f6a"
         },
         {
             "name": "test12217",
@@ -561,7 +561,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_not_annexb/streams/test12294.obu",
             "output_format": "yuv420p",
-            "result": "3bd75974f3a8beeee3eccb33992487d3"
+            "result": "077d1e79a67bd8ac7c703e714b32fc02"
         },
         {
             "name": "test223",
@@ -569,7 +569,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test223.obu",
             "output_format": "Unknown",
-            "result": "6269bb895c13254a2f5249982516b555"
+            "result": ""
         },
         {
             "name": "test270",
@@ -577,7 +577,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test270.obu",
             "output_format": "yuv420p",
-            "result": "dd5c0c4663f74bd093f930d034a3cf06"
+            "result": ""
         },
         {
             "name": "test175",
@@ -585,7 +585,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test175.obu",
             "output_format": "yuv420p",
-            "result": "60bf7e1ad8b0be2b5d99560e79198187"
+            "result": ""
         },
         {
             "name": "test269",
@@ -593,7 +593,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test269.obu",
             "output_format": "Unknown",
-            "result": "93871a2fc6c7845c738f7e35a71ce45a"
+            "result": ""
         },
         {
             "name": "test261",
@@ -601,7 +601,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test261.obu",
             "output_format": "Unknown",
-            "result": "13f7d4ba027f7a793b90ba519b42e08a"
+            "result": ""
         },
         {
             "name": "test276",
@@ -609,7 +609,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test276.obu",
             "output_format": "Unknown",
-            "result": "758cf7c5ef7df6aa3a91d50697600ea5"
+            "result": ""
         },
         {
             "name": "test184",
@@ -617,7 +617,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test184.obu",
             "output_format": "yuv420p10le",
-            "result": "3efe211180a40e74ebebfb177289580b"
+            "result": ""
         },
         {
             "name": "test291",
@@ -625,7 +625,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test291.obu",
             "output_format": "Unknown",
-            "result": "256fcc7980c7e947a96a8fe40fa6fc0b"
+            "result": ""
         },
         {
             "name": "test170",
@@ -633,7 +633,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test170.obu",
             "output_format": "Unknown",
-            "result": "a0545780db0d02b6b7736eae0eec8882"
+            "result": ""
         },
         {
             "name": "test145",
@@ -641,7 +641,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test145.obu",
             "output_format": "Unknown",
-            "result": "f623c91c464764cb0a1bf2211e71095f"
+            "result": ""
         },
         {
             "name": "test87",
@@ -649,7 +649,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test87.obu",
             "output_format": "gray10le",
-            "result": "6592248639ac9ecd70cee0bb3a30cb4c"
+            "result": ""
         },
         {
             "name": "test242",
@@ -657,7 +657,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test242.obu",
             "output_format": "None",
-            "result": "2fab99dc1e069ff90b2768ba345bb45f"
+            "result": ""
         },
         {
             "name": "test244",
@@ -665,7 +665,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test244.obu",
             "output_format": "Unknown",
-            "result": "37a3808a7048885254a0f9513a471bb0"
+            "result": ""
         },
         {
             "name": "test182",
@@ -673,7 +673,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test182.obu",
             "output_format": "Unknown",
-            "result": "069bbceb9bc58f9b51c1bef00878122a"
+            "result": ""
         },
         {
             "name": "test190",
@@ -681,7 +681,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test190.obu",
             "output_format": "Unknown",
-            "result": "7d637a9a229afe037953d3453ef716b8"
+            "result": ""
         },
         {
             "name": "test60",
@@ -689,7 +689,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test60.obu",
             "output_format": "Unknown",
-            "result": "ac66fc0f7520bf6dec6ee7ead7109d27"
+            "result": ""
         },
         {
             "name": "test216",
@@ -697,7 +697,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test216.obu",
             "output_format": "Unknown",
-            "result": "4a09d8f7208d8d84365ac9918d1ad13e"
+            "result": ""
         },
         {
             "name": "test260",
@@ -705,7 +705,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test260.obu",
             "output_format": "Unknown",
-            "result": "0768920462b3b3c4e258478789e80779"
+            "result": ""
         },
         {
             "name": "test185",
@@ -713,7 +713,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test185.obu",
             "output_format": "Unknown",
-            "result": "30c556b109800fd1c2e77aa16c782ec5"
+            "result": ""
         },
         {
             "name": "test92",
@@ -721,7 +721,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test92.obu",
             "output_format": "Unknown",
-            "result": "9ffe2b2fbfe081d57bce295f8963eec5"
+            "result": ""
         },
         {
             "name": "test288",
@@ -729,7 +729,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test288.obu",
             "output_format": "Unknown",
-            "result": "5816d4dd9d3e877ca3d0e926c4e55aa9"
+            "result": ""
         },
         {
             "name": "test74",
@@ -737,7 +737,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test74.obu",
             "output_format": "Unknown",
-            "result": "5a4b3c0456b05acc4be0ebd0f17c5d26"
+            "result": ""
         },
         {
             "name": "test272",
@@ -745,7 +745,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test272.obu",
             "output_format": "yuv420p10le",
-            "result": "d688719827d42eb2d85720dd09d381d5"
+            "result": ""
         },
         {
             "name": "test237",
@@ -753,7 +753,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test237.obu",
             "output_format": "Unknown",
-            "result": "a5bc04bfdff1946668c4bbb2a5dd6111"
+            "result": ""
         },
         {
             "name": "test294",
@@ -761,7 +761,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test294.obu",
             "output_format": "yuv420p10le",
-            "result": "69b2839c5e7cc8fac841fc7aa26c493d"
+            "result": ""
         },
         {
             "name": "test208",
@@ -769,7 +769,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test208.obu",
             "output_format": "Unknown",
-            "result": "eb63a249681a45a198ca1e16dae644f0"
+            "result": ""
         },
         {
             "name": "test292",
@@ -777,7 +777,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test292.obu",
             "output_format": "yuv420p",
-            "result": "1ccff59056635c3714599ce03184fcd6"
+            "result": ""
         },
         {
             "name": "test78",
@@ -785,7 +785,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test78.obu",
             "output_format": "gray10le",
-            "result": "042bbd95fd380967effca3708de7e1f7"
+            "result": ""
         },
         {
             "name": "test172",
@@ -793,7 +793,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test172.obu",
             "output_format": "gray10le",
-            "result": "040cb66a08e19fd5ac03fd55a4072414"
+            "result": ""
         },
         {
             "name": "test289",
@@ -801,7 +801,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test289.obu",
             "output_format": "Unknown",
-            "result": "939d7c29283550ca906163eeaea6568e"
+            "result": ""
         },
         {
             "name": "test268",
@@ -809,7 +809,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test268.obu",
             "output_format": "yuv420p10le",
-            "result": "8f2afaf6d681c0c46136f7162cb3a995"
+            "result": ""
         },
         {
             "name": "test273",
@@ -817,7 +817,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test273.obu",
             "output_format": "Unknown",
-            "result": "434fa9041130a9bb3157783ce33b6c25"
+            "result": ""
         },
         {
             "name": "test283",
@@ -825,7 +825,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test283.obu",
             "output_format": "yuv420p",
-            "result": "9ee18b648ac93afd411f10ee2a77e76a"
+            "result": ""
         },
         {
             "name": "test279",
@@ -833,7 +833,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test279.obu",
             "output_format": "yuv420p",
-            "result": "e651d6b982b792428d071e2cd141e48b"
+            "result": ""
         },
         {
             "name": "test246",
@@ -841,7 +841,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test246.obu",
             "output_format": "Unknown",
-            "result": "69039ba288245be1c4018a9d8b52a305"
+            "result": ""
         },
         {
             "name": "test218",
@@ -849,7 +849,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test218.obu",
             "output_format": "gray",
-            "result": "d0468dbc31e91dc6d0248a1c76c16200"
+            "result": ""
         },
         {
             "name": "test159",
@@ -857,7 +857,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test159.obu",
             "output_format": "Unknown",
-            "result": "d158a14b3bf34c92f023481000e2a719"
+            "result": ""
         },
         {
             "name": "test118",
@@ -865,7 +865,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test118.obu",
             "output_format": "gray10le",
-            "result": "0245d09e7148b06f7505c3a3894fccca"
+            "result": ""
         },
         {
             "name": "test91",
@@ -873,7 +873,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test91.obu",
             "output_format": "Unknown",
-            "result": "19cd079dde217252be257f6e74e744ae"
+            "result": ""
         },
         {
             "name": "test200",
@@ -881,7 +881,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test200.obu",
             "output_format": "Unknown",
-            "result": "5f76b7749d8b9c63bd4fa4b2c93d46c2"
+            "result": ""
         },
         {
             "name": "test69",
@@ -889,7 +889,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test69.obu",
             "output_format": "Unknown",
-            "result": "14f84afe9dfae9732c351a8e00fa7109"
+            "result": ""
         },
         {
             "name": "test114",
@@ -897,7 +897,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test114.obu",
             "output_format": "Unknown",
-            "result": "1993b1a9f3d5a87097038aac8906c26b"
+            "result": ""
         },
         {
             "name": "test254",
@@ -905,7 +905,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test254.obu",
             "output_format": "yuv420p10le",
-            "result": "1d16b8c437f9e4800d2164c8a66f2710"
+            "result": ""
         },
         {
             "name": "test298",
@@ -913,7 +913,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test298.obu",
             "output_format": "Unknown",
-            "result": "44ad010d26344667082c56bb1a627f1f"
+            "result": ""
         },
         {
             "name": "test124",
@@ -921,7 +921,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test124.obu",
             "output_format": "Unknown",
-            "result": "02b6ce7d5d7cf45915b6bfa669c03495"
+            "result": ""
         },
         {
             "name": "test167",
@@ -929,7 +929,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test167.obu",
             "output_format": "yuv420p10le",
-            "result": "d6e5c21649cdd56b98e54cb74e3cae4a"
+            "result": ""
         },
         {
             "name": "test271",
@@ -937,7 +937,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test271.obu",
             "output_format": "Unknown",
-            "result": "1ab8fdfecd5157e993a447d2705c7764"
+            "result": ""
         },
         {
             "name": "test155",
@@ -945,7 +945,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test155.obu",
             "output_format": "gray",
-            "result": "a4b45e3b67349b47a3ced25103e0110f"
+            "result": ""
         },
         {
             "name": "test96",
@@ -953,7 +953,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test96.obu",
             "output_format": "Unknown",
-            "result": "622d7bd33f59e8a8b98f2ce70b4a3b86"
+            "result": ""
         },
         {
             "name": "test265",
@@ -961,7 +961,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test265.obu",
             "output_format": "gray",
-            "result": "03211bb24b0c7968cdeb12c6980a8805"
+            "result": ""
         },
         {
             "name": "test243",
@@ -969,7 +969,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test243.obu",
             "output_format": "yuv420p10le",
-            "result": "b2ca4312504f38be90bf2debef53d902"
+            "result": ""
         },
         {
             "name": "test251",
@@ -977,7 +977,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test251.obu",
             "output_format": "yuv420p10le",
-            "result": "a6716311c88e7e1cecfa58be45c1507c"
+            "result": ""
         },
         {
             "name": "test95",
@@ -985,7 +985,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test95.obu",
             "output_format": "gray10le",
-            "result": "2662c3818a3e81490bd0ced3906731f0"
+            "result": ""
         },
         {
             "name": "test248",
@@ -993,7 +993,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test248.obu",
             "output_format": "Unknown",
-            "result": "a4c19bc2158f1d643188fd32ae333c48"
+            "result": ""
         },
         {
             "name": "test275",
@@ -1001,7 +1001,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test275.obu",
             "output_format": "yuv420p",
-            "result": "f24750f3d85a5febcb37b0f52738aeae"
+            "result": ""
         },
         {
             "name": "test203",
@@ -1009,7 +1009,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test203.obu",
             "output_format": "gray10le",
-            "result": "b03259b26150d665cfb9003c0282bfda"
+            "result": ""
         },
         {
             "name": "test173",
@@ -1017,7 +1017,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test173.obu",
             "output_format": "yuv420p",
-            "result": "67af21be004f6dd3fa437c773d5a1598"
+            "result": ""
         },
         {
             "name": "test195",
@@ -1025,7 +1025,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test195.obu",
             "output_format": "Unknown",
-            "result": "b34fde029eef9b213f022f46a875b7df"
+            "result": ""
         },
         {
             "name": "test176",
@@ -1033,7 +1033,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test176.obu",
             "output_format": "yuv420p10le",
-            "result": "813115754c67ae6aabf8d3b1b5a47d98"
+            "result": ""
         },
         {
             "name": "test286",
@@ -1041,7 +1041,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test286.obu",
             "output_format": "yuv420p10le",
-            "result": "2b5d538eff04acf01a3d2f2bf862fbfc"
+            "result": ""
         },
         {
             "name": "test84",
@@ -1049,7 +1049,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test84.obu",
             "output_format": "gray10le",
-            "result": "6e605f2a93973708839bb20d416c4258"
+            "result": ""
         },
         {
             "name": "test290",
@@ -1057,7 +1057,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test290.obu",
             "output_format": "Unknown",
-            "result": "b737f9c965047bdef9e752a34340da55"
+            "result": ""
         },
         {
             "name": "test144",
@@ -1065,7 +1065,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test144.obu",
             "output_format": "yuv420p",
-            "result": "98af5bbf9c024b654147e34f2c28ec69"
+            "result": ""
         },
         {
             "name": "test278",
@@ -1073,7 +1073,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test278.obu",
             "output_format": "Unknown",
-            "result": "a3717f329a62762abce8b88e9789dcc9"
+            "result": ""
         },
         {
             "name": "test196",
@@ -1081,7 +1081,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test196.obu",
             "output_format": "Unknown",
-            "result": "ac87168e85b79040c0f7d9fe6bf1ccf4"
+            "result": ""
         },
         {
             "name": "test239",
@@ -1089,7 +1089,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test239.obu",
             "output_format": "Unknown",
-            "result": "a81b4f694e6dc0f8bbc33970909dd913"
+            "result": ""
         },
         {
             "name": "test187",
@@ -1097,7 +1097,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test187.obu",
             "output_format": "Unknown",
-            "result": "a422e7bc56c28b0cdbbdd4790aad220f"
+            "result": ""
         },
         {
             "name": "test162",
@@ -1105,7 +1105,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test162.obu",
             "output_format": "Unknown",
-            "result": "0db57f383772793f9a283886a320a802"
+            "result": ""
         },
         {
             "name": "test106",
@@ -1113,7 +1113,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test106.obu",
             "output_format": "yuv420p",
-            "result": "172ff3a0c3e5755f829a2005a4876137"
+            "result": ""
         },
         {
             "name": "test150",
@@ -1121,7 +1121,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test150.obu",
             "output_format": "Unknown",
-            "result": "14185c6988b5764b798ccd481d0ad27b"
+            "result": ""
         },
         {
             "name": "test85",
@@ -1129,7 +1129,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test85.obu",
             "output_format": "yuv420p10le",
-            "result": "fb4314cb31688b346fce2c7502e15f74"
+            "result": ""
         },
         {
             "name": "test181",
@@ -1137,7 +1137,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test181.obu",
             "output_format": "yuv420p10le",
-            "result": "8bdc99b536a1f0ca23d2353f3a6fb4dd"
+            "result": ""
         },
         {
             "name": "test226",
@@ -1145,7 +1145,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test226.obu",
             "output_format": "Unknown",
-            "result": "972a07528d7fe559b92fca23914df0ef"
+            "result": ""
         },
         {
             "name": "test300",
@@ -1153,7 +1153,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test300.obu",
             "output_format": "Unknown",
-            "result": "7a1278f3d3356a5961bb4c34fdb769f7"
+            "result": ""
         },
         {
             "name": "test101",
@@ -1161,7 +1161,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test101.obu",
             "output_format": "Unknown",
-            "result": "22886958fa603fe85057e48b8488c97f"
+            "result": ""
         },
         {
             "name": "test83",
@@ -1169,7 +1169,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test83.obu",
             "output_format": "yuv420p10le",
-            "result": "9ac83b638cb1d9c25374c79560341a24"
+            "result": ""
         },
         {
             "name": "test149",
@@ -1177,7 +1177,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test149.obu",
             "output_format": "Unknown",
-            "result": "f5f45554d539ec02b68472d2db781bd1"
+            "result": ""
         },
         {
             "name": "test280",
@@ -1185,7 +1185,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test280.obu",
             "output_format": "yuv420p",
-            "result": "cff92ac90953b0ec66890fa2a2393b17"
+            "result": ""
         },
         {
             "name": "test110",
@@ -1193,7 +1193,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test110.obu",
             "output_format": "gray10le",
-            "result": "23c9b0eb3b958f1e28478fe1139ea5e3"
+            "result": ""
         },
         {
             "name": "test193",
@@ -1201,7 +1201,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test193.obu",
             "output_format": "Unknown",
-            "result": "70bfa5dc69aa5cd0ecc893340409aab0"
+            "result": ""
         },
         {
             "name": "test168",
@@ -1209,7 +1209,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test168.obu",
             "output_format": "Unknown",
-            "result": "f860803a341774cc8f08e75ca32ab2a0"
+            "result": ""
         },
         {
             "name": "test285",
@@ -1217,7 +1217,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test285.obu",
             "output_format": "yuv420p10le",
-            "result": "399e5236cba8458baae8489fb4e7da35"
+            "result": ""
         },
         {
             "name": "test88",
@@ -1225,7 +1225,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test88.obu",
             "output_format": "Unknown",
-            "result": "03d2910339f7d7605d7cbc8d08b880fa"
+            "result": ""
         },
         {
             "name": "test281",
@@ -1233,7 +1233,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test281.obu",
             "output_format": "yuv420p10le",
-            "result": "e4be9fec4c356a8ac7fc2753cd52d179"
+            "result": ""
         },
         {
             "name": "test189",
@@ -1241,7 +1241,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test189.obu",
             "output_format": "gray10le",
-            "result": "64453ce32176167119e51603ec1afa5f"
+            "result": ""
         },
         {
             "name": "test287",
@@ -1249,7 +1249,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test287.obu",
             "output_format": "yuv420p",
-            "result": "61021c7a0a12841a04dfa301f58389db"
+            "result": ""
         },
         {
             "name": "test295",
@@ -1257,7 +1257,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test295.obu",
             "output_format": "yuv420p10le",
-            "result": "6794a8a9cd33da1993e11c143ce6beb3"
+            "result": ""
         },
         {
             "name": "test111",
@@ -1265,7 +1265,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test111.obu",
             "output_format": "Unknown",
-            "result": "c1539617962f97058b773574e6a0b0cf"
+            "result": ""
         },
         {
             "name": "test229",
@@ -1273,7 +1273,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test229.obu",
             "output_format": "Unknown",
-            "result": "ae5483a08fb675a2afe64edd0809b3d9"
+            "result": ""
         },
         {
             "name": "test234",
@@ -1281,7 +1281,8 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile0_error/streams/test234.obu",
             "output_format": "yuv420p10le",
-            "result": "efba2da8f75747220324576081da74ed"
+            "result": ""
         }
-    ]
+    ],
+    "test_method": "md5"
 }

--- a/test_suites/av1/AV1-ARGON-PROFILE0-STRESS-ANNEX-B.json
+++ b/test_suites/av1/AV1-ARGON-PROFILE0-STRESS-ANNEX-B.json
@@ -707,5 +707,6 @@
             "output_format": "yuv420p",
             "result": "03b70d6a4ce7e80c5ed5070791768e79"
         }
-    ]
+    ],
+    "test_method": "md5"
 }

--- a/test_suites/av1/AV1-ARGON-PROFILE1-CORE-ANNEX-B.json
+++ b/test_suites/av1/AV1-ARGON-PROFILE1-CORE-ANNEX-B.json
@@ -457,7 +457,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1183.obu",
             "output_format": "gbrp",
-            "result": "ed1d84c718afa82a2a3b0cd729f7d0b9"
+            "result": "91617f0ad2129a7b5616f018e4fe8940"
         },
         {
             "name": "test2416",
@@ -497,7 +497,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test6703_4825_3365.obu",
             "output_format": "gbrp10le",
-            "result": "083e524e8aba0b50bccbc9b7d7c1201d"
+            "result": "a59743416e6845bc1c0bc3647c56705e"
         },
         {
             "name": "test1787_7212_404",
@@ -521,7 +521,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7521.obu",
             "output_format": "yuv444p",
-            "result": "0666563bed6a0b93f72ae6340cfc21a8"
+            "result": "7a3e6e9478755cd67365ac9b179e683f"
         },
         {
             "name": "test7165_2027",
@@ -529,7 +529,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7165_2027.obu",
             "output_format": "yuv444p",
-            "result": "6dca6fc01043a7a96dfb9f57ea283b6a"
+            "result": "706aeeab59cd483dba230231d04dd6ad"
         },
         {
             "name": "test6970_5130",
@@ -537,7 +537,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test6970_5130.obu",
             "output_format": "gbrp",
-            "result": "1a9d3e39c878a3445ccbc76e4c79f73a"
+            "result": "fb451cd961c08122226e4e0896b61cc5"
         },
         {
             "name": "test3641_5177_599",
@@ -561,7 +561,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1173_5126_4611.obu",
             "output_format": "yuv444p10le",
-            "result": "0aad6d7bdd1698112980ec7002ab2444"
+            "result": "d31d4de603d5979b8cabe0cafa13bdbb"
         },
         {
             "name": "test2081",
@@ -569,7 +569,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test2081.obu",
             "output_format": "gbrp",
-            "result": "3e943e020536da4fb064d3877e03182e"
+            "result": "f0c079ebc80269274359339e2a9238b9"
         },
         {
             "name": "test5959",
@@ -713,7 +713,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7133_1615.obu",
             "output_format": "gbrp",
-            "result": "112fca3b83936a5fa727fbf3b5b44351"
+            "result": "79b3b89a963a48f279bd088f87fca706"
         },
         {
             "name": "test5508_7274_5209",
@@ -721,7 +721,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5508_7274_5209.obu",
             "output_format": "yuv444p",
-            "result": "1604a0c48e870c2658138c871239a47b"
+            "result": "9e4c79d6c0efd539c4e9957b49d693c2"
         },
         {
             "name": "test2684",
@@ -737,7 +737,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test6062.obu",
             "output_format": "gbrp10le",
-            "result": "bc93d27c4d9b850f0330fffd0fd52838"
+            "result": "685cd2ff80bf058c559a308b834ccea3"
         },
         {
             "name": "test4589",
@@ -753,7 +753,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test908_6370_1876.obu",
             "output_format": "yuv444p10le",
-            "result": "ccea5b997222e70a1abf7baa5dcc35dd"
+            "result": "04203510b5d3aae5e70189aa4c556ca0"
         },
         {
             "name": "test4570",
@@ -769,7 +769,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test4864_4295_5577.obu",
             "output_format": "gbrp",
-            "result": "9d73ea4e6c43d60cd60f79886289c072"
+            "result": "364eae2d25c545f28f1056d6f52ef3ef"
         },
         {
             "name": "test3392",
@@ -793,7 +793,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test805_6068_4563.obu",
             "output_format": "gbrp",
-            "result": "7eca47a891ba02c71bd2142e6fe0a1ca"
+            "result": "25d6113008c18cdd967f3670b5b9e8fb"
         },
         {
             "name": "test641",
@@ -857,7 +857,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test943_1896_5461.obu",
             "output_format": "yuv444p",
-            "result": "c00e0129134369f1830f5321f1e1ca34"
+            "result": "fc9c591791a48945de34408bba8db51e"
         },
         {
             "name": "test4665",
@@ -913,7 +913,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test6574.obu",
             "output_format": "yuv444p10le",
-            "result": "24b7f5e9d027689c2949c38d2602c9fd"
+            "result": "03b1420fead3265ab0eb0c00adbf7d37"
         },
         {
             "name": "test2516",
@@ -985,7 +985,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1556_273_5657.obu",
             "output_format": "yuv444p",
-            "result": "7305b2319102959d8a90fe64eb9afb9b"
+            "result": "b7a8024513b13111ad7ab2a67f491965"
         },
         {
             "name": "test1294",
@@ -1049,7 +1049,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test382_5606.obu",
             "output_format": "yuv444p10le",
-            "result": "4a32c15d97b905125bde6de019b19f67"
+            "result": "74e303409c2eb2cedeea4c2488d8e1dc"
         },
         {
             "name": "test2726",
@@ -1081,7 +1081,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1275.obu",
             "output_format": "gbrp10le",
-            "result": "5a396a6b795cf5151ab18ff0185ccfae"
+            "result": "d4e0f4dee25822cbb81d51380ee71240"
         },
         {
             "name": "test6474",
@@ -1265,7 +1265,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test439_262_1642.obu",
             "output_format": "gbrp",
-            "result": "9a672f8839b92ea009845723c760db5a"
+            "result": "9fc35e2eb3fb6514dcacd0c656823234"
         },
         {
             "name": "test5360",
@@ -1337,7 +1337,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1251.obu",
             "output_format": "yuv444p",
-            "result": "9b16dfd38ceb77a2e30ac2c0617f47a5"
+            "result": "689e9ab398c40e61ab8919a0c4c37307"
         },
         {
             "name": "test7455",
@@ -1353,7 +1353,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test6420_5253.obu",
             "output_format": "yuv444p10le",
-            "result": "c15d6d49dacf21f66e2e3043b8c00c3e"
+            "result": "ed690fd181401e5828ab021bbc600b1a"
         },
         {
             "name": "test1419_5692_32",
@@ -1361,7 +1361,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1419_5692_32.obu",
             "output_format": "yuv444p",
-            "result": "f533e6cf5ec7ca14d020724da066f998"
+            "result": "649a78af63ac44caf980288c33187314"
         },
         {
             "name": "test2096",
@@ -1433,7 +1433,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7345.obu",
             "output_format": "gbrp10le",
-            "result": "dccee7b03d542e21a86f3cabf497e949"
+            "result": "cc44d01ddd26cd00771d6117b5d4b33e"
         },
         {
             "name": "test184_589",
@@ -1521,7 +1521,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test20026.obu",
             "output_format": "yuv444p",
-            "result": "41ee8069caaba21d524d56b381313f55"
+            "result": "70fd6deea6319aa67d1eb3cdcf027cd9"
         },
         {
             "name": "test6056",
@@ -1553,7 +1553,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7586.obu",
             "output_format": "gbrp",
-            "result": "4d9868da6a91dde51dd932ed771bad5a"
+            "result": "9028a2133cedcb1708c6c2741a6be112"
         },
         {
             "name": "test4685",
@@ -1633,7 +1633,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test6664_6873.obu",
             "output_format": "yuv444p",
-            "result": "ea7503938ce51f33cb9faffbad2e4388"
+            "result": "670a92117a032d6a883fc09dcf323390"
         },
         {
             "name": "test2369_1557_2112",
@@ -1649,7 +1649,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1662.obu",
             "output_format": "gbrp",
-            "result": "d401d59fd69ad39f14eeda3c513ae7b1"
+            "result": "af6d881206a56ff0c1cc3f9b9ee1b609"
         },
         {
             "name": "test3069",
@@ -1697,7 +1697,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test4679_2869.obu",
             "output_format": "gbrp10le",
-            "result": "ade12547cd38e10f4332a985d24a647a"
+            "result": "6777413f99b743303b72298013ace980"
         },
         {
             "name": "test6035_5333",
@@ -1745,7 +1745,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5517_2579_6680.obu",
             "output_format": "yuv444p",
-            "result": "34b04fb7461c6d83c3d8a678ce93de7b"
+            "result": "3631de5eb08bba3a8bff42381fad487f"
         },
         {
             "name": "test6632_2374",
@@ -1753,7 +1753,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test6632_2374.obu",
             "output_format": "yuv444p10le",
-            "result": "66ca163f36d400c20d98be007f750d1d"
+            "result": "9360ceb0273279d1087ef638d78686d7"
         },
         {
             "name": "test1563",
@@ -1785,7 +1785,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test2082.obu",
             "output_format": "yuv444p",
-            "result": "c48fd145c9d77efa58ac5c2b6223ed16"
+            "result": "906ee4b9853a48046d74fe519cb5d347"
         },
         {
             "name": "test6658_2514",
@@ -1817,7 +1817,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test2217_302.obu",
             "output_format": "gbrp10le",
-            "result": "7bcf51b46cbc8fac1b26bcbd0ebd7fff"
+            "result": "e3d4a9ead70d0f686502e7715c5c168f"
         },
         {
             "name": "test1495",
@@ -1857,7 +1857,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7061_4978_4052.obu",
             "output_format": "yuv444p10le",
-            "result": "290509ed77c98f50079776f555337209"
+            "result": "2b56d7e5bf7bf70b2a6088a512b5c1e2"
         },
         {
             "name": "test4037_1785_1877",
@@ -1977,7 +1977,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5677_3343.obu",
             "output_format": "gbrp10le",
-            "result": "02fe1bb183ddf8531b6279c1e820863f"
+            "result": "cb019a23d7e0fc0b13dc358a115302e0"
         },
         {
             "name": "test1586",
@@ -2073,7 +2073,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test20029.obu",
             "output_format": "yuv444p",
-            "result": "e17516a012a8e4c51aedad1cd99bb0c8"
+            "result": "eca5033a2800cf3be5edd8ce3991bd49"
         },
         {
             "name": "test7734",
@@ -2153,7 +2153,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test105_1123.obu",
             "output_format": "yuv444p",
-            "result": "052ae219db24fcdeee8b521488cfd5e0"
+            "result": "16633a08bf0ddbe815796da410e25682"
         },
         {
             "name": "test2834",
@@ -2169,7 +2169,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test84_7242_2594.obu",
             "output_format": "gbrp",
-            "result": "f0f11f766ac9e136de3324818d5b8a3f"
+            "result": "d9b4bfd482f8754510bcbe9a5ef7b195"
         },
         {
             "name": "test1348",
@@ -2185,7 +2185,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5319.obu",
             "output_format": "gbrp",
-            "result": "dd243a288753b684dfa9bba6d1ae4241"
+            "result": "54be3f323d6a4368ddb72c2ea6d532c2"
         },
         {
             "name": "test5466_1830",
@@ -2249,7 +2249,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test673_4935_7356.obu",
             "output_format": "yuv444p",
-            "result": "ad55ce58e9297335324f9a7ee0172954"
+            "result": "36e62bdb02efcfcd8c977e76f578e877"
         },
         {
             "name": "test2509",
@@ -2345,7 +2345,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test4837_4698.obu",
             "output_format": "yuv444p",
-            "result": "d3f1633c38789509b21260a1cf0333b1"
+            "result": "4cccc2ee62b9b5383a09be3982037220"
         },
         {
             "name": "test1736",
@@ -2417,7 +2417,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7127.obu",
             "output_format": "yuv444p",
-            "result": "1c9ed70dd89d701fa03d557959770b68"
+            "result": "a9dce48419573a95ad445d9d19ea936e"
         },
         {
             "name": "test2968_2753",
@@ -2433,7 +2433,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test3551_5291_7343.obu",
             "output_format": "yuv444p",
-            "result": "93969ed992efb7189df4f80c0be2fe3d"
+            "result": "f9750c23961d9f2d763c6c22a984f0b7"
         },
         {
             "name": "test7515",
@@ -2457,7 +2457,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7409_6983.obu",
             "output_format": "yuv444p10le",
-            "result": "7b8b74a7b0a8e7e099a1066f8d96df4d"
+            "result": "945bf1727136ca9da90b7820876d8efa"
         },
         {
             "name": "test6034",
@@ -2513,7 +2513,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7120_849.obu",
             "output_format": "gbrp",
-            "result": "0ce8cd006d16dacc1fbe4d04ea79a4fc"
+            "result": "6467465b9787509052733e9ae12b9312"
         },
         {
             "name": "test6417",
@@ -2553,7 +2553,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test2714.obu",
             "output_format": "yuv444p",
-            "result": "708b0d8484b7ed24c2e53201a4e73721"
+            "result": "6d617ab98bc417adda8517fa84d942e8"
         },
         {
             "name": "test6979_5029",
@@ -2561,7 +2561,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test6979_5029.obu",
             "output_format": "yuv444p10le",
-            "result": "d2a181d96df68271934c25da4be89883"
+            "result": "345ef20e156835393834f02eb4b819b8"
         },
         {
             "name": "test1410_4794",
@@ -2569,7 +2569,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1410_4794.obu",
             "output_format": "gbrp",
-            "result": "d6a43abb511a7b461412dadd62f92359"
+            "result": "d667aa6c037c466f84b7dddbf1af8939"
         },
         {
             "name": "test1169",
@@ -2601,7 +2601,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1116_2562_4007.obu",
             "output_format": "yuv444p10le",
-            "result": "b2c7ccb9b5b8d4c93ce612c7d0f9ad11"
+            "result": "1279b38b32db3f79a1b5aa2892a4f0e2"
         },
         {
             "name": "test7740",
@@ -2705,7 +2705,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test6713_6982_288.obu",
             "output_format": "yuv444p",
-            "result": "f1e22a465e9a5a19ad9426281e15b3e0"
+            "result": "8bc0c9297a7142284f337574b7ba719a"
         },
         {
             "name": "test7770_7783",
@@ -2721,7 +2721,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7431_2365.obu",
             "output_format": "gbrp10le",
-            "result": "34b8b3573aa90655a853c95bf02af85e"
+            "result": "eb20ff4114d4bb74ac7d95c88e07227b"
         },
         {
             "name": "test6444_696_1816",
@@ -2729,7 +2729,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test6444_696_1816.obu",
             "output_format": "gbrp",
-            "result": "eaf12092979cc2e2e8c675f8363f3a31"
+            "result": "1d56c764c4e73bd5a1cc3e517d882e09"
         },
         {
             "name": "test7504",
@@ -2777,7 +2777,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test463_1013_5244.obu",
             "output_format": "gbrp",
-            "result": "3ac1522e490ed59e5af0e3b208f519c0"
+            "result": "a54849b9d3196db84d484b908f183dc7"
         },
         {
             "name": "test2274",
@@ -2809,7 +2809,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test3616_1699_5771.obu",
             "output_format": "yuv444p10le",
-            "result": "b59212030fc04ac13a0bdb37e0a1fe67"
+            "result": "719e626b84a44376b0dadeb8521b7fa8"
         },
         {
             "name": "test7191",
@@ -2905,7 +2905,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test909_5289.obu",
             "output_format": "yuv444p",
-            "result": "0fbc21f409eba8e6f8afd03c0c9a5a68"
+            "result": "aa1748a016dd6fcfaef3fddd1cdb4a99"
         },
         {
             "name": "test4597",
@@ -2953,7 +2953,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test462_4522_4964.obu",
             "output_format": "gbrp10le",
-            "result": "7b0624cc27494fb49f97374053a5dc93"
+            "result": "e3b037c97b5dd3e647486500b77addaf"
         },
         {
             "name": "test2368_1746",
@@ -2977,7 +2977,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1635.obu",
             "output_format": "yuv444p10le",
-            "result": "d7255f7ea9fed5804b9056bc3de666b0"
+            "result": "dbcc5a1844cded89a67725e411d5824a"
         },
         {
             "name": "test1859",
@@ -3049,7 +3049,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test399.obu",
             "output_format": "yuv444p",
-            "result": "691389de4032e65b8738462a75b5b2cf"
+            "result": "6e23fbdc51e5d2b70f9f8eb0b2d4c2d9"
         },
         {
             "name": "test5580",
@@ -3129,7 +3129,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test2833_4650_760.obu",
             "output_format": "gbrp10le",
-            "result": "6c54ca1635cb793374345d63b05c9ede"
+            "result": "6e7072f8b42680a67e8dd938d67467e6"
         },
         {
             "name": "test4898",
@@ -3177,7 +3177,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5751_5997_2083.obu",
             "output_format": "yuv444p10le",
-            "result": "4cf62fd8bccef618cd67ba0844699ff4"
+            "result": "96b8f681bf1e144d919c6fe90d303589"
         },
         {
             "name": "test7123",
@@ -3201,7 +3201,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5445_7154.obu",
             "output_format": "yuv444p",
-            "result": "9fd946c253fbd63708065dc1cc36dc06"
+            "result": "2a24de8ca4b4cf6142d894cc4757e232"
         },
         {
             "name": "test1901_2832",
@@ -3337,7 +3337,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test2818.obu",
             "output_format": "yuv444p10le",
-            "result": "818a3e089c3d00fc0e5b315688ec202f"
+            "result": "c9db4a17df57a03f295a34c527c83b34"
         },
         {
             "name": "test2870_5855",
@@ -3497,7 +3497,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5043_2441_494.obu",
             "output_format": "yuv444p",
-            "result": "e9f9f22d1d08e10a0b3ebf8bf1b9cd2c"
+            "result": "80446001d282e9bc11e21048f091f0a4"
         },
         {
             "name": "test2795",
@@ -3537,7 +3537,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5109_5487.obu",
             "output_format": "yuv444p10le",
-            "result": "cd66d0a5fbce3a63b472815ce392f043"
+            "result": "40e2b0b0a7be1b59ee58854e285faa7e"
         },
         {
             "name": "test7472",
@@ -3553,7 +3553,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5788_987_428.obu",
             "output_format": "gbrp",
-            "result": "f2a46e1d1f0307eca14e237225c1c135"
+            "result": "53ef3b927756970debd4ef2dfe60ae8c"
         },
         {
             "name": "test493_4426",
@@ -3561,7 +3561,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test493_4426.obu",
             "output_format": "yuv444p10le",
-            "result": "de193f8c120e54590e9f5fb87007cfb2"
+            "result": "6ebec0187ed0da33408cfa5668c6be9b"
         },
         {
             "name": "test7509",
@@ -3705,7 +3705,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7166_6684_1868.obu",
             "output_format": "gbrp10le",
-            "result": "ca6c49eb13bbeb0b0d8fbde720880812"
+            "result": "148f0040efae93f37debb8a0e91a094f"
         },
         {
             "name": "test7244",
@@ -3729,7 +3729,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1096_7336.obu",
             "output_format": "yuv444p",
-            "result": "2a709abe8f8933c388854469b968e06b"
+            "result": "251a1e6ea7625ba4b2ee955315f9714f"
         },
         {
             "name": "test6096_7092_3804",
@@ -3785,7 +3785,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1232_4003_4557.obu",
             "output_format": "gbrp10le",
-            "result": "c2d3c9a102ff0bceb15a327679d9f542"
+            "result": "b48c5608c7f96cec9ea74e8f25592fdd"
         },
         {
             "name": "test4545_443_2533",
@@ -3913,7 +3913,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test3870_2802_6204.obu",
             "output_format": "yuv444p",
-            "result": "bc606c09d0a29e606722695b011c2b6b"
+            "result": "e6f6d4e4c87e7acb7f39045883096599"
         },
         {
             "name": "test6037_7206_6811",
@@ -3921,7 +3921,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test6037_7206_6811.obu",
             "output_format": "gbrp10le",
-            "result": "15b31afb8bb497b4a6015210324010cf"
+            "result": "e0280aa63214a91222f80152a3540732"
         },
         {
             "name": "test1861",
@@ -3977,7 +3977,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7354_1352.obu",
             "output_format": "yuv444p",
-            "result": "535e62089f15eb7556237acec8ae02b3"
+            "result": "26e9773129501879a05630fc65e7d594"
         },
         {
             "name": "test2189",
@@ -3993,7 +3993,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test4728_429.obu",
             "output_format": "yuv444p10le",
-            "result": "4ce2c2c1e3b0901c031b29418b5c91e4"
+            "result": "a7030c08e5d065b86da52763e7e93113"
         },
         {
             "name": "test7736",
@@ -4009,7 +4009,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test20022.obu",
             "output_format": "yuv444p",
-            "result": "f5d56151b8b6d32c7484c02dfb292776"
+            "result": "bec4be234a54ff80d14f640817f57305"
         },
         {
             "name": "test4844",
@@ -4137,7 +4137,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1493.obu",
             "output_format": "gbrp10le",
-            "result": "bb31aa8f99acea1c55b2b04e6ac102fb"
+            "result": "3c5507e3708bad5af7486a7b8f8ba56a"
         },
         {
             "name": "test383",
@@ -4177,7 +4177,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test2557_2639_444.obu",
             "output_format": "yuv444p10le",
-            "result": "fcfc98d9d16d605f7d9ec0c316f79315"
+            "result": "f57e0e881f01ef54c4f884f0b062561e"
         },
         {
             "name": "test2643",
@@ -4209,7 +4209,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test6442.obu",
             "output_format": "yuv444p10le",
-            "result": "21346b14bd3d0c89f4b6314ba86c7e47"
+            "result": "ed39e99b8ef9da11dfa3b9b8bc79c617"
         },
         {
             "name": "test4933",
@@ -4289,7 +4289,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test20027.obu",
             "output_format": "gbrp",
-            "result": "818b508c38f95e7eedeee692aabf3d81"
+            "result": "1ad3d0eb1c978f38a1eb4d0caefba101"
         },
         {
             "name": "test7744",
@@ -4369,7 +4369,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5492_4657.obu",
             "output_format": "yuv444p10le",
-            "result": "5d9aa060daefd81cec666b185a0a15d9"
+            "result": "d935d4167c96b008564b33802ace452f"
         },
         {
             "name": "test4546_1529",
@@ -4417,7 +4417,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test834_5877_6685.obu",
             "output_format": "gbrp10le",
-            "result": "e341f61c79567257e288ad721df8a14d"
+            "result": "bfffd6152316acddef6b51db7f5d594f"
         },
         {
             "name": "test6581",
@@ -4481,7 +4481,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5097_1260_4584.obu",
             "output_format": "gbrp10le",
-            "result": "12b7898e2de22b934116335718db59fb"
+            "result": "62e2214318cca60cb81ab7d24d4e854b"
         },
         {
             "name": "test6621",
@@ -4649,7 +4649,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test4402_6515.obu",
             "output_format": "yuv444p10le",
-            "result": "4861888085a6dc2dba3eea6e18e98b64"
+            "result": "0e919cd9f35558afe08e616c6d27e90a"
         },
         {
             "name": "test3941",
@@ -4697,7 +4697,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1007.obu",
             "output_format": "yuv444p10le",
-            "result": "5552cc21e30b517edbb95a193adb5aff"
+            "result": "5d5685dcf1a57ce47b84d27be8d9420c"
         },
         {
             "name": "test5078_2051_519",
@@ -4713,7 +4713,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5099_1293.obu",
             "output_format": "yuv444p10le",
-            "result": "d963f73265545aeca522dd09d05048db"
+            "result": "919fdbe2b50a4b13f912121d9033c62e"
         },
         {
             "name": "test7309",
@@ -4729,7 +4729,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5025_2981_7100.obu",
             "output_format": "yuv444p10le",
-            "result": "791544eff9b758ddc411e62b9b22d454"
+            "result": "719019651c932ae608014427f25a82fa"
         },
         {
             "name": "test2423",
@@ -4777,7 +4777,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5792.obu",
             "output_format": "gbrp10le",
-            "result": "75fd688beb488d81d7caa375de854b90"
+            "result": "071482d346f91925d354fd549903384d"
         },
         {
             "name": "test2336_1886_6010",
@@ -4841,7 +4841,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test4963_1040.obu",
             "output_format": "yuv444p",
-            "result": "709dd13b909f0706458c1f555167ae66"
+            "result": "62c6da414958dd2590949fc50f8cdb0c"
         },
         {
             "name": "test7019",
@@ -5009,7 +5009,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test20013.obu",
             "output_format": "gbrp10le",
-            "result": "14d585f51dad8cfbbc0342d47e157721"
+            "result": "bcafba4ead3fa30d0c6e8d2f754dbfc6"
         },
         {
             "name": "test4701",
@@ -5057,7 +5057,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test2449_1454.obu",
             "output_format": "yuv444p",
-            "result": "08719be7f47d3624a85c2aca1e7e645a"
+            "result": "630721f1e3968b97148375f73c314c7b"
         },
         {
             "name": "test1156_824",
@@ -5193,7 +5193,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test20019.obu",
             "output_format": "yuv444p",
-            "result": "abade8411340ac6a1125c4780cbdb37f"
+            "result": "a095786727a0822d1a11151bf7941ed6"
         },
         {
             "name": "test1931_2001",
@@ -5217,7 +5217,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test826_2982.obu",
             "output_format": "gbrp10le",
-            "result": "0d10fd689374bef52d07ddf009dc1d02"
+            "result": "69a61567eb6a3c20c8ab62309dc7fb3b"
         },
         {
             "name": "test4925",
@@ -5353,7 +5353,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5573_1112_2685.obu",
             "output_format": "gbrp",
-            "result": "06491bf5fca15c8bd83b2c50a42e68bb"
+            "result": "ab27af17ec77ae2133f75fd24026bf9f"
         },
         {
             "name": "test1878",
@@ -5385,7 +5385,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7508_7618.obu",
             "output_format": "None",
-            "result": "245332e54c1b57321f549582cdf1f86a"
+            "result": "dc2dab3fe72edc11f2d2cc2ff853b260"
         },
         {
             "name": "test20021",
@@ -5393,7 +5393,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test20021.obu",
             "output_format": "gbrp10le",
-            "result": "7b52aba037f542e02ca7c0e914e849f9"
+            "result": "ae35932ce258e7635ea45009c3cdff1a"
         },
         {
             "name": "test627",
@@ -5425,7 +5425,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7490_7584.obu",
             "output_format": "gbrp",
-            "result": "85a8827ccc4f86c602cddaa4a9fa94ed"
+            "result": "19a7b21eb4c0753fc140d4a2290581fe"
         },
         {
             "name": "test4224",
@@ -5441,7 +5441,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test2507.obu",
             "output_format": "gbrp10le",
-            "result": "ca948acb453f48d4d343102f34be0251"
+            "result": "e69bbdebcb3491669638540a0cb41de0"
         },
         {
             "name": "test7741",
@@ -5529,7 +5529,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1274_7478.obu",
             "output_format": "yuv444p10le",
-            "result": "b6f7478dcfebec9ca06fff4652ef181a"
+            "result": "f5cfe1b78bf1b5ad790c837086c342b3"
         },
         {
             "name": "test1848",
@@ -5585,7 +5585,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7459_36_676.obu",
             "output_format": "gbrp10le",
-            "result": "f6ab456505544f23303b96b4d4be0fbd"
+            "result": "2a1d868ea3380206d89eecad1869c151"
         },
         {
             "name": "test580_996_2111",
@@ -5593,7 +5593,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test580_996_2111.obu",
             "output_format": "gbrp10le",
-            "result": "4011f74d8dc227f5537c4d16083f57d8"
+            "result": "fbfffc25ff8bccf8c3eb0b8e2d5be065"
         },
         {
             "name": "test6429_808_7473",
@@ -5769,7 +5769,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test6615.obu",
             "output_format": "gbrp",
-            "result": "4e1de87b328b95b3a0665cede8556ad8"
+            "result": "8da501d00e0c5d4a572d1d806237a625"
         },
         {
             "name": "test7688_7698_7691",
@@ -5841,7 +5841,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test20017.obu",
             "output_format": "yuv444p10le",
-            "result": "440f034eae83bb944de0b1f847c4db73"
+            "result": "b40ae76497b91785f8688cf6b93d33fc"
         },
         {
             "name": "test1766",
@@ -5849,7 +5849,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1766.obu",
             "output_format": "gbrp10le",
-            "result": "0ac0f9069826ce2331a5d9ad0b01c2a1"
+            "result": "0a5c35a2557403dc8817dd9e28f22f90"
         },
         {
             "name": "test5635",
@@ -5905,7 +5905,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7029_2405.obu",
             "output_format": "gbrp10le",
-            "result": "db2882becb171991781712a6035143d4"
+            "result": "25483dfbd28bbd06b17829b3caed0a60"
         },
         {
             "name": "test501",
@@ -5969,7 +5969,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test2715.obu",
             "output_format": "yuv444p",
-            "result": "7803ee69eba174e4849d4e86cb3f547a"
+            "result": "e3d7944dfb4cc1a568cecec42604d6fc"
         },
         {
             "name": "test2708_1329",
@@ -5977,7 +5977,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test2708_1329.obu",
             "output_format": "yuv444p10le",
-            "result": "b6df9a0c5e4f223a75e79beef3dd566f"
+            "result": "b645ef1f650f2277213df63d8d6e9536"
         },
         {
             "name": "test7401",
@@ -6009,7 +6009,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test7482_5111_5195.obu",
             "output_format": "yuv444p",
-            "result": "b7b0ac7b03c2284201a2d2f6437be3d8"
+            "result": "681a6413f92476924bfaf8e9abd93b65"
         },
         {
             "name": "test4788",
@@ -6025,7 +6025,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test716.obu",
             "output_format": "gbrp",
-            "result": "9971cb07d3f219b931a39134307f2a66"
+            "result": "ea38074ed70e0e83d4e0e3903a1e7275"
         },
         {
             "name": "test765",
@@ -6041,7 +6041,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test6761_7445_5525.obu",
             "output_format": "gbrp",
-            "result": "a9d564a4c2d7eb844da5a8305179c2ea"
+            "result": "a058bbcbf70cf7a16d400abb75aea3db"
         },
         {
             "name": "test7492",
@@ -6057,7 +6057,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test5772.obu",
             "output_format": "yuv444p10le",
-            "result": "1fd60677ab415ceac48d87df820f4704"
+            "result": "8528ed1f640deb268171003758fa707c"
         },
         {
             "name": "test6359",
@@ -6217,7 +6217,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test1672_5292_4796.obu",
             "output_format": "gbrp10le",
-            "result": "f712c840f0399a48f4e1be6a0dd6b8af"
+            "result": "c68ba7ab754b99d4f16ebd4d60bbf813"
         },
         {
             "name": "test712_951_6914",
@@ -6225,7 +6225,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_core/streams/test712_951_6914.obu",
             "output_format": "gbrp",
-            "result": "1e85f28bae0ffe127731a0fc0aeb5e96"
+            "result": "295c8fe1e007fb6337c407fc3ed018c7"
         },
         {
             "name": "test1283_6876",
@@ -6251,5 +6251,6 @@
             "output_format": "gbrp",
             "result": "a74310365ba4ba6b8392bb968d2cc281"
         }
-    ]
+    ],
+    "test_method": "md5"
 }

--- a/test_suites/av1/AV1-ARGON-PROFILE1-NON-ANNEX-B.json
+++ b/test_suites/av1/AV1-ARGON-PROFILE1-NON-ANNEX-B.json
@@ -17,7 +17,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test15.obu",
             "output_format": "Unknown",
-            "result": "60d1c161138e4fd68b4575607347a666"
+            "result": ""
         },
         {
             "name": "test7",
@@ -33,7 +33,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test29.obu",
             "output_format": "yuv444p",
-            "result": "2ee3e930ee474935d3500531ee9315e5"
+            "result": ""
         },
         {
             "name": "test14",
@@ -41,7 +41,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test14.obu",
             "output_format": "None",
-            "result": "e401c54d66e52a570082f57ec302242e"
+            "result": ""
         },
         {
             "name": "test35",
@@ -65,7 +65,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test24.obu",
             "output_format": "Unknown",
-            "result": "18525db0befcb2a96d4346f352dec31c"
+            "result": ""
         },
         {
             "name": "test54",
@@ -137,7 +137,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test53.obu",
             "output_format": "gbrp10le",
-            "result": "9302aac405c36409ddb9b52de490af4e"
+            "result": ""
         },
         {
             "name": "test18",
@@ -161,7 +161,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test25.obu",
             "output_format": "Unknown",
-            "result": "a7c8d66afc5289e5958c8a92395b2f4a"
+            "result": ""
         },
         {
             "name": "test55",
@@ -225,7 +225,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test4.obu",
             "output_format": "Unknown",
-            "result": "5966978949a311394d011a9d269c3d1d"
+            "result": ""
         },
         {
             "name": "test11",
@@ -321,7 +321,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test34.obu",
             "output_format": "Unknown",
-            "result": "8e7e975aba2aeaac9465bf60cdcc4089"
+            "result": ""
         },
         {
             "name": "test28",
@@ -345,7 +345,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test3.obu",
             "output_format": "Unknown",
-            "result": "fe269cdf874bc3ed6a30ffac99c8c388"
+            "result": ""
         },
         {
             "name": "test36",
@@ -361,7 +361,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test19.obu",
             "output_format": "gbrp",
-            "result": "d30614f1f02d72d7c50d34a1087726bf"
+            "result": ""
         },
         {
             "name": "test37",
@@ -377,7 +377,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test41.obu",
             "output_format": "yuv444p",
-            "result": "e628a64e92bc24cf4617634d16036786"
+            "result": ""
         },
         {
             "name": "test49",
@@ -385,7 +385,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test49.obu",
             "output_format": "Unknown",
-            "result": "43d44cb2de65bc87986f6c8ee09d1d50"
+            "result": ""
         },
         {
             "name": "test5",
@@ -393,7 +393,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test5.obu",
             "output_format": "Unknown",
-            "result": "5ff78e9eaa2753584fe9017754ccf1ff"
+            "result": ""
         },
         {
             "name": "test10",
@@ -409,7 +409,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test23.obu",
             "output_format": "Unknown",
-            "result": "1ea2394395e52aefd85c46dcad905582"
+            "result": ""
         },
         {
             "name": "test1",
@@ -417,7 +417,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test1.obu",
             "output_format": "Unknown",
-            "result": "ba582db12e333af20fffcae9d42404ed"
+            "result": ""
         },
         {
             "name": "test2",
@@ -425,7 +425,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test2.obu",
             "output_format": "Unknown",
-            "result": "d87198268475e694914679ce0099e593"
+            "result": ""
         },
         {
             "name": "test32",
@@ -441,7 +441,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test12.obu",
             "output_format": "None",
-            "result": "2f212b69e18d8a4a1c182e633a96b694"
+            "result": ""
         },
         {
             "name": "test8650",
@@ -529,7 +529,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_not_annexb/streams/test8640_8699_8672.obu",
             "output_format": "gbrp",
-            "result": "41b8859cc54af48abcb4fb79485211ee"
+            "result": "8e5be89564591ab37e9e689f2cf3a242"
         },
         {
             "name": "test8865",
@@ -553,7 +553,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_not_annexb/streams/test8861_8857_8751.obu",
             "output_format": "yuv444p",
-            "result": "f61565a8403f0c25ab1e45e843bcb631"
+            "result": "c566ae0b15e7ac277563d935bfc82362"
         },
         {
             "name": "test223",
@@ -561,7 +561,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test223.obu",
             "output_format": "yuv444p",
-            "result": "8991974aac9050b34a88ba3819be5b48"
+            "result": ""
         },
         {
             "name": "test461",
@@ -569,7 +569,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test461.obu",
             "output_format": "Unknown",
-            "result": "312cdac532b15b1f2e4edb6fbb3b490c"
+            "result": ""
         },
         {
             "name": "test183",
@@ -577,7 +577,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test183.obu",
             "output_format": "yuv444p10le",
-            "result": "b7e79c92feceab2464359f86f3f369fb"
+            "result": ""
         },
         {
             "name": "test442",
@@ -585,7 +585,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test442.obu",
             "output_format": "yuv444p10le",
-            "result": "7c7b4c971670ce1127852131a58e461c"
+            "result": ""
         },
         {
             "name": "test261",
@@ -593,7 +593,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test261.obu",
             "output_format": "Unknown",
-            "result": "73fa06435efc1e608598bd584855ac70"
+            "result": ""
         },
         {
             "name": "test184",
@@ -601,7 +601,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test184.obu",
             "output_format": "yuv444p10le",
-            "result": "f997c90fd3fda7c327658fa46a0a2d77"
+            "result": ""
         },
         {
             "name": "test438",
@@ -609,7 +609,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test438.obu",
             "output_format": "gbrp10le",
-            "result": "da39f3a3ebd3ffceef17aed8cdeed219"
+            "result": ""
         },
         {
             "name": "test134",
@@ -617,7 +617,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test134.obu",
             "output_format": "Unknown",
-            "result": "22483c4b082e4ff6f567a60b70067591"
+            "result": ""
         },
         {
             "name": "test94",
@@ -625,7 +625,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test94.obu",
             "output_format": "gbrp",
-            "result": "f2df4c6b5c7338e109222f32547124e7"
+            "result": ""
         },
         {
             "name": "test359",
@@ -633,7 +633,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test359.obu",
             "output_format": "Unknown",
-            "result": "99b5f8a79bcf9f7dd4708decc63d49af"
+            "result": ""
         },
         {
             "name": "test452",
@@ -641,7 +641,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test452.obu",
             "output_format": "yuv444p10le",
-            "result": "3763df79ca5a1994b713ab0b36d3b6ec"
+            "result": ""
         },
         {
             "name": "test334",
@@ -649,7 +649,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test334.obu",
             "output_format": "gbrp10le",
-            "result": "7e4c045733cc7bfb9d39664d04f70e4f"
+            "result": ""
         },
         {
             "name": "test186",
@@ -657,7 +657,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test186.obu",
             "output_format": "gbrp10le",
-            "result": "abe4fb2ba55828c383b75a9461051023"
+            "result": ""
         },
         {
             "name": "test430",
@@ -665,7 +665,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test430.obu",
             "output_format": "yuv444p",
-            "result": "9772e5a95f71372020da3c96c9ba8a20"
+            "result": ""
         },
         {
             "name": "test424",
@@ -673,7 +673,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test424.obu",
             "output_format": "Unknown",
-            "result": "2dfe41b867edff6b5004238c8e6a2196"
+            "result": ""
         },
         {
             "name": "test390",
@@ -681,7 +681,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test390.obu",
             "output_format": "Unknown",
-            "result": "f6f91560a0e0e3523ddbb866362cafa0"
+            "result": ""
         },
         {
             "name": "test127",
@@ -689,7 +689,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test127.obu",
             "output_format": "Unknown",
-            "result": "3d43e2cfc2b84710bfdedc5a9ec5fe0c"
+            "result": ""
         },
         {
             "name": "test244",
@@ -697,7 +697,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test244.obu",
             "output_format": "gbrp10le",
-            "result": "04b656434481d9d2c947e0276953e6e0"
+            "result": ""
         },
         {
             "name": "test182",
@@ -705,7 +705,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test182.obu",
             "output_format": "gbrp10le",
-            "result": "975683612fca72add6b1ef5b6e8a1315"
+            "result": ""
         },
         {
             "name": "test60",
@@ -713,7 +713,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test60.obu",
             "output_format": "Unknown",
-            "result": "d7dc0c4d13c7b80f75089bac537b1dfa"
+            "result": ""
         },
         {
             "name": "test332",
@@ -721,7 +721,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test332.obu",
             "output_format": "Unknown",
-            "result": "1838c9e972f92bf74c28a6d9b044299d"
+            "result": ""
         },
         {
             "name": "test454",
@@ -729,7 +729,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test454.obu",
             "output_format": "yuv444p10le",
-            "result": "9a6f07aa6134998ab299ce8b19b25290"
+            "result": ""
         },
         {
             "name": "test434",
@@ -737,7 +737,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test434.obu",
             "output_format": "gbrp10le",
-            "result": "5bc31e2c4b2e7eea99bb29ae765424dd"
+            "result": ""
         },
         {
             "name": "test136",
@@ -745,7 +745,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test136.obu",
             "output_format": "Unknown",
-            "result": "84bb5cc35acd55a73e0bf9e676fc9a5e"
+            "result": ""
         },
         {
             "name": "test185",
@@ -753,7 +753,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test185.obu",
             "output_format": "Unknown",
-            "result": "0c66d70e9367b8b4252367277392ed31"
+            "result": ""
         },
         {
             "name": "test92",
@@ -761,7 +761,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test92.obu",
             "output_format": "gbrp10le",
-            "result": "07bee7fa425f613ca79c9d1fd23b11c6"
+            "result": ""
         },
         {
             "name": "test310",
@@ -769,7 +769,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test310.obu",
             "output_format": "gbrp10le",
-            "result": "ae4ed156721a899836230765b2c1cefe"
+            "result": ""
         },
         {
             "name": "test421",
@@ -777,7 +777,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test421.obu",
             "output_format": "Unknown",
-            "result": "d1e314a59f291493290fa970079cbe75"
+            "result": ""
         },
         {
             "name": "test429",
@@ -785,7 +785,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test429.obu",
             "output_format": "yuv444p10le",
-            "result": "b214e47a66cc263946c9c6d2863cd815"
+            "result": ""
         },
         {
             "name": "test428",
@@ -793,7 +793,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test428.obu",
             "output_format": "Unknown",
-            "result": "b8664b83bb675a2efdeb717a4159f767"
+            "result": ""
         },
         {
             "name": "test426",
@@ -801,7 +801,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test426.obu",
             "output_format": "Unknown",
-            "result": "e6ca79b83f7f1176072625b1ab708b48"
+            "result": ""
         },
         {
             "name": "test267",
@@ -809,7 +809,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test267.obu",
             "output_format": "Unknown",
-            "result": "3c947747329cc152c44615c412be5eb5"
+            "result": ""
         },
         {
             "name": "test414",
@@ -817,7 +817,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test414.obu",
             "output_format": "yuv444p10le",
-            "result": "a019139f8dd429d9f29e8410da565958"
+            "result": ""
         },
         {
             "name": "test79",
@@ -825,7 +825,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test79.obu",
             "output_format": "Unknown",
-            "result": "9785ed65416c4f6e5a346862d145b4e8"
+            "result": ""
         },
         {
             "name": "test272",
@@ -833,7 +833,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test272.obu",
             "output_format": "yuv444p",
-            "result": "c910c56f093156f344ec00d175185948"
+            "result": ""
         },
         {
             "name": "test237",
@@ -841,7 +841,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test237.obu",
             "output_format": "Unknown",
-            "result": "00201766b387040567e0c75a6c746912"
+            "result": ""
         },
         {
             "name": "test57",
@@ -849,7 +849,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test57.obu",
             "output_format": "yuv444p10le",
-            "result": "41f403bccf4c6d17f665492650ce875b"
+            "result": ""
         },
         {
             "name": "test78",
@@ -857,7 +857,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test78.obu",
             "output_format": "Unknown",
-            "result": "8377fdbffc8c235f1d3968486d311629"
+            "result": ""
         },
         {
             "name": "test435",
@@ -865,7 +865,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test435.obu",
             "output_format": "yuv444p10le",
-            "result": "947a9b1fb16e07d5831b7f5543a8928f"
+            "result": ""
         },
         {
             "name": "test289",
@@ -873,7 +873,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test289.obu",
             "output_format": "gbrp10le",
-            "result": "e99d5ab2e5a2e748f5ce4632437ccbee"
+            "result": ""
         },
         {
             "name": "test415",
@@ -881,7 +881,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test415.obu",
             "output_format": "yuv444p",
-            "result": "71177a1df9b45ee214289f4aae5bcdc3"
+            "result": ""
         },
         {
             "name": "test417",
@@ -889,7 +889,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test417.obu",
             "output_format": "yuv444p",
-            "result": "ef51d4cb7ec2a8d37153da46b8feb018"
+            "result": ""
         },
         {
             "name": "test459",
@@ -897,7 +897,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test459.obu",
             "output_format": "Unknown",
-            "result": "f66af354bcfbc16ef3eeb41c57bc2a7c"
+            "result": ""
         },
         {
             "name": "test274",
@@ -905,7 +905,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test274.obu",
             "output_format": "Unknown",
-            "result": "cab3aff81276f99eecf5530d63f62c7d"
+            "result": ""
         },
         {
             "name": "test197",
@@ -913,7 +913,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test197.obu",
             "output_format": "Unknown",
-            "result": "cd7179db9211ebc7a906dae85e302b22"
+            "result": ""
         },
         {
             "name": "test420",
@@ -921,7 +921,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test420.obu",
             "output_format": "yuv444p10le",
-            "result": "d1e3a9413217438e153428140f8af7dd"
+            "result": ""
         },
         {
             "name": "test283",
@@ -929,7 +929,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test283.obu",
             "output_format": "Unknown",
-            "result": "836ed4f45cc52089d12222d17d4a42bc"
+            "result": ""
         },
         {
             "name": "test458",
@@ -937,7 +937,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test458.obu",
             "output_format": "yuv444p",
-            "result": "2f11dc45f5bc1b8d90a29ea6cfc0f68e"
+            "result": ""
         },
         {
             "name": "test398",
@@ -945,7 +945,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test398.obu",
             "output_format": "Unknown",
-            "result": "f29ea82d81c098f1a01735313b403d39"
+            "result": ""
         },
         {
             "name": "test58",
@@ -953,7 +953,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test58.obu",
             "output_format": "yuv444p10le",
-            "result": "1f73bb3525dc8ee6e854d3666f4e9af2"
+            "result": ""
         },
         {
             "name": "test201",
@@ -961,7 +961,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test201.obu",
             "output_format": "gbrp10le",
-            "result": "0845fa512f53dfc4881603f792dda587"
+            "result": ""
         },
         {
             "name": "test228",
@@ -969,7 +969,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test228.obu",
             "output_format": "Unknown",
-            "result": "bfcdb00bd5b4a632f3f0e7aaec5030d7"
+            "result": ""
         },
         {
             "name": "test124",
@@ -977,7 +977,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test124.obu",
             "output_format": "Unknown",
-            "result": "ad9639d9c974fc18081f8629c5e34ba5"
+            "result": ""
         },
         {
             "name": "test202",
@@ -985,7 +985,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test202.obu",
             "output_format": "gbrp10le",
-            "result": "14093ed5985a6e826166a42b748daf62"
+            "result": ""
         },
         {
             "name": "test433",
@@ -993,7 +993,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test433.obu",
             "output_format": "Unknown",
-            "result": "28daa1e950842b66b857991e53328313"
+            "result": ""
         },
         {
             "name": "test224",
@@ -1001,7 +1001,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test224.obu",
             "output_format": "gbrp",
-            "result": "d6f816c08065d6491f8fd26e2b12556f"
+            "result": ""
         },
         {
             "name": "test96",
@@ -1009,7 +1009,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test96.obu",
             "output_format": "Unknown",
-            "result": "668d15434591dd689d672ec14cdc881b"
+            "result": ""
         },
         {
             "name": "test265",
@@ -1017,7 +1017,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test265.obu",
             "output_format": "Unknown",
-            "result": "74a34c7090d96f4e200be6cc2b25efb9"
+            "result": ""
         },
         {
             "name": "test95",
@@ -1025,7 +1025,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test95.obu",
             "output_format": "gbrp10le",
-            "result": "be3a7f326cadca957acca523f3948d39"
+            "result": ""
         },
         {
             "name": "test81",
@@ -1033,7 +1033,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test81.obu",
             "output_format": "yuv444p10le",
-            "result": "f133adeef10d431be0128c7fa6d02847"
+            "result": ""
         },
         {
             "name": "test275",
@@ -1041,7 +1041,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test275.obu",
             "output_format": "Unknown",
-            "result": "ac7ae628848862b9e3f4bfcc6dfb5d67"
+            "result": ""
         },
         {
             "name": "test199",
@@ -1049,7 +1049,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test199.obu",
             "output_format": "gbrp10le",
-            "result": "8b019d2fd1e2f0a0354f5be52c516c18"
+            "result": ""
         },
         {
             "name": "test394",
@@ -1057,7 +1057,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test394.obu",
             "output_format": "Unknown",
-            "result": "20527830f0cd7858288ecdca0a9e33ca"
+            "result": ""
         },
         {
             "name": "test432",
@@ -1065,7 +1065,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test432.obu",
             "output_format": "yuv444p",
-            "result": "21607f2051dd4eb42cfe6f04b0dc420a"
+            "result": ""
         },
         {
             "name": "test448",
@@ -1073,7 +1073,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test448.obu",
             "output_format": "gbrp",
-            "result": "b76441585103ac8bca75538a5daf2eb1"
+            "result": ""
         },
         {
             "name": "test176",
@@ -1081,7 +1081,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test176.obu",
             "output_format": "yuv444p10le",
-            "result": "49df84d37d9765e7bd322d2bab06816f"
+            "result": ""
         },
         {
             "name": "test225",
@@ -1089,7 +1089,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test225.obu",
             "output_format": "yuv444p10le",
-            "result": "9191a469d312108546b40e4d212d3587"
+            "result": ""
         },
         {
             "name": "test330",
@@ -1097,7 +1097,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test330.obu",
             "output_format": "gbrp",
-            "result": "8561de98191394a011e5bb3ce6000774"
+            "result": ""
         },
         {
             "name": "test84",
@@ -1105,7 +1105,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test84.obu",
             "output_format": "Unknown",
-            "result": "1b91b612be150166365a6935f74d77e6"
+            "result": ""
         },
         {
             "name": "test314",
@@ -1113,7 +1113,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test314.obu",
             "output_format": "Unknown",
-            "result": "1ac70639c376dea7321e5eec6623f1d2"
+            "result": ""
         },
         {
             "name": "test144",
@@ -1121,7 +1121,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test144.obu",
             "output_format": "yuv444p",
-            "result": "97850149949ad1222850e69a86f3a468"
+            "result": ""
         },
         {
             "name": "test387",
@@ -1129,7 +1129,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test387.obu",
             "output_format": "Unknown",
-            "result": "933c4233ae8f37bf2888737788172a84"
+            "result": ""
         },
         {
             "name": "test239",
@@ -1137,7 +1137,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test239.obu",
             "output_format": "Unknown",
-            "result": "70cd391bad913e88b82890a6feeff77f"
+            "result": ""
         },
         {
             "name": "test444",
@@ -1145,7 +1145,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test444.obu",
             "output_format": "gbrp",
-            "result": "bd5924934e23f32e766475e5cd304d21"
+            "result": ""
         },
         {
             "name": "test401",
@@ -1153,7 +1153,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test401.obu",
             "output_format": "yuv444p",
-            "result": "5d28342cb95f6d8c70716cdb0324db5b"
+            "result": ""
         },
         {
             "name": "test249",
@@ -1161,7 +1161,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test249.obu",
             "output_format": "Unknown",
-            "result": "126bac69f89aca019e1e7d5ae9e01a71"
+            "result": ""
         },
         {
             "name": "test319",
@@ -1169,7 +1169,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test319.obu",
             "output_format": "Unknown",
-            "result": "a238509a8d45bc3fdf536589699d9bd7"
+            "result": ""
         },
         {
             "name": "test89",
@@ -1177,7 +1177,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test89.obu",
             "output_format": "Unknown",
-            "result": "dd5bbde4d0aa48d9cb2dfd07ef9aa01c"
+            "result": ""
         },
         {
             "name": "test181",
@@ -1185,7 +1185,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test181.obu",
             "output_format": "yuv444p10le",
-            "result": "6866a715848bc4fca1a57029af29b405"
+            "result": ""
         },
         {
             "name": "test80",
@@ -1193,7 +1193,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test80.obu",
             "output_format": "Unknown",
-            "result": "955808727711a625ec15c6d1abf8bad2"
+            "result": ""
         },
         {
             "name": "test315",
@@ -1201,7 +1201,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test315.obu",
             "output_format": "Unknown",
-            "result": "0290497cd0dd467dda498d473c29832a"
+            "result": ""
         },
         {
             "name": "test226",
@@ -1209,7 +1209,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test226.obu",
             "output_format": "gbrp",
-            "result": "e38959519873f9472f0085e063dd0d1f"
+            "result": ""
         },
         {
             "name": "test101",
@@ -1217,7 +1217,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test101.obu",
             "output_format": "yuv444p",
-            "result": "35ed6e091d33f3a7dbcf4bfcccf287d4"
+            "result": ""
         },
         {
             "name": "test413",
@@ -1225,7 +1225,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test413.obu",
             "output_format": "yuv444p",
-            "result": "1fbe3bffc503921b58f0f1225ea9db5f"
+            "result": ""
         },
         {
             "name": "test149",
@@ -1233,7 +1233,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test149.obu",
             "output_format": "gbrp",
-            "result": "4dd84932fdb15addd6ad1c51878dcf73"
+            "result": ""
         },
         {
             "name": "test436",
@@ -1241,7 +1241,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test436.obu",
             "output_format": "gbrp",
-            "result": "742864bfc43eab1a0209c4af9384ce26"
+            "result": ""
         },
         {
             "name": "test378",
@@ -1249,7 +1249,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test378.obu",
             "output_format": "Unknown",
-            "result": "30745dbb89e2856331dc38011cb05fa3"
+            "result": ""
         },
         {
             "name": "test168",
@@ -1257,7 +1257,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test168.obu",
             "output_format": "Unknown",
-            "result": "26f38e202e0ed7ba1d2385f168aa51f4"
+            "result": ""
         },
         {
             "name": "test373",
@@ -1265,7 +1265,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test373.obu",
             "output_format": "yuv444p",
-            "result": "97758bc4c1deaae6d82fa2dd4426b195"
+            "result": ""
         },
         {
             "name": "test198",
@@ -1273,7 +1273,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test198.obu",
             "output_format": "yuv444p10le",
-            "result": "529e477ab32b15c7a849a4256f80bd1e"
+            "result": ""
         },
         {
             "name": "test380",
@@ -1281,7 +1281,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test380.obu",
             "output_format": "Unknown",
-            "result": "876b0ee804e2fada60e8b148146b62eb"
+            "result": ""
         },
         {
             "name": "test132",
@@ -1289,7 +1289,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test132.obu",
             "output_format": "Unknown",
-            "result": "fc6ab81ebd78888195eefc57d6c24396"
+            "result": ""
         },
         {
             "name": "test234",
@@ -1297,7 +1297,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test234.obu",
             "output_format": "Unknown",
-            "result": "438bc3db6ab2db23d566c1b3368ff598"
+            "result": ""
         },
         {
             "name": "test146",
@@ -1305,7 +1305,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test146.obu",
             "output_format": "Unknown",
-            "result": "08d36cdbb609f9751b422d919a1a252a"
+            "result": ""
         },
         {
             "name": "test439",
@@ -1313,7 +1313,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test439.obu",
             "output_format": "yuv444p",
-            "result": "f4ee524f2ba2d414a1dec8f0e474eb19"
+            "result": ""
         },
         {
             "name": "test368",
@@ -1321,7 +1321,8 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile1_error/streams/test368.obu",
             "output_format": "gbrp",
-            "result": "7da8c397b3250895a35fdc0605729111"
+            "result": ""
         }
-    ]
+    ],
+    "test_method": "md5"
 }

--- a/test_suites/av1/AV1-ARGON-PROFILE1-STRESS-ANNEX-B.json
+++ b/test_suites/av1/AV1-ARGON-PROFILE1-STRESS-ANNEX-B.json
@@ -619,5 +619,6 @@
             "output_format": "yuv444p",
             "result": "333310ca5e5be9bb90a188b841db43ed"
         }
-    ]
+    ],
+    "test_method": "md5"
 }

--- a/test_suites/av1/AV1-ARGON-PROFILE2-CORE-ANNEX-B.json
+++ b/test_suites/av1/AV1-ARGON-PROFILE2-CORE-ANNEX-B.json
@@ -297,7 +297,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test47.obu",
             "output_format": "gray12le",
-            "result": "77b5c454adac9c975f386d92582adb7f"
+            "result": "53979d6bb46dd08fb35cbb9cb5a88ffe"
         },
         {
             "name": "test9",
@@ -449,7 +449,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test11997_6690_5338.obu",
             "output_format": "yuv422p",
-            "result": "8204d4bf2db09cfabd3043a6c734984d"
+            "result": "9f1eee2f277acb6a73d6a0e3dcdb1a8f"
         },
         {
             "name": "test8082",
@@ -513,7 +513,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test178_3361_4308.obu",
             "output_format": "gbrp12le",
-            "result": "011813c6974f02529799daacbeb51d75"
+            "result": "9577a2fef33b6e30f404194215ed1765"
         },
         {
             "name": "test15639",
@@ -601,7 +601,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1846.obu",
             "output_format": "gbrp12le",
-            "result": "2f23dd6f75083a456f2b5302a152a750"
+            "result": "3b87e0dd58845c003103e9ff95add10b"
         },
         {
             "name": "test3266",
@@ -649,7 +649,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9288_15593_11317.obu",
             "output_format": "yuv422p",
-            "result": "6a62db6af8a9d8156319935158f9865f"
+            "result": "960767e3f3a93df84cd08ad0eb21fd2b"
         },
         {
             "name": "test996",
@@ -705,7 +705,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test3790_15453_1234.obu",
             "output_format": "yuv422p",
-            "result": "3fba2a016b3bf3fdf6b4f83055edcdf4"
+            "result": "ddd17cc6dc0c1b3c15e032d9d66f18f9"
         },
         {
             "name": "test13842_13489",
@@ -753,7 +753,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test7233_319_5836.obu",
             "output_format": "yuv420p12le",
-            "result": "6317733dffd4705bcd2428ec31677c1c"
+            "result": "95d69d70bc85d0e7b8dab3bc380cfc59"
         },
         {
             "name": "test15352",
@@ -809,7 +809,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test4695_12937.obu",
             "output_format": "yuv422p10le",
-            "result": "491fa0adacf61fb273c281ce0ab3ce34"
+            "result": "86079da44601158db067c4e2967541e6"
         },
         {
             "name": "test14588_1783",
@@ -825,7 +825,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test2158_15601_7549.obu",
             "output_format": "yuv422p10le",
-            "result": "a724d53125bc2075f77029b2451c7df2"
+            "result": "4ce99a1cd0d648dba093c44cb5b3e74a"
         },
         {
             "name": "test1431_10699_15341",
@@ -849,7 +849,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1139.obu",
             "output_format": "gray12le",
-            "result": "e2704d4b25021eab449fddff657fb00a"
+            "result": "9b0f7c059da6b64e80cb7ef8ccbf8e68"
         },
         {
             "name": "test15493_15265",
@@ -953,7 +953,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test2319_15483.obu",
             "output_format": "gray12le",
-            "result": "a401aa651184f56ea3edad56d1be4332"
+            "result": "fdab2b8353db6e7736b3dbf2381c23f8"
         },
         {
             "name": "test12420",
@@ -969,7 +969,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test10125_14610_2396.obu",
             "output_format": "yuv420p12le",
-            "result": "552ad095143dcf4e2937b4a772708b7e"
+            "result": "8978cf1de30940854f9e6850486309c7"
         },
         {
             "name": "test15273_13430",
@@ -993,7 +993,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15260_13581.obu",
             "output_format": "gray12le",
-            "result": "e8bb28727dea4da1e75ef0bb1c937813"
+            "result": "6c84f49d12ebbc5051da3906540a681c"
         },
         {
             "name": "test4860_8277_3794",
@@ -1001,7 +1001,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test4860_8277_3794.obu",
             "output_format": "gray",
-            "result": "2a149a8016d0e54cb03b733f103d1acf"
+            "result": "3e56b216808e415abf1b44c97b5f550b"
         },
         {
             "name": "test13913",
@@ -1057,7 +1057,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1377_3641_9479.obu",
             "output_format": "yuv422p10le",
-            "result": "d6e8a6d1de3b5749b3d18bb4e88cb093"
+            "result": "67d3c10140f8266cd556e180fc7b9d86"
         },
         {
             "name": "test15750",
@@ -1105,7 +1105,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test13393_15303_3666.obu",
             "output_format": "gray12le",
-            "result": "bd9fe2dc9fadaca6380742d44188fa0d"
+            "result": "b6741708b2531caf0eae3f0cebe04941"
         },
         {
             "name": "test1618",
@@ -1153,7 +1153,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test13964_9357_3973.obu",
             "output_format": "yuv422p10le",
-            "result": "98835ab90401fb63312354309da6bba8"
+            "result": "020b0fd641e95fe7c6630f807a716137"
         },
         {
             "name": "test8217",
@@ -1201,7 +1201,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test867_8111.obu",
             "output_format": "gbrp12le",
-            "result": "d203495b4694782aa18cd4b3a330da11"
+            "result": "aaf990dc7fceb6484f0d627f7ca21c8f"
         },
         {
             "name": "test312",
@@ -1241,7 +1241,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9148_15478_738.obu",
             "output_format": "gbrp12le",
-            "result": "879c1b0218f15b4efd6a61856b99cc1a"
+            "result": "091dd3d470239e4ddafd3377f856270f"
         },
         {
             "name": "test1506",
@@ -1265,7 +1265,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test177.obu",
             "output_format": "gbrp12le",
-            "result": "93e9b0a29470be0c5b6a8a0e598b354a"
+            "result": "7840d12670d633c7d27e7b1ba530e8ab"
         },
         {
             "name": "test3612",
@@ -1305,7 +1305,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15697.obu",
             "output_format": "gray10le",
-            "result": "2594fecb6595c6da28e85bbe7196ae98"
+            "result": "17d61f6271b2067461f515063566d798"
         },
         {
             "name": "test4823_15592_2802",
@@ -1313,7 +1313,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test4823_15592_2802.obu",
             "output_format": "yuv444p12le",
-            "result": "a3b46fc77460108402b411f4197faf7b"
+            "result": "10c55b6004e07583707c99f880b002f4"
         },
         {
             "name": "test4885",
@@ -1329,7 +1329,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test7528.obu",
             "output_format": "gray12le",
-            "result": "698d6c5db4cba017d76c8cd5e6bdcca2"
+            "result": "19126c1fb9165c67a370e02f0c477dd8"
         },
         {
             "name": "test4164",
@@ -1417,7 +1417,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test3808_7208_14504.obu",
             "output_format": "gray12le",
-            "result": "9b03aa56b4e3cd5fd2c81a99e0f52f97"
+            "result": "05f3fd514379069c153d376d4e2cc098"
         },
         {
             "name": "test624_4691",
@@ -1425,7 +1425,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test624_4691.obu",
             "output_format": "yuv422p12le",
-            "result": "ee87943def942a4eda242ede8c51b2c9"
+            "result": "371c2e07945416694cb6ac8eebbfb70f"
         },
         {
             "name": "test14652_5866",
@@ -1441,7 +1441,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test12985_13711_8481.obu",
             "output_format": "gray12le",
-            "result": "5ca1fccce1f65e114c6f5eea96808c7e"
+            "result": "f0a541815d8c9deb92973a47a353c55d"
         },
         {
             "name": "test3830",
@@ -1457,7 +1457,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9539.obu",
             "output_format": "gray10le",
-            "result": "4e325702258b8bdc2ed4fdb1aa9a7878"
+            "result": "fc4548eb2c21314f8fdd6c67d556e3a1"
         },
         {
             "name": "test12450_11539_15284",
@@ -1465,7 +1465,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test12450_11539_15284.obu",
             "output_format": "yuv422p",
-            "result": "16089696190fba8b21f2663257d07b8e"
+            "result": "79b209a44ae2b72a3cb86715d4d3170a"
         },
         {
             "name": "test7129",
@@ -1489,7 +1489,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1931_15237_7192.obu",
             "output_format": "yuv444p12le",
-            "result": "0ae2d96c56d10e5cbd7e33f44d38d29f"
+            "result": "f19621874259454dfca2b1a5dff9fb9e"
         },
         {
             "name": "test8407",
@@ -1705,7 +1705,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1344_12973_13990.obu",
             "output_format": "gray12le",
-            "result": "f72e8857f0fa270e3a6fbd76204aab0c"
+            "result": "2221a2f1aca2f3df2995f1114d454ae2"
         },
         {
             "name": "test14338",
@@ -1721,7 +1721,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test20018.obu",
             "output_format": "gray12le",
-            "result": "91ab08fd980fb795c2c732b175e7f05d"
+            "result": "1c0d447e8a190c7514ba67153025463f"
         },
         {
             "name": "test8863",
@@ -1729,7 +1729,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test8863.obu",
             "output_format": "yuv444p12le",
-            "result": "e6a527d906821c61aea57585e096420e"
+            "result": "ed32fb9219cdb77916897cfdb9748b77"
         },
         {
             "name": "test71",
@@ -1769,7 +1769,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test8630_5887_11130.obu",
             "output_format": "gray12le",
-            "result": "e96676eaf0ec75197d908b1ee788616f"
+            "result": "ccb7f03cf23e15378d9873bbbcb5be60"
         },
         {
             "name": "test5716",
@@ -1777,7 +1777,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test5716.obu",
             "output_format": "gbrp12le",
-            "result": "052c0c8ea1c66f08afeb4a2f7f49a791"
+            "result": "7538e584d44bbc3d89cceb357228c6e1"
         },
         {
             "name": "test2856",
@@ -1793,7 +1793,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test10443_15654_4261.obu",
             "output_format": "yuv444p12le",
-            "result": "12591ad310538edf053451a09e641381"
+            "result": "bf54afd1bb72ffc9efafecdc935bf994"
         },
         {
             "name": "test6373",
@@ -1801,7 +1801,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test6373.obu",
             "output_format": "yuv444p12le",
-            "result": "785648145afdd22ad3f3d46103132f9a"
+            "result": "38c01873bb19141cacef55f04633ecee"
         },
         {
             "name": "test12838",
@@ -1825,7 +1825,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test632_15361.obu",
             "output_format": "gray12le",
-            "result": "6baa2c32c48cfc4f1e8eeb0b6689f014"
+            "result": "725c25c453641ade163ecbfcfabb8595"
         },
         {
             "name": "test1157",
@@ -1841,7 +1841,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test8532.obu",
             "output_format": "yuv422p",
-            "result": "cda546e26839bd16dad64ac65e6b8775"
+            "result": "e07dc27bbf89666e3fd1d761572aeb4b"
         },
         {
             "name": "test185",
@@ -1913,7 +1913,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15615_8094_6940.obu",
             "output_format": "yuv422p10le",
-            "result": "c9506763e0eb2ed7fe7d38200de98e08"
+            "result": "93b1d7215f40ac3c4a5ad1b1cfd0cff6"
         },
         {
             "name": "test1772_7179",
@@ -2001,7 +2001,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test2738.obu",
             "output_format": "yuv422p12le",
-            "result": "871323f97f4fa139afc0863ec37e485c"
+            "result": "34e6996839d985df6e0dec817eaf36b7"
         },
         {
             "name": "test8648",
@@ -2065,7 +2065,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1453_11901.obu",
             "output_format": "gray12le",
-            "result": "8b60cc01032d0c457ccc70d93e00763a"
+            "result": "fa057153ba4f29e993a48c5c284dee45"
         },
         {
             "name": "test824",
@@ -2161,7 +2161,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test2398_8555_11569.obu",
             "output_format": "yuv444p12le",
-            "result": "2fb774dc3e170cad37562da28d2f9b85"
+            "result": "f934d7ff2964edfa764c2908140747d6"
         },
         {
             "name": "test10341",
@@ -2273,7 +2273,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1534_13851.obu",
             "output_format": "gray12le",
-            "result": "fc9041901f8cc32e7323b022862af124"
+            "result": "aa59d566d2470b4427d369935ce81439"
         },
         {
             "name": "test10646",
@@ -2337,7 +2337,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15550_15500_4018.obu",
             "output_format": "gbrp12le",
-            "result": "c2625d3f7ef239464b3e7ebe1509ee11"
+            "result": "9e4e3d12ea9d92a88e67347873da4052"
         },
         {
             "name": "test16199",
@@ -2409,7 +2409,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test20031.obu",
             "output_format": "gray12le",
-            "result": "a27d52a5f56027d6121bab9463277348"
+            "result": "1835eeb8b80e1394a63729f9dc0e8412"
         },
         {
             "name": "test10041",
@@ -2425,7 +2425,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9092_12795_10250.obu",
             "output_format": "yuv422p12le",
-            "result": "aa582b260dc150f394aad5df65e6f613"
+            "result": "474c45f5c9030d71d766c0f7bc0f083a"
         },
         {
             "name": "test15357",
@@ -2449,7 +2449,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test7609_14866.obu",
             "output_format": "gray12le",
-            "result": "ca1e0485407086338ffdb5a857db7931"
+            "result": "b51f4f800b03d42f432bc16f5708d1dc"
         },
         {
             "name": "test10975",
@@ -2465,7 +2465,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test10160_14286_6588.obu",
             "output_format": "yuv422p12le",
-            "result": "c93e2a3595695f6b8edecb9901d15196"
+            "result": "43668e151ddc4dc675a20cb65230c0ff"
         },
         {
             "name": "test12371",
@@ -2473,7 +2473,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test12371.obu",
             "output_format": "yuv422p10le",
-            "result": "506a698739e763713dfcb6249564925a"
+            "result": "55e52b40dc01df3dec225086ddccd6a4"
         },
         {
             "name": "test16049_16187_16181",
@@ -2489,7 +2489,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test2490_4226_8984.obu",
             "output_format": "yuv422p12le",
-            "result": "b7d6feaa390f655f7f072f37b0ab4d58"
+            "result": "060d3e979289ceddcb309524177d5d0c"
         },
         {
             "name": "test5947",
@@ -2513,7 +2513,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9503_1572.obu",
             "output_format": "gbrp12le",
-            "result": "441f64fdbd96657db2225135501d2faa"
+            "result": "f4b60f34e1f0a3c17735f6ddaf12b880"
         },
         {
             "name": "test1530",
@@ -2545,7 +2545,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test3951_9615_9024.obu",
             "output_format": "gray12le",
-            "result": "59ed557da13f25d5f73ba5b03a7cc36b"
+            "result": "f2752adee7ef3149ff49417fd9f95216"
         },
         {
             "name": "test5673",
@@ -2561,7 +2561,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test16137_16088_16209.obu",
             "output_format": "gray12le",
-            "result": "104276cf5c5f8345a6281abd1012924b"
+            "result": "425c7da81ebe65ad0c4fd9ca7c2132c7"
         },
         {
             "name": "test15617_13610_316",
@@ -2593,7 +2593,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test2834.obu",
             "output_format": "yuv422p12le",
-            "result": "98f99e2360d14b1dce70989e4ffb183b"
+            "result": "2507215df9e750352abb9b074912224b"
         },
         {
             "name": "test15523_12198",
@@ -2657,7 +2657,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9454.obu",
             "output_format": "gray12le",
-            "result": "72ecb57a70c3ae4907c21103605996b6"
+            "result": "11b0e5779caeaa1de0230bd48d1ed289"
         },
         {
             "name": "test10403",
@@ -2665,7 +2665,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test10403.obu",
             "output_format": "gray10le",
-            "result": "62612a1ea9f57c01f328f4d41d35d88f"
+            "result": "9eea781da48648f8ed8f4a44875552b8"
         },
         {
             "name": "test15436",
@@ -2705,7 +2705,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test14330_8389_14362.obu",
             "output_format": "yuv422p",
-            "result": "e3586bd1aa7d49dd99dc88c9c3da3af4"
+            "result": "674245558ceb6385c81911aa98764a3b"
         },
         {
             "name": "test15815",
@@ -2769,7 +2769,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test13008_12410_7659.obu",
             "output_format": "yuv422p10le",
-            "result": "a4bbccdeb52d5628e76d55e98e78b05a"
+            "result": "13cb28833b5e6878000c4e5d1d42fa79"
         },
         {
             "name": "test15053_3606_6900",
@@ -2785,7 +2785,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test11667_10692_12033.obu",
             "output_format": "yuv420p12le",
-            "result": "5e0ee0bfa1a183e425b453c22b6d65b9"
+            "result": "5fdfacd1a58ab32942e0d135e4d68626"
         },
         {
             "name": "test15703",
@@ -2913,7 +2913,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test8518_9441_6353.obu",
             "output_format": "gbrp12le",
-            "result": "9f92a29973c611e0018f0804cdb8928f"
+            "result": "a4138ccd30f37952eb8eafbff4bcd72d"
         },
         {
             "name": "test15402",
@@ -2929,7 +2929,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15637.obu",
             "output_format": "gbrp12le",
-            "result": "682cfb8eaa8ed1334350c14d711c39fc"
+            "result": "294c9ce57ae926b650a993a2d9b96e1a"
         },
         {
             "name": "test3734",
@@ -2977,7 +2977,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9317_4725.obu",
             "output_format": "gray12le",
-            "result": "3fb87744c6ac0c8a5664fb954650a825"
+            "result": "4c3a33a2a8af7f76c103f4926f2a46b2"
         },
         {
             "name": "test7482_7751_9886",
@@ -3033,7 +3033,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test13577_5079.obu",
             "output_format": "yuv422p12le",
-            "result": "f3905cede3eeb5368fd37c58404d3e28"
+            "result": "efdda0127abdb8eb9465f65bee1b668a"
         },
         {
             "name": "test15672_9772_4833",
@@ -3153,7 +3153,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9873.obu",
             "output_format": "yuv420p12le",
-            "result": "42ee1461e721913bb1ac121b101a8338"
+            "result": "af87771d134db4251cd1b26fd99964bf"
         },
         {
             "name": "test12355_15292",
@@ -3169,7 +3169,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test11485_1299.obu",
             "output_format": "gbrp12le",
-            "result": "3fa05f795f8a6ec3dbd913bd96fa67b7"
+            "result": "e084e7008a8ab169065e47d3946cf004"
         },
         {
             "name": "test6075",
@@ -3225,7 +3225,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test6934_3244_12762.obu",
             "output_format": "yuv422p10le",
-            "result": "bbf241fce2da0f96ca7972aaece9a200"
+            "result": "588e73080c952403ef8f313e20668023"
         },
         {
             "name": "test2704_15452_3714",
@@ -3265,7 +3265,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test5349_4555.obu",
             "output_format": "yuv422p12le",
-            "result": "def9bbb8192f68671e9e40851201900b"
+            "result": "bd3d836f05d90d7702867b619268c067"
         },
         {
             "name": "test3054_10093",
@@ -3289,7 +3289,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test16104_16064.obu",
             "output_format": "gray10le",
-            "result": "500adad380c1f8a241010b6cff7629d1"
+            "result": "be4d48a414d14aec0d1fbf22b36d7d97"
         },
         {
             "name": "test14320_3628",
@@ -3297,7 +3297,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test14320_3628.obu",
             "output_format": "gbrp12le",
-            "result": "269f626a3ba7c71af0434248a59bd809"
+            "result": "ff3cbc5b9c942c0bea40067fb5fc2dbe"
         },
         {
             "name": "test14341_15473",
@@ -3321,7 +3321,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9978_11155.obu",
             "output_format": "gbrp12le",
-            "result": "eae51aae3309a1dcb429ca36a1b9e3b5"
+            "result": "73eccb1b0162f931ccc2b55017e9ff58"
         },
         {
             "name": "test15584_11581_7200",
@@ -3369,7 +3369,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1237.obu",
             "output_format": "yuv422p",
-            "result": "d25fba4705e9cfa5c29b3b8f8aee85ee"
+            "result": "68e819cc3a7955d5e40f7af61275f742"
         },
         {
             "name": "test8046_3510",
@@ -3433,7 +3433,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15669.obu",
             "output_format": "gbrp12le",
-            "result": "72b9f4d2eed6f408eff4583a9e476d78"
+            "result": "83802b2f639b938a8bf765b71e130397"
         },
         {
             "name": "test11106",
@@ -3537,7 +3537,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test8068_15793_7434.obu",
             "output_format": "gbrp12le",
-            "result": "8169ae8f33a4c3da5def360f602a94fc"
+            "result": "c3e41551437dba42025bafe372c852d5"
         },
         {
             "name": "test16164",
@@ -3657,7 +3657,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test7771.obu",
             "output_format": "gray12le",
-            "result": "a2538c66bbdc5e8a832b45134de75fe3"
+            "result": "8aa2997daed6adf03f55f903eb697c4f"
         },
         {
             "name": "test12556_7212_11122",
@@ -3761,7 +3761,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test12690_3412.obu",
             "output_format": "gray12le",
-            "result": "35575ad25a7cc90cd13916facda61df8"
+            "result": "866691a213d6d2585456ac4252329568"
         },
         {
             "name": "test6896",
@@ -3825,7 +3825,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test6252_1524_4311.obu",
             "output_format": "gray12le",
-            "result": "fc3106f40ce754bfdf15a3ab00dfc669"
+            "result": "a0cfe537dc0b726696b5fb67caf70dc4"
         },
         {
             "name": "test10256_3651",
@@ -3833,7 +3833,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test10256_3651.obu",
             "output_format": "gray10le",
-            "result": "caf96b5d53e6e0391bd5d5bd4d8a7fc7"
+            "result": "29083989b669b3e77cb7699b3d60889f"
         },
         {
             "name": "test16101_16158_16169",
@@ -3873,7 +3873,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test10574.obu",
             "output_format": "yuv444p12le",
-            "result": "d4daaa5ef29d5ed031f340766f3c8c54"
+            "result": "dfa37562395fded4468914f90f76ec40"
         },
         {
             "name": "test1261",
@@ -3913,7 +3913,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15268_10813_8444.obu",
             "output_format": "gbrp12le",
-            "result": "919673c0455096b24746d36dc3b49e8f"
+            "result": "94b2988343e7dbc8b2fd2d9d7a604da2"
         },
         {
             "name": "test5054",
@@ -3985,7 +3985,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test4728_2018.obu",
             "output_format": "gray12le",
-            "result": "c740938c12053f7a8b04a42e2c5fc8c5"
+            "result": "f8121baa405acc2613a49c122642ff1f"
         },
         {
             "name": "test7163",
@@ -4145,7 +4145,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test16218_16182.obu",
             "output_format": "gray12le",
-            "result": "201a117100d5108109e684c6f39c2ddd"
+            "result": "70adfe12aa4eaae788089802911769fa"
         },
         {
             "name": "test8697_7299",
@@ -4177,7 +4177,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1422_14989_8694.obu",
             "output_format": "gray12le",
-            "result": "af337b32da978fb6ada3fe189e75a968"
+            "result": "2418ace0d43eb3fab90063540cd8f46f"
         },
         {
             "name": "test1250",
@@ -4273,7 +4273,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test3519.obu",
             "output_format": "gray12le",
-            "result": "d7c2ef7222b4f38906ea0ff048212537"
+            "result": "82e14b3d0753cae1e9a21715f24bd7ca"
         },
         {
             "name": "test10933_6408",
@@ -4289,7 +4289,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15586_10393.obu",
             "output_format": "gbrp12le",
-            "result": "1a0b83b2d21b15289b07ad3124f175a1"
+            "result": "057b71b13d948e3aad7b9f5f4fc2ebcb"
         },
         {
             "name": "test9368",
@@ -4305,7 +4305,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test5617_562_11322.obu",
             "output_format": "yuv420p12le",
-            "result": "c841d2ca94c54ee0ccfcdcd2069ca8ac"
+            "result": "db7d2347d43c3942a0e38670c0bcb322"
         },
         {
             "name": "test15540_14986_12106",
@@ -4313,7 +4313,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15540_14986_12106.obu",
             "output_format": "yuv422p",
-            "result": "00c1b671353e6a0715669216df5285b7"
+            "result": "4b72b48d3e5f89ef2c9be81cb2f879df"
         },
         {
             "name": "test7622",
@@ -4353,7 +4353,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test5344_2514.obu",
             "output_format": "gbrp12le",
-            "result": "637cbb1bf3ad7e1d6597110d26776768"
+            "result": "fb5355aa22df0747d3be91876aef02b6"
         },
         {
             "name": "test11527",
@@ -4377,7 +4377,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test13591_2009_15766.obu",
             "output_format": "yuv422p",
-            "result": "835ff8da0d90727d6f4d091ea03e42de"
+            "result": "352919ec9e9e3709b8b95c10cc97316b"
         },
         {
             "name": "test16224",
@@ -4393,7 +4393,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test14275_13705_9472.obu",
             "output_format": "gray12le",
-            "result": "4dfbf74b8489dd0b0915922bce6eefbb"
+            "result": "094d82e7375d5559401416330d4ea63c"
         },
         {
             "name": "test15636_1722_6348",
@@ -4401,7 +4401,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15636_1722_6348.obu",
             "output_format": "gray12le",
-            "result": "c7d018436aad5afe7e6e3995dc86e9dc"
+            "result": "6e098242e8405b138b08e7b400271eee"
         },
         {
             "name": "test14151_2829_5983",
@@ -4433,7 +4433,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15599_12921.obu",
             "output_format": "None",
-            "result": "0f7a032c38545b6100a1a51034b247ca"
+            "result": "8351892ed7507ddeeff3685f75a0f7f9"
         },
         {
             "name": "test13150_1938_15619",
@@ -4457,7 +4457,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test20030.obu",
             "output_format": "gray10le",
-            "result": "436161bd20023d60ec8908c4c7e1529b"
+            "result": "52c5630c1d8d569db2977d6bff51ba6c"
         },
         {
             "name": "test9200",
@@ -4553,7 +4553,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test12380.obu",
             "output_format": "gray12le",
-            "result": "5f45f0a327eea60038a6e77d65d62d4a"
+            "result": "19749f874a6ee6a208eb425f3b76a5fb"
         },
         {
             "name": "test9791",
@@ -4609,7 +4609,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test2956_8455_6579.obu",
             "output_format": "gbrp12le",
-            "result": "b39d59e142b0e21a5229b828b83cbbbc"
+            "result": "c6e90734655e751f60e3266920e49ac3"
         },
         {
             "name": "test15443_9605_13755",
@@ -4657,7 +4657,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1714_14948_6607.obu",
             "output_format": "gbrp12le",
-            "result": "4723521d7124fd97e8308a12f3033285"
+            "result": "a77a8e0dd356d73e80785689b9cc6a48"
         },
         {
             "name": "test6542_6258",
@@ -4681,7 +4681,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test12083_15567_15660.obu",
             "output_format": "yuv444p12le",
-            "result": "d35cea31bd44aeb28403f68a4b0aebcc"
+            "result": "9d14d339cfb0431732898b5b5953828f"
         },
         {
             "name": "test4207",
@@ -4705,7 +4705,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9078.obu",
             "output_format": "yuv422p",
-            "result": "8aca1179e33593b9b801248cde8125bd"
+            "result": "760a0a71d046da8f6f77e9c4f6d08f9b"
         },
         {
             "name": "test9297_6729",
@@ -4713,7 +4713,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9297_6729.obu",
             "output_format": "yuv444p12le",
-            "result": "bfe591898fc9cdb379937d70dd23ba21"
+            "result": "cabc6dd0fd43be182f03a1622ba90470"
         },
         {
             "name": "test9354",
@@ -4745,7 +4745,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test2189.obu",
             "output_format": "yuv422p",
-            "result": "300d8180363f7e13915067271ccf1492"
+            "result": "38baff83a2cae74ef09f005350881bed"
         },
         {
             "name": "test243",
@@ -4761,7 +4761,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15618_4443.obu",
             "output_format": "gbrp12le",
-            "result": "3056a6ed3d34c461ec531e47bcfad2a5"
+            "result": "f27c7c6d87ac1249092d849e13f531b0"
         },
         {
             "name": "test15836",
@@ -4809,7 +4809,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test20022.obu",
             "output_format": "gray",
-            "result": "fdb772f6a00f945f49067fd144e644b0"
+            "result": "ef2e5c0ad19a437fd193c82f560fe933"
         },
         {
             "name": "test95",
@@ -4833,7 +4833,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15314_2235.obu",
             "output_format": "gray12le",
-            "result": "51076f2185c1a264801d20bf5a6fb727"
+            "result": "d18c981e42aa17a2e39ffbdf214604d5"
         },
         {
             "name": "test12143",
@@ -4873,7 +4873,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test10028_4295.obu",
             "output_format": "yuv444p12le",
-            "result": "750461285f63a6fe6328efba8b4fba1c"
+            "result": "1598b3599bcabd6f42c74f5de56db834"
         },
         {
             "name": "test4212_8154_15495",
@@ -4881,7 +4881,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test4212_8154_15495.obu",
             "output_format": "gray12le",
-            "result": "5ebc184cd91b66514989cc1542c817c7"
+            "result": "0c083fd15a413252f6bf5b5cae1cd7d2"
         },
         {
             "name": "test8590",
@@ -4913,7 +4913,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test12614_1186_15392.obu",
             "output_format": "gray12le",
-            "result": "92ef61f2423bf18b3d977c622a3a6d14"
+            "result": "e0c565fcc0c48fa8b5035abc6d534f68"
         },
         {
             "name": "test1493",
@@ -4945,7 +4945,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test7352.obu",
             "output_format": "yuv420p12le",
-            "result": "85f845f4de1b5ef4dd9d5206fedac133"
+            "result": "56d51366f4905c4e0beb9e9353b21dc1"
         },
         {
             "name": "test12215_15291",
@@ -4961,7 +4961,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test634_5396_6076.obu",
             "output_format": "gray12le",
-            "result": "234a92fd40e31459306ba1f8933c439c"
+            "result": "4e3d0053738c8b7c6ec947846a139109"
         },
         {
             "name": "test12586",
@@ -5081,7 +5081,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test20027.obu",
             "output_format": "gray12le",
-            "result": "2664f3e3993368c583b87ef4e15c66ad"
+            "result": "6a2dc55dc95503f5f501069f3353d488"
         },
         {
             "name": "test16216",
@@ -5137,7 +5137,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test14950_1603_3332.obu",
             "output_format": "gray12le",
-            "result": "31bec701e5db6dd4b4bf0d2359a46151"
+            "result": "eeedb463e2a43946aec1e0f16399501d"
         },
         {
             "name": "test10870",
@@ -5225,7 +5225,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test13830_2606_9042.obu",
             "output_format": "gray12le",
-            "result": "e58acd3dc17ae3032bc1bca00923908e"
+            "result": "73c6858d9975227c2f9931304c43c5b6"
         },
         {
             "name": "test896",
@@ -5241,7 +5241,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test13263_10189_7905.obu",
             "output_format": "yuv444p12le",
-            "result": "10eda19d0734304d4a15f45525d10e2c"
+            "result": "930f4c1147000e38c62a57a9f7953c92"
         },
         {
             "name": "test14547_15256_3421",
@@ -5265,7 +5265,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test5677_6460.obu",
             "output_format": "gray",
-            "result": "5961e0191b25820eb39ea31339fd854c"
+            "result": "ea9d5040b978ba7200b6fb3ff2cae37a"
         },
         {
             "name": "test15063",
@@ -5313,7 +5313,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1006.obu",
             "output_format": "yuv422p",
-            "result": "32a0c1baacb71b084102856c25207510"
+            "result": "f2618676f58cc0273a0a8c4fca5d796f"
         },
         {
             "name": "test15772",
@@ -5441,7 +5441,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9403.obu",
             "output_format": "gray12le",
-            "result": "4a3257087c88f1f76bbfa79cefdd4635"
+            "result": "576df8088f3bd58fb9417b399c4244be"
         },
         {
             "name": "test13456",
@@ -5577,7 +5577,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1224.obu",
             "output_format": "yuv422p10le",
-            "result": "247770e89cf4c9aad710d6350c42a43e"
+            "result": "8d7552d3b65dbeac31a6ded030b65334"
         },
         {
             "name": "test13409",
@@ -5641,7 +5641,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15605_12946_3403.obu",
             "output_format": "gray12le",
-            "result": "f0ecab69db31ff2ba9d88e499a165010"
+            "result": "a0f36a78f0dfdd06384f1257deceb9ae"
         },
         {
             "name": "test14898",
@@ -5745,7 +5745,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test7900.obu",
             "output_format": "yuv420p12le",
-            "result": "ab32ebb9bf0ebd1d97d9a09a76901580"
+            "result": "34755ec4a375dfd9743a25981bea518a"
         },
         {
             "name": "test14097",
@@ -5761,7 +5761,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test8189.obu",
             "output_format": "gray12le",
-            "result": "9dbe033037890101c6075a7ba6d7db7e"
+            "result": "6edfa6456eb156cb3f241722f61ef6ea"
         },
         {
             "name": "test1857",
@@ -5801,7 +5801,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test232_2997.obu",
             "output_format": "gray12le",
-            "result": "3163872e917a5b5c13426871f1760a48"
+            "result": "2f30dcfc387609a3d8d61e40c22e3cf1"
         },
         {
             "name": "test15411_13499",
@@ -5809,7 +5809,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15411_13499.obu",
             "output_format": "yuv444p12le",
-            "result": "af7905babb5c4750dd019108a84a4b85"
+            "result": "0cf0cd8cffbf6ced747603d290805a8f"
         },
         {
             "name": "test401",
@@ -5825,7 +5825,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test12567_7432_4876.obu",
             "output_format": "gbrp12le",
-            "result": "2841875380033d5277767a1ef743b507"
+            "result": "0f5dc17ba240f148f579752cc921190d"
         },
         {
             "name": "test5652",
@@ -5905,7 +5905,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test2141_15552.obu",
             "output_format": "yuv420p12le",
-            "result": "68064454f9364dc6311dac12a79983fd"
+            "result": "ead7fd274ad10e8db133ca4b7fa242fa"
         },
         {
             "name": "test1289",
@@ -5921,7 +5921,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15379_133.obu",
             "output_format": "yuv420p12le",
-            "result": "c01a9b12260b3e4456f302cf3251a0de"
+            "result": "6c044e52657e12b769dd7e888ab9c611"
         },
         {
             "name": "test8482_9815",
@@ -5953,7 +5953,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test10346.obu",
             "output_format": "gray12le",
-            "result": "0665c69c777d76f2654644dae8951f3e"
+            "result": "d055baad6dcea1c8f11d6e0e6f426804"
         },
         {
             "name": "test9716_1647_5590",
@@ -5961,7 +5961,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9716_1647_5590.obu",
             "output_format": "gray12le",
-            "result": "207c48f686e9ddc0360eafa442c8b987"
+            "result": "2473d5ff752fe4f9e97f5eaaf2da76e3"
         },
         {
             "name": "test2033_9068",
@@ -5969,7 +5969,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test2033_9068.obu",
             "output_format": "gray12le",
-            "result": "8f16709a104b1118efc1132e712fbfdf"
+            "result": "c4d3cb028a4c3d53c8416ef34aa3cb60"
         },
         {
             "name": "test15226",
@@ -6009,7 +6009,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test20013.obu",
             "output_format": "yuv422p10le",
-            "result": "bd73ca5a9e5a09e33f0e6d263cbb4f19"
+            "result": "eab8fb0e6dfc01773db061e53b0e3811"
         },
         {
             "name": "test11942_494",
@@ -6065,7 +6065,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test85.obu",
             "output_format": "gray12le",
-            "result": "85007f6e8e31bf98d543a3d73e6ac555"
+            "result": "4192d90ce41c6e879a04674c37a2818c"
         },
         {
             "name": "test1896_305_15751",
@@ -6073,7 +6073,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1896_305_15751.obu",
             "output_format": "yuv444p12le",
-            "result": "8f1174a2f21bd145915fcf3bf5c7c072"
+            "result": "84dfe75eb6cb1b5d43f56369f021e571"
         },
         {
             "name": "test14511_455_13695",
@@ -6081,7 +6081,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test14511_455_13695.obu",
             "output_format": "yuv444p12le",
-            "result": "f3bff1fd21facaf8f9ac827c98809552"
+            "result": "d6a155a9bd745dba3967156f4ad77e9e"
         },
         {
             "name": "test3311",
@@ -6201,7 +6201,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test13560_4866_9738.obu",
             "output_format": "gray10le",
-            "result": "54e8028fc8eefd940c9bd39b76ef3aa8"
+            "result": "ef5d28a105567a77d0e3e24505180773"
         },
         {
             "name": "test14884",
@@ -6225,7 +6225,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15620_7076_9220.obu",
             "output_format": "gbrp12le",
-            "result": "d1b1385bfd944efa34f083347b1a2805"
+            "result": "faf4103fed1ef36e0ab4feff6dad9cb9"
         },
         {
             "name": "test8663_641_1710",
@@ -6233,7 +6233,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test8663_641_1710.obu",
             "output_format": "gray12le",
-            "result": "c6a096dbac427f04f930bb43d061c026"
+            "result": "80b7bdc74087ab098454228394d54657"
         },
         {
             "name": "test7811_15342",
@@ -6257,7 +6257,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test12901_5068.obu",
             "output_format": "gray12le",
-            "result": "2de43d013b3f6aeb627976af2fcab078"
+            "result": "c6cefe26e595228bdc1b09f89bd79e70"
         },
         {
             "name": "test12078_83",
@@ -6289,7 +6289,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test16140_16050_16083.obu",
             "output_format": "gray12le",
-            "result": "b4fedfd3c647cc72391d25d3941776cd"
+            "result": "0906639c68a835a2d63b36867e9bcbd0"
         },
         {
             "name": "test3131",
@@ -6337,7 +6337,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15944_15928.obu",
             "output_format": "gray12le",
-            "result": "071be22f611ccd0ae03dc3e68cf9586e"
+            "result": "4dd268fc1bee62733f99d146c94ce4f0"
         },
         {
             "name": "test11028",
@@ -6393,7 +6393,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test12101_12207_15674.obu",
             "output_format": "gray12le",
-            "result": "b2df20d320d521af539b76ce7eef9f15"
+            "result": "67229989fc99fbccc93c9c4c70077dd3"
         },
         {
             "name": "test9566",
@@ -6449,7 +6449,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15549_5522_4902.obu",
             "output_format": "gray12le",
-            "result": "99d56f3a41a59891a769c4020db0554c"
+            "result": "c1a636f53bc7f53fea084d588ee87bac"
         },
         {
             "name": "test15547",
@@ -6521,7 +6521,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test12432_11686_8021.obu",
             "output_format": "gray10le",
-            "result": "10aa86f0d51d87f87231f39fc31c8711"
+            "result": "2e8b40757d6066e4c1b6ddc7485968af"
         },
         {
             "name": "test20021",
@@ -6529,7 +6529,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test20021.obu",
             "output_format": "gray12le",
-            "result": "7b79a7afac4b1e8e28a97f46b54c1b34"
+            "result": "36b422975a619608ab7cb3b2ee145718"
         },
         {
             "name": "test8757",
@@ -6545,7 +6545,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test8733_3239_12680.obu",
             "output_format": "yuv420p12le",
-            "result": "aa872fa2601e999084cf679281fd6954"
+            "result": "652e9870d05c23807788ec8bf71d3dfc"
         },
         {
             "name": "test794",
@@ -6601,7 +6601,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9616.obu",
             "output_format": "gray12le",
-            "result": "59ed30c0937841a8a26370ee768c3f33"
+            "result": "b302300583493153cb11c2d400842575"
         },
         {
             "name": "test11436_4874",
@@ -6625,7 +6625,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1488_15241_14537.obu",
             "output_format": "yuv422p",
-            "result": "ee17ebe9c83b6978a1ff598ce88e6127"
+            "result": "fba001820c2c1bd65b5b34ba9fb68d35"
         },
         {
             "name": "test15530",
@@ -6809,7 +6809,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test13011_14467.obu",
             "output_format": "yuv444p12le",
-            "result": "742884c545fe9f0d5ff62fe8113a2116"
+            "result": "ef9d8f211ac8b808eb686d713b5cf8d5"
         },
         {
             "name": "test11370",
@@ -6825,7 +6825,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test3984_10619.obu",
             "output_format": "yuv420p12le",
-            "result": "133500d94b08bb96fd86451c9b694c9e"
+            "result": "379bf88d6c3748553f2afbe06fadf9de"
         },
         {
             "name": "test6702_9843_12184",
@@ -6833,7 +6833,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test6702_9843_12184.obu",
             "output_format": "yuv444p12le",
-            "result": "f73eddb9eb48f2929c4a7929237b9b4a"
+            "result": "1fb2d716a2aeb78816c50b326b789e6d"
         },
         {
             "name": "test1300_13013_1727",
@@ -6897,7 +6897,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test2926.obu",
             "output_format": "gray12le",
-            "result": "9416f373794c4d5954826df79ff8f9b1"
+            "result": "018793357dfd8029bd429d1f36ddf198"
         },
         {
             "name": "test6914",
@@ -6921,7 +6921,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test12332_448.obu",
             "output_format": "gbrp12le",
-            "result": "b18883c52949f46d14452071cd002f69"
+            "result": "e6fddc4ae5df3824883007e76a31753f"
         },
         {
             "name": "test6411",
@@ -6945,7 +6945,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test2934_15781.obu",
             "output_format": "yuv422p",
-            "result": "983dac0d258bd5b3d922984cfbe12999"
+            "result": "d95e0f949cac4a91395c3fdff67c0109"
         },
         {
             "name": "test11583",
@@ -6961,7 +6961,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test15597_7921.obu",
             "output_format": "yuv422p",
-            "result": "d9043cc46ae9e73417262f3e2ca6d8f1"
+            "result": "ef9e7f7c2f917b3619786cfaa86c93b8"
         },
         {
             "name": "test6013",
@@ -6985,7 +6985,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test940_15331_12296.obu",
             "output_format": "gray12le",
-            "result": "45039aaeb03980c3963e4e4d76cc9856"
+            "result": "cf44c3d82a5a9489d1fd4dc94084a70b"
         },
         {
             "name": "test12887",
@@ -7025,7 +7025,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test1672.obu",
             "output_format": "yuv422p",
-            "result": "d6be420f813e31fde2ec1c85055931a2"
+            "result": "204e65aac483a2481b6dc775e71cde3b"
         },
         {
             "name": "test11512_3763_12971",
@@ -7033,7 +7033,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test11512_3763_12971.obu",
             "output_format": "gbrp12le",
-            "result": "2a049584ce96b1333121943bab459c8a"
+            "result": "54905ac1de6e6d5f6ca0d4d2bb3197bf"
         },
         {
             "name": "test15760_15561_14559",
@@ -7065,7 +7065,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test14606_3966.obu",
             "output_format": "gray12le",
-            "result": "1ccb391463df522e6aa4bb8482f0ce23"
+            "result": "8bd02780dcc319afa000d8d9e080cd44"
         },
         {
             "name": "test13826",
@@ -7113,7 +7113,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test2859.obu",
             "output_format": "gray12le",
-            "result": "cae680f18475e9ef84cac1a4e7c8d144"
+            "result": "545364a46d5fbce77a6a28fdc0cf4d14"
         },
         {
             "name": "test20020",
@@ -7121,7 +7121,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test20020.obu",
             "output_format": "gbrp12le",
-            "result": "c6fc814384c33443c22c305ad765d250"
+            "result": "f21d55a7a807af1820add1960f566625"
         },
         {
             "name": "test1835",
@@ -7185,7 +7185,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test6524_1941.obu",
             "output_format": "yuv422p",
-            "result": "0a769bdd17a6910fb8b61a39968f1cae"
+            "result": "e6bf7c1642039ab23558765855f24128"
         },
         {
             "name": "test4436",
@@ -7201,7 +7201,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test13281_4413.obu",
             "output_format": "gbrp12le",
-            "result": "27599ffebe37000d129fe7f3df398153"
+            "result": "23bb3a55932092afa6e9cbb57869bbad"
         },
         {
             "name": "test836",
@@ -7305,7 +7305,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test10625_9039.obu",
             "output_format": "yuv420p12le",
-            "result": "d279200759bdf93e18d88b5d924a1257"
+            "result": "987d69234543e4d205d966822a446ec8"
         },
         {
             "name": "test9315",
@@ -7321,7 +7321,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test11588_10229_5787.obu",
             "output_format": "gray12le",
-            "result": "75f422e4e99248072c7204cee2977aaf"
+            "result": "b033d7ce06c2d2b2c62a840a75c22a4d"
         },
         {
             "name": "test14344_11111",
@@ -7401,7 +7401,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test4091_12014.obu",
             "output_format": "gbrp12le",
-            "result": "92f4e6cc5f788202d4b09dedd3982f2f"
+            "result": "ab08690f126b89bd7472f55573cf70f0"
         },
         {
             "name": "test15885",
@@ -7481,7 +7481,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_core/streams/test9787_2739_1738.obu",
             "output_format": "gbrp12le",
-            "result": "a98ca27f73cc1948cedb25ee57b5ffd7"
+            "result": "a86711790d0d43d5e70f1719f347c821"
         },
         {
             "name": "test6953",
@@ -7571,5 +7571,6 @@
             "output_format": "gbrp12le",
             "result": "bd467ff845d182f45b9bc4327bf67a93"
         }
-    ]
+    ],
+    "test_method": "md5"
 }

--- a/test_suites/av1/AV1-ARGON-PROFILE2-NON-ANNEX-B.json
+++ b/test_suites/av1/AV1-ARGON-PROFILE2-NON-ANNEX-B.json
@@ -33,7 +33,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test29.obu",
             "output_format": "yuv420p12le",
-            "result": "699ba17db22ae0e64af4bd8008200fcb"
+            "result": ""
         },
         {
             "name": "test14",
@@ -41,7 +41,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test14.obu",
             "output_format": "None",
-            "result": "6395dc0b40ba0acef4d0c315b47eeb76"
+            "result": ""
         },
         {
             "name": "test35",
@@ -49,7 +49,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test35.obu",
             "output_format": "Unknown",
-            "result": "b7087683859a67f843fbcfaa4995cdcb"
+            "result": ""
         },
         {
             "name": "test44",
@@ -57,7 +57,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test44.obu",
             "output_format": "gray12le",
-            "result": "c8cffc977280d396421e7fb5e71a6e96"
+            "result": ""
         },
         {
             "name": "test24",
@@ -65,7 +65,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test24.obu",
             "output_format": "Unknown",
-            "result": "bc3ae7cd7bb2dfe38cd5cca8c509631c"
+            "result": ""
         },
         {
             "name": "test54",
@@ -73,7 +73,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test54.obu",
             "output_format": "Unknown",
-            "result": "e33defff6c1595b2d285049804888146"
+            "result": ""
         },
         {
             "name": "test52",
@@ -89,7 +89,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test38.obu",
             "output_format": "Unknown",
-            "result": "65ef3de9d7dbb8ddec03dd2e06b47e22"
+            "result": ""
         },
         {
             "name": "test22",
@@ -161,7 +161,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test25.obu",
             "output_format": "Unknown",
-            "result": "6b1e6090e92e4a992a66fbd63182aea7"
+            "result": ""
         },
         {
             "name": "test55",
@@ -185,7 +185,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test17.obu",
             "output_format": "Unknown",
-            "result": "adbff1184ceedf9fb8fa9dcdfa2f0147"
+            "result": ""
         },
         {
             "name": "test26",
@@ -193,7 +193,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test26.obu",
             "output_format": "Unknown",
-            "result": "3a6120c481910d01f5a48c32e1504a12"
+            "result": ""
         },
         {
             "name": "test8",
@@ -201,7 +201,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test8.obu",
             "output_format": "yuv420p12le",
-            "result": "214ee5aa14307738829d0e5607f5f5ec"
+            "result": ""
         },
         {
             "name": "test42",
@@ -217,7 +217,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test13.obu",
             "output_format": "Unknown",
-            "result": "d0332c3f2db3b4ec168b095724d18ef6"
+            "result": ""
         },
         {
             "name": "test4",
@@ -241,7 +241,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test39.obu",
             "output_format": "Unknown",
-            "result": "410227e21465d084c8918f4d8241c055"
+            "result": ""
         },
         {
             "name": "test45",
@@ -281,7 +281,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test50.obu",
             "output_format": "Unknown",
-            "result": "345d3f3758f2ae8e8d3d2e416bf046ab"
+            "result": ""
         },
         {
             "name": "test31",
@@ -297,7 +297,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test47.obu",
             "output_format": "Unknown",
-            "result": "d05c9ecef80a81ff1877996146183a5a"
+            "result": ""
         },
         {
             "name": "test9",
@@ -321,7 +321,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test34.obu",
             "output_format": "gray12le",
-            "result": "33f66fb7043355b9e2e485da8d5335ac"
+            "result": ""
         },
         {
             "name": "test28",
@@ -345,7 +345,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test3.obu",
             "output_format": "Unknown",
-            "result": "6a0042b1c5834f591d2938282a449a4b"
+            "result": ""
         },
         {
             "name": "test36",
@@ -369,7 +369,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test37.obu",
             "output_format": "Unknown",
-            "result": "4736354f6125a533c9bb80ec2d8c1249"
+            "result": ""
         },
         {
             "name": "test41",
@@ -377,7 +377,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test41.obu",
             "output_format": "Unknown",
-            "result": "45e125df1947f6c233b813a271fe6f77"
+            "result": ""
         },
         {
             "name": "test49",
@@ -393,7 +393,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test5.obu",
             "output_format": "yuv444p12le",
-            "result": "01eff40f2d46a73b30d82be9ebd559d1"
+            "result": ""
         },
         {
             "name": "test10",
@@ -417,7 +417,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test1.obu",
             "output_format": "Unknown",
-            "result": "54420d097145d69f3211b7e722c481ca"
+            "result": ""
         },
         {
             "name": "test2",
@@ -513,7 +513,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test223.obu",
             "output_format": "Unknown",
-            "result": "a6c822ed65e68d6dfe7fad34b7462059"
+            "result": ""
         },
         {
             "name": "test261",
@@ -521,7 +521,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test261.obu",
             "output_format": "Unknown",
-            "result": "05c80bda847f57bab126a6ab669324bf"
+            "result": ""
         },
         {
             "name": "test326",
@@ -529,7 +529,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test326.obu",
             "output_format": "yuv420p12le",
-            "result": "9d39990b6ae128d88b1fe16ecf39ad41"
+            "result": ""
         },
         {
             "name": "test276",
@@ -537,7 +537,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test276.obu",
             "output_format": "Unknown",
-            "result": "6e30949a80fc7cbc0193aa6bd8658f16"
+            "result": ""
         },
         {
             "name": "test184",
@@ -545,7 +545,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test184.obu",
             "output_format": "yuv422p10le",
-            "result": "61941bf4b7d44d487b761c68f15d5c21"
+            "result": ""
         },
         {
             "name": "test359",
@@ -553,7 +553,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test359.obu",
             "output_format": "yuv422p10le",
-            "result": "48eabc0bf11bc33722d7b3d872630079"
+            "result": ""
         },
         {
             "name": "test334",
@@ -561,7 +561,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test334.obu",
             "output_format": "gbrp12le",
-            "result": "f4d5a1d3b97ea4e0a46b1460f8d31f43"
+            "result": ""
         },
         {
             "name": "test186",
@@ -569,7 +569,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test186.obu",
             "output_format": "gray10le",
-            "result": "aacbe3acc6fa0cfd0cde8d15b749871b"
+            "result": ""
         },
         {
             "name": "test145",
@@ -577,7 +577,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test145.obu",
             "output_format": "yuv422p",
-            "result": "ae7d89605f18a16fa69f52d6d36f076d"
+            "result": ""
         },
         {
             "name": "test312",
@@ -585,7 +585,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test312.obu",
             "output_format": "yuv422p10le",
-            "result": "c9f5cd7d172a83258c707f5dc4977182"
+            "result": ""
         },
         {
             "name": "test244",
@@ -593,7 +593,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test244.obu",
             "output_format": "Unknown",
-            "result": "7f1906feace7c32f0d2874146f5da68b"
+            "result": ""
         },
         {
             "name": "test317",
@@ -601,7 +601,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test317.obu",
             "output_format": "yuv422p",
-            "result": "4fce3c9daea4055af65338fd5a00bdde"
+            "result": ""
         },
         {
             "name": "test60",
@@ -609,7 +609,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test60.obu",
             "output_format": "Unknown",
-            "result": "7e1e28efe769a7490fd328a47c8e33b8"
+            "result": ""
         },
         {
             "name": "test126",
@@ -617,7 +617,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test126.obu",
             "output_format": "None",
-            "result": "359f76055e538e847279d4ce4fe15fc7"
+            "result": ""
         },
         {
             "name": "test216",
@@ -625,7 +625,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test216.obu",
             "output_format": "Unknown",
-            "result": "def28bc0738be96c29feab81369af88a"
+            "result": ""
         },
         {
             "name": "test336",
@@ -633,7 +633,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test336.obu",
             "output_format": "Unknown",
-            "result": "ab58034a3a8085d3a3706216d80864f4"
+            "result": ""
         },
         {
             "name": "test260",
@@ -641,7 +641,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test260.obu",
             "output_format": "Unknown",
-            "result": "23c4bd575d4ad97fbe1131761e9e982f"
+            "result": ""
         },
         {
             "name": "test68",
@@ -649,7 +649,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test68.obu",
             "output_format": "Unknown",
-            "result": "2e2bd2aa1994b87d220da4e1259cf277"
+            "result": ""
         },
         {
             "name": "test136",
@@ -657,7 +657,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test136.obu",
             "output_format": "Unknown",
-            "result": "d2bb1058f703961849f2837642d55d45"
+            "result": ""
         },
         {
             "name": "test185",
@@ -665,7 +665,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test185.obu",
             "output_format": "Unknown",
-            "result": "8e1c9c1de155f134f2ef600dbbf654d2"
+            "result": ""
         },
         {
             "name": "test337",
@@ -673,7 +673,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test337.obu",
             "output_format": "gray12le",
-            "result": "22a7a840e7293d6a0da2b2b6e3a9ce88"
+            "result": ""
         },
         {
             "name": "test310",
@@ -681,7 +681,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test310.obu",
             "output_format": "yuv422p12le",
-            "result": "bcce7f308660a2bf11a1792b7ed5e5bb"
+            "result": ""
         },
         {
             "name": "test264",
@@ -689,7 +689,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test264.obu",
             "output_format": "Unknown",
-            "result": "2b55333f361fee686b33db24651822d7"
+            "result": ""
         },
         {
             "name": "test237",
@@ -697,7 +697,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test237.obu",
             "output_format": "Unknown",
-            "result": "34e77d7fd4961b4a9803478e0ba674c9"
+            "result": ""
         },
         {
             "name": "test62",
@@ -705,7 +705,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test62.obu",
             "output_format": "gray10le",
-            "result": "e257f666dfb3953ea53637a21979c611"
+            "result": ""
         },
         {
             "name": "test208",
@@ -713,7 +713,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test208.obu",
             "output_format": "Unknown",
-            "result": "f66c87091972a70be183a71628d6ff36"
+            "result": ""
         },
         {
             "name": "test57",
@@ -721,7 +721,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test57.obu",
             "output_format": "Unknown",
-            "result": "545f09e3b236b0e59f5ea538a07f8178"
+            "result": ""
         },
         {
             "name": "test304",
@@ -729,7 +729,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test304.obu",
             "output_format": "yuv444p12le",
-            "result": "6f8af181bc1e117067f25502cd4ae2b6"
+            "result": ""
         },
         {
             "name": "test316",
@@ -737,7 +737,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test316.obu",
             "output_format": "Unknown",
-            "result": "b0d774a0a01ab701a6af802fbae72639"
+            "result": ""
         },
         {
             "name": "test258",
@@ -745,7 +745,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test258.obu",
             "output_format": "Unknown",
-            "result": "e92af631fe78db1572a94c15d1f33399"
+            "result": ""
         },
         {
             "name": "test307",
@@ -753,7 +753,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test307.obu",
             "output_format": "gbrp12le",
-            "result": "a06d2bacfeba743a5ad7b36fa4b9b94b"
+            "result": ""
         },
         {
             "name": "test133",
@@ -761,7 +761,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test133.obu",
             "output_format": "yuv422p",
-            "result": "a3e447a893f4b9fcfaf6eb86905108db"
+            "result": ""
         },
         {
             "name": "test255",
@@ -769,7 +769,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test255.obu",
             "output_format": "yuv444p12le",
-            "result": "3451b4b2ead51e1431a21b1a425c0258"
+            "result": ""
         },
         {
             "name": "test350",
@@ -777,7 +777,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test350.obu",
             "output_format": "yuv444p12le",
-            "result": "5339cff0deb9821dd1868db841cf5855"
+            "result": ""
         },
         {
             "name": "test325",
@@ -785,7 +785,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test325.obu",
             "output_format": "yuv422p",
-            "result": "ddb315d6073f9a2ea6dc4e05b278adaa"
+            "result": ""
         },
         {
             "name": "test191",
@@ -793,7 +793,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test191.obu",
             "output_format": "yuv422p10le",
-            "result": "6503582c253e8f302dc3f86fe22f3601"
+            "result": ""
         },
         {
             "name": "test283",
@@ -801,7 +801,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test283.obu",
             "output_format": "Unknown",
-            "result": "963d53169cde8b37d5aa6f88b8b6572a"
+            "result": ""
         },
         {
             "name": "test327",
@@ -809,7 +809,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test327.obu",
             "output_format": "Unknown",
-            "result": "aef21af3152041e6c9850642ee399615"
+            "result": ""
         },
         {
             "name": "test205",
@@ -817,7 +817,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test205.obu",
             "output_format": "Unknown",
-            "result": "8079bfd8606e73af04d5b92a02fbae1f"
+            "result": ""
         },
         {
             "name": "test246",
@@ -825,7 +825,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test246.obu",
             "output_format": "Unknown",
-            "result": "f1af4ca49be33e2da6772abfd7ec6c63"
+            "result": ""
         },
         {
             "name": "test218",
@@ -833,7 +833,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test218.obu",
             "output_format": "gray12le",
-            "result": "353ec396d728b77cd1c6519f705ccf10"
+            "result": ""
         },
         {
             "name": "test159",
@@ -841,7 +841,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test159.obu",
             "output_format": "Unknown",
-            "result": "4e10b9ec589570f71dc972a4827c93dc"
+            "result": ""
         },
         {
             "name": "test118",
@@ -849,7 +849,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test118.obu",
             "output_format": "gray12le",
-            "result": "3ebdc2cd31ce004582f713ab714274cc"
+            "result": ""
         },
         {
             "name": "test91",
@@ -857,7 +857,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test91.obu",
             "output_format": "Unknown",
-            "result": "2cf672a7f35be0ac3d3543ea9ffd5195"
+            "result": ""
         },
         {
             "name": "test69",
@@ -865,7 +865,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test69.obu",
             "output_format": "Unknown",
-            "result": "c2087ac918b86cbead165553c662d832"
+            "result": ""
         },
         {
             "name": "test114",
@@ -873,7 +873,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test114.obu",
             "output_format": "Unknown",
-            "result": "d712cc6379d6935bc3c0a72edf6eecca"
+            "result": ""
         },
         {
             "name": "test124",
@@ -881,7 +881,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test124.obu",
             "output_format": "Unknown",
-            "result": "7fd4617925418aecde95f53fe6b3421b"
+            "result": ""
         },
         {
             "name": "test167",
@@ -889,7 +889,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test167.obu",
             "output_format": "Unknown",
-            "result": "cdb015fa349ae9e72d1aaadcb313ed75"
+            "result": ""
         },
         {
             "name": "test321",
@@ -897,7 +897,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test321.obu",
             "output_format": "gbrp12le",
-            "result": "75db75a7d55f370153572cc68fc28341"
+            "result": ""
         },
         {
             "name": "test358",
@@ -905,7 +905,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test358.obu",
             "output_format": "Unknown",
-            "result": "d8a8a680e82efac27227480d2e0d4b7f"
+            "result": ""
         },
         {
             "name": "test160",
@@ -913,7 +913,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test160.obu",
             "output_format": "Unknown",
-            "result": "7d4405ec1972d44c5bd56c71ce273ee1"
+            "result": ""
         },
         {
             "name": "test96",
@@ -921,7 +921,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test96.obu",
             "output_format": "Unknown",
-            "result": "61e4d1a0b923bf90bfd2346996d680cd"
+            "result": ""
         },
         {
             "name": "test338",
@@ -929,7 +929,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test338.obu",
             "output_format": "Unknown",
-            "result": "ae6fc02bf6dac0494b50c99644747a92"
+            "result": ""
         },
         {
             "name": "test243",
@@ -937,7 +937,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test243.obu",
             "output_format": "Unknown",
-            "result": "aae65dc4a73392df1fe8ecaf679d934d"
+            "result": ""
         },
         {
             "name": "test251",
@@ -945,7 +945,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test251.obu",
             "output_format": "Unknown",
-            "result": "edf99b69f03d9a1ea003ba4818c73e73"
+            "result": ""
         },
         {
             "name": "test344",
@@ -953,7 +953,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test344.obu",
             "output_format": "Unknown",
-            "result": "ae4bbad3778ee2e9c1f2a887e6c9c8d9"
+            "result": ""
         },
         {
             "name": "test61",
@@ -961,7 +961,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test61.obu",
             "output_format": "Unknown",
-            "result": "4aea9b6d81770ac990a50323a17f5a1e"
+            "result": ""
         },
         {
             "name": "test248",
@@ -969,7 +969,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test248.obu",
             "output_format": "Unknown",
-            "result": "5b4024b04fd8804de57bfca3ccf00159"
+            "result": ""
         },
         {
             "name": "test142",
@@ -977,7 +977,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test142.obu",
             "output_format": "yuv420p12le",
-            "result": "965e130858c7b5111416603e0b5e200d"
+            "result": ""
         },
         {
             "name": "test331",
@@ -985,7 +985,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test331.obu",
             "output_format": "Unknown",
-            "result": "cac75e57f3e610fc2c0181c4b917a496"
+            "result": ""
         },
         {
             "name": "test225",
@@ -993,7 +993,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test225.obu",
             "output_format": "gbrp12le",
-            "result": "091be454bb67cb4ce22511695eaa8ce5"
+            "result": ""
         },
         {
             "name": "test286",
@@ -1001,7 +1001,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test286.obu",
             "output_format": "gray12le",
-            "result": "dd062719afc74f26517769955dc523db"
+            "result": ""
         },
         {
             "name": "test330",
@@ -1009,7 +1009,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test330.obu",
             "output_format": "gbrp12le",
-            "result": "70c145cfd654f84c6a067f97d58d880c"
+            "result": ""
         },
         {
             "name": "test305",
@@ -1017,7 +1017,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test305.obu",
             "output_format": "yuv422p",
-            "result": "ff8ec6497b247b31489fbe40def16401"
+            "result": ""
         },
         {
             "name": "test239",
@@ -1025,7 +1025,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test239.obu",
             "output_format": "Unknown",
-            "result": "a7b88215f12d4b6a1cf5eea76f5098d1"
+            "result": ""
         },
         {
             "name": "test249",
@@ -1033,7 +1033,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test249.obu",
             "output_format": "Unknown",
-            "result": "595df32439f903098a0efcac7330d94e"
+            "result": ""
         },
         {
             "name": "test106",
@@ -1041,7 +1041,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test106.obu",
             "output_format": "Unknown",
-            "result": "c77885a9a697d2f96388fafa2fcbb32d"
+            "result": ""
         },
         {
             "name": "test328",
@@ -1049,7 +1049,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test328.obu",
             "output_format": "gbrp12le",
-            "result": "acca9104a4ef1f396f53151e6d50bf39"
+            "result": ""
         },
         {
             "name": "test319",
@@ -1057,7 +1057,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test319.obu",
             "output_format": "yuv422p12le",
-            "result": "4a3baf7004a8ea4af2b5557cb4ad186f"
+            "result": ""
         },
         {
             "name": "test315",
@@ -1065,7 +1065,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test315.obu",
             "output_format": "yuv420p12le",
-            "result": "fb3ef5ba444b71403feaa4db7614776e"
+            "result": ""
         },
         {
             "name": "test300",
@@ -1073,7 +1073,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test300.obu",
             "output_format": "Unknown",
-            "result": "9b2eb82ecca67068fdcffd0b800543ee"
+            "result": ""
         },
         {
             "name": "test101",
@@ -1081,7 +1081,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test101.obu",
             "output_format": "yuv444p12le",
-            "result": "6af5afcb26b9b0df2952a5cd60bc18de"
+            "result": ""
         },
         {
             "name": "test306",
@@ -1089,7 +1089,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test306.obu",
             "output_format": "yuv422p10le",
-            "result": "dcdcdbe1008630d0d99849b07db15444"
+            "result": ""
         },
         {
             "name": "test206",
@@ -1097,7 +1097,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test206.obu",
             "output_format": "Unknown",
-            "result": "7664c4a628c5a2a9ccfff8175fafdf0b"
+            "result": ""
         },
         {
             "name": "test110",
@@ -1105,7 +1105,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test110.obu",
             "output_format": "gray12le",
-            "result": "23b19b7dd1427606bb629bc31d7f7eed"
+            "result": ""
         },
         {
             "name": "test209",
@@ -1113,7 +1113,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test209.obu",
             "output_format": "Unknown",
-            "result": "479edbb42d954055cb41c037cf5d7497"
+            "result": ""
         },
         {
             "name": "test285",
@@ -1121,7 +1121,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test285.obu",
             "output_format": "Unknown",
-            "result": "0b25f22f129997c4e316f5ef62f57d3c"
+            "result": ""
         },
         {
             "name": "test166",
@@ -1129,7 +1129,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test166.obu",
             "output_format": "Unknown",
-            "result": "685cb1357328129ab23eaf4ec6e0135b"
+            "result": ""
         },
         {
             "name": "test345",
@@ -1137,7 +1137,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test345.obu",
             "output_format": "gbrp12le",
-            "result": "02d417b613c25b72655066436336feb2"
+            "result": ""
         },
         {
             "name": "test230",
@@ -1145,7 +1145,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test230.obu",
             "output_format": "Unknown",
-            "result": "c35a602337461cf9d31c24ca1140e7aa"
+            "result": ""
         },
         {
             "name": "test303",
@@ -1153,7 +1153,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test303.obu",
             "output_format": "yuv422p10le",
-            "result": "c58b274d7795a8aabb4a5e2cc213a79c"
+            "result": ""
         },
         {
             "name": "test284",
@@ -1161,7 +1161,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test284.obu",
             "output_format": "Unknown",
-            "result": "ddebb30a88c5fa619d3c9b24818f803a"
+            "result": ""
         },
         {
             "name": "test295",
@@ -1169,7 +1169,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test295.obu",
             "output_format": "Unknown",
-            "result": "4c2f8bea3a472db1a01f9f6732f4d526"
+            "result": ""
         },
         {
             "name": "test163",
@@ -1177,7 +1177,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test163.obu",
             "output_format": "Unknown",
-            "result": "b99ede49006ec81b8eb6ca73db1d7f65"
+            "result": ""
         },
         {
             "name": "test324",
@@ -1185,7 +1185,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test324.obu",
             "output_format": "Unknown",
-            "result": "e138fece0c38c0aa03a12a9886fb150b"
+            "result": ""
         },
         {
             "name": "test234",
@@ -1193,7 +1193,7 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test234.obu",
             "output_format": "yuv444p12le",
-            "result": "89128828e18e61389070951c0e253809"
+            "result": ""
         },
         {
             "name": "test112",
@@ -1201,7 +1201,8 @@
             "source_checksum": "5dd3554c3f73c80f06c7fceeaa1f5dd9",
             "input_file": "argon_coveragetool_av1_base_and_extended_profiles_v2.1/profile2_error/streams/test112.obu",
             "output_format": "gbrp12le",
-            "result": "adb9670210067a9e9f28b28b0b72ea50"
+            "result": ""
         }
-    ]
+    ],
+    "test_method": "md5"
 }

--- a/test_suites/av1/AV1-ARGON-PROFILE2-STRESS-ANNEX-B.json
+++ b/test_suites/av1/AV1-ARGON-PROFILE2-STRESS-ANNEX-B.json
@@ -699,5 +699,6 @@
             "output_format": "gbrp12le",
             "result": "fc23c2acfc269e725e8f229ecc3ff72d"
         }
-    ]
+    ],
+    "test_method": "md5"
 }


### PR DESCRIPTION
- modify AV1 argon test suite generator to calculate expected md5 checksums using libaom AV1 reference decoder
- remove `multiple_layers` parameter from libaom AV1 decoder
- refactor for multiple OSs