### PR TITLE
fix: force h266parse for vvdec

### DIFF
--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -721,6 +721,7 @@ class GStreamerVVdeCH266Decoder(GStreamer10Video):
     codec = Codec.H266
     decoder_bin = " vvdec "
     api = "VVdeC"
+    parser = " h266parse "
 
 
 @register_decoder


### PR DESCRIPTION
When `avdec_h266` and `vvdec` are installed with next priorities and sink caps (values at 1.26):

```
avdec_h266: Factory Details:
avdec_h266:   Rank                     primary (256)
avdec_h266:   Long-name                libav VVC (Versatile Video Coding) decoder
avdec_h266:   Klass                    Codec/Decoder/Video
avdec_h266:   Description              libav vvc decoder
avdec_h266:   Author                   Wim Taymans <wim.taymans@gmail.com>, Ronald Bultje <rbultje@ronald.bitfreak.net>, Edward Hervey <bilboed@bilboed.com>
avdec_h266:   Documentation            https://gstreamer.freedesktop.org/documentation/libav/avdec_h266.html
...
avdec_h266: Pad Templates:
avdec_h266:   SINK template: 'sink'
avdec_h266:     Availability: Always
avdec_h266:     Capabilities:
avdec_h266:       video/x-h266
avdec_h266:               alignment: au
avdec_h266:           stream-format: { (string)vvc1, (string)vvi1, (string)byte-stream }
...
...
...
vvdec: Factory Details:
vvdec:   Rank                     secondary (128)
vvdec:   Long-name                VVdeC VVC/H.266 Decoder
vvdec:   Klass                    Codec/Decoder/Video
vvdec:   Description              Decode VVC/H.266 video streams with VVdeC
vvdec:   Author                   Carlos Bentzen <cadubentzen@igalia.com>
vvdec:   Documentation            https://gstreamer.freedesktop.org/documentation/vvdec/#vvdec-page
...
vvdec: Pad Templates:
vvdec:   SINK template: 'sink'
vvdec:     Availability: Always
vvdec:     Capabilities:
vvdec:       video/x-h266
vvdec:           stream-format: byte-stream
vvdec:               alignment: au
```

Note: more the greater rank in avdec_h266 and different vvdec sink caps ara a subset of avdec_h266 sink caps.

Using parsebin doesn't work. The parsebin element was desinged to be used with playbin and uses all the GST_ELEMENT_FACTORY_TYPE_DECODABLE factories avaliable to define the caps to use (note gst_parse_bin_update_factories_list). Other generic solution would be to use GST_PLUGIN_FEATURE_RANK=%targetdecoder%:MAX to be sure parsebin uses the correct decoder, but it requires to extract the decoder element from the decoder_bin.

```
gst-launch-1.0 --no-fault filesrc location=JVET-VVC_draft6/DCI_A_Tencent_3/DCI_A_Tencent_3.bit ! parsebin ! vvdec ! video/x-raw ! fakesink
Setting pipeline to PAUSED ...
Pipeline is PREROLLING ...
Redistribute latency...
ERROR: from element /GstPipeline:pipeline0/GstParseBin:parsebin0/GstH266Parse:h266parse0: Internal data stream error.
Additional debug info:
../gstreamer/subprojects/gstreamer/libs/gst/base/gstbaseparse.c(3731): gst_base_parse_loop (): /GstPipeline:pipeline0/GstParseBin:parsebin0/GstH266Parse:h266parse0:
streaming stopped, reason not-linked (-1)
ERROR: pipeline doesn't want to preroll.
Setting pipeline to NULL ...
Freeing pipeline ...
```