### PR TITLE
ci: add markdown instruction files for co-pilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,38 @@
+# Generic Copilot Instructions
+
+These instructions are intended for GitHub Copilot and similar AI coding assistants. They provide general best practices and coding standards that can be applied to any Fluendo's software project.
+
+## Coding Standards
+- Follow the existing code style (brace placement, indentation, naming conventions, comments, documentation, etc.).
+- Use descriptive variable and function names, following ruff and mypy rules.
+- Add comments for non-obvious logic.
+- Prefer readability over micro-optimizations for non-critical code.
+- Write modular, reusable functions.
+- Avoid large functions; break them into smaller units.
+- Handle errors gracefully, checking return values of functions.
+- Add appropriate logging where needed.
+- Use Doxygen-style or project-standard comments for public APIs and entry points.
+- Refer to project or ecosystem coding standards and best practices if in doubt.
+
+## Compatibility
+- Ensure code is portable across supported platforms.
+- Use appropriate compiler flags and options to ensure compatibility.
+- Use APIs correctly, following their documentation and best practices.
+- Ensure new code adheres to project development guidelines.
+
+## Continuous Integration and Testing
+- CI should validate pull requests and main branch changes by running the full build and test suite.
+- Ensure all tests pass before submitting changes.
+- Update the build system and CI configuration if you add new components or tests.
+- Add new tests to the test directory and include them in the build.
+- Always validate changes with the full test suite and CI.
+
+## File Structure and Organization
+- Place new or modified code in the appropriate subdirectory.
+- Use or extend libraries for shared logic.
+- Use project documentation for additional details.
+- Only perform a search if the information in these instructions is incomplete or found to be in error.
+
+## Security and Confidentiality
+- Do not generate or suggest code for proprietary, confidential, or security-sensitive algorithms.
+- Review all generated code for vulnerabilities, especially in buffer handling, file I/O, and network operations.

--- a/.github/git-commit-instructions.md
+++ b/.github/git-commit-instructions.md
@@ -1,0 +1,42 @@
+# Generic Git Commit Instructions
+
+These guidelines are intended for any software project to ensure that all commits are clear, actionable, and maintainable. Follow these instructions for every commit and pull request.
+
+## Commit Message Structure
+- **Summary line:** Start with a short, descriptive summary (max 72 characters).
+- **Issue reference:** If applicable, include the issue or ticket number (e.g., `PROJECT-1234`).
+- **Detailed description:** Add a blank line, then provide context, rationale, and details about the change. Include:
+  - What was changed and why
+  - Any relevant error messages or bug descriptions
+  - Implementation notes or side effects
+
+## Best Practices
+- Group related changes in a single commit. Avoid mixing unrelated changes.
+- Reference affected files or components if not obvious from the context.
+- For bug fixes, describe the root cause and how it was resolved.
+- For new features, explain the motivation and usage.
+- For refactoring, explain the reason and expected impact.
+- For documentation, specify what was updated or clarified.
+- For CI/build changes, describe the effect on the workflow.
+- Prefer writing paragraphs instead of bullet points or enumeration.
+- Start the commit title with the main component or module affected, if applicable.
+
+## Examples
+```
+core: Fix memory leak in buffer handling
+A memory leak was found in the buffer allocation logic. This commit ensures all buffers are properly freed after use.
+
+Issue: PROJECT-1234
+
+---
+
+docs: Update API usage examples
+Expanded the documentation to include new usage examples for the latest API changes.
+```
+
+## Additional Guidelines
+- Use tags for releases and versioning as appropriate.
+- Keep commit messages in English.
+- Proofread messages for clarity and completeness.
+- If reverting, reference the original commit and explain why.
+- For WIP (work in progress), clearly mark the commit and avoid merging to main branches.


### PR DESCRIPTION
add instruction files for use by co-pilot to ensure best practices are followed