### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "fluster-conformance"
 # TODO: Ensure that version 0.x.0 is marked as the final version in the CI release workflow only when we are certain
 # about deploying a new release. This prevents creating an irreversible history in PyPI, which would block re-uploading
 # the same version.
-version = "0.5.1"
+version = "0.6.0"
 authors = [
     {name = "Andoni Morales Alastruey", email="amorales@fluendo.com"},
     # {name = "Pablo Marcos Oltra"}, wait to (https://github.com/pypi/warehouse/issues/12877)


### PR DESCRIPTION
Due to commits marked as feat, the next version will increment to 0.6.0 instead of 0.5.1