### PR TITLE
Remove deprecated Fluendo HW VA decoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,8 +326,6 @@ H.264
     FFmpeg-H.264-Vulkan: FFmpeg H.264 Vulkan decoder
     FFmpeg-H.264-v4l2m2m: FFmpeg H.264 v4l2m2m decoder
     Fluendo-H.264-DXVA2-Gst1.0: Fluendo H.264 DXVA2 decoder for GStreamer 1.0
-    Fluendo-H.264-HW-Gst1.0: Fluendo H.264 HW decoder for GStreamer 1.0
-    Fluendo-H.264-HW-hwvah264dec-Gst1.0: Fluendo H.264 HW decoder for GStreamer 1.0
     Fluendo-H.264-HW-lcevchwvah264dec-Gst1.0: Fluendo H.264 HW decoder for GStreamer 1.0
     Fluendo-H.264-SW-Gst1.0: Fluendo H.264 SW decoder for GStreamer 1.0
     Fluendo-H.264-VAAPI-Gst1.0: Fluendo H.264 VAAPI decoder for GStreamer 1.0
@@ -381,7 +379,6 @@ H.265
     FFmpeg-H.265-Vulkan: FFmpeg H.265 Vulkan decoder
     FFmpeg-H.265-v4l2m2m: FFmpeg H.265 v4l2m2m decoder
     Fluendo-H.265-DXVA2-Gst1.0: Fluendo H.265 DXVA2 decoder for GStreamer 1.0
-    Fluendo-H.265-HW-hwvah265dec-Gst1.0: Fluendo H.265 HW decoder for GStreamer 1.0
     Fluendo-H.265-SW-Gst1.0: Fluendo H.265 SW decoder for GStreamer 1.0
     Fluendo-H.265-VAAPI-Gst1.0: Fluendo H.265 VAAPI decoder for GStreamer 1.0
     Fluendo-H.265-VDA-Gst1.0: Fluendo H.265 VDA decoder for GStreamer 1.0

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -810,38 +810,6 @@ class FluendoMPEG2VideoGst10Decoder(GStreamer10Video):
 
 
 @register_decoder
-class FluendoH264VAGst10Decoder(GStreamer10Video):
-    """Fluendo H.264 hardware decoder implementation for GStreamer 1.0"""
-
-    codec = Codec.H264
-    decoder_bin = " fluhwvadec "
-    provider = "Fluendo"
-    api = "HW"
-
-
-@register_decoder
-class FluendoFluVAH265DecGst10Decoder(GStreamer10Video):
-    """Fluendo H.265 separated plugin hardware decoder for GStreamer 1.0"""
-
-    codec = Codec.H265
-    decoder_bin = " fluhwvah265dec "
-    provider = "Fluendo"
-    api = "HW"
-    name = f"{provider}-{codec.value}-{api}-hwvah265dec-Gst1.0"
-
-
-@register_decoder
-class FluendoFluVAH264DecGst10Decoder(GStreamer10Video):
-    """Fluendo H.264 separated plugin hardware decoder for GStreamer 1.0"""
-
-    codec = Codec.H264
-    decoder_bin = " fluhwvah264dec "
-    provider = "Fluendo"
-    api = "HW"
-    name = f"{provider}-{codec.value}-{api}-hwvah264dec-Gst1.0"
-
-
-@register_decoder
 class FluendoFluAACDecGst10Decoder(GStreamer10Audio):
     """Fluendo AAC plugin decoder for GStreamer 1.0"""
 


### PR DESCRIPTION
Remove legacy Fluendo VA decoder classes used before the plugin split per backend. These decoders have not been needed for over a year since the split was completed.