### PR TITLE
feat: add support for V4l2 AV1 stateful video decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ AV1
     GStreamer-AV1-Vulkan-Gst1.0: GStreamer AV1 Vulkan decoder for GStreamer 1.0
     GStreamer-AV1-dav1d-Gst1.0: GStreamer AV1 dav1d decoder for GStreamer 1.0
     GStreamer-AV1-libaom-Gst1.0: GStreamer AV1 libaom decoder for GStreamer 1.0
+    GStreamer-AV1-V4L2-Gst1.0: GStreamer AV1 V4L2 decoder for GStreamer 1.0
     VKVS-AV1: Vulkan Video Samples AV1 decoder
     ccdec-AV1: AV1 cros-codecs decoder
     dav1d-AV1: dav1d AV1 decoder

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -370,6 +370,15 @@ class GStreamerV4l2H265Gst10Decoder(GStreamer10Video):
 
 
 @register_decoder
+class GStreamerV4l2AV1Gst10Decoder(GStreamer10Video):
+    """GStreamer AV1 V4L2 stateful decoder implementation for GStreamer 1.0"""
+
+    codec = Codec.AV1
+    decoder_bin = " v4l2av1dec "
+    api = "V4L2"
+
+
+@register_decoder
 class GStreamerVaapiH264Gst10Decoder(GStreamer10Video):
     """GStreamer H.264 VAAPI decoder implementation for GStreamer 1.0"""
 


### PR DESCRIPTION
Add support for v4l2av1dec gstreamer plugin used to run AV1 stateful decoder through V4l2 api.