### PR TITLE
feat: add TestVector optional decoder parameters

### DIFF
--- a/fluster/decoder.py
+++ b/fluster/decoder.py
@@ -18,7 +18,7 @@
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from shutil import which
-from typing import List, Optional, Type
+from typing import Any, Dict, List, Optional, Type
 
 from fluster.codec import Codec, OutputFormat
 from fluster.utils import normalize_binary_cmd
@@ -47,6 +47,7 @@ class Decoder(ABC):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         raise Exception("Not implemented")

--- a/fluster/decoders/ac4_decoder_reference.py
+++ b/fluster/decoders/ac4_decoder_reference.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
+from typing import Any, Dict, Optional
+
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
 from fluster.utils import file_checksum, run_command
@@ -38,6 +40,7 @@ class DolbyPADSDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         run_command(

--- a/fluster/decoders/av1_aom.py
+++ b/fluster/decoders/av1_aom.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -38,6 +39,7 @@ class AV1AOMDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         fmt = "--rawvideo"

--- a/fluster/decoders/av1_dav1d.py
+++ b/fluster/decoders/av1_dav1d.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -37,6 +38,7 @@ class AV1Dav1dDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         fmt = "yuv"

--- a/fluster/decoders/chromium.py
+++ b/fluster/decoders/chromium.py
@@ -16,6 +16,7 @@
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
 from functools import lru_cache
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -50,6 +51,7 @@ class ChromiumH264(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         return str(main(input_filepath))
 

--- a/fluster/decoders/cros_codecs.py
+++ b/fluster/decoders/cros_codecs.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -38,6 +39,7 @@ class CrosCodecsDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
 

--- a/fluster/decoders/dummy.py
+++ b/fluster/decoders/dummy.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -36,5 +37,6 @@ class Dummy(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         return file_checksum(input_filepath)

--- a/fluster/decoders/ffmpeg.py
+++ b/fluster/decoders/ffmpeg.py
@@ -19,7 +19,7 @@
 import re
 import subprocess
 from functools import lru_cache
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -70,6 +70,7 @@ class FFmpegDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         command = [self.binary, "-hide_banner", "-nostdin"]

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -22,7 +22,7 @@ import re
 import shlex
 import subprocess
 from functools import lru_cache
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -134,9 +134,11 @@ class GStreamer(Decoder):
         input_filepath: str,
         output_filepath: Optional[str],
         output_format: OutputFormat,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Generate the GStreamer pipeline used to decode the test vector"""
         output = f"location={output_filepath}" if output_filepath else ""
+
         return PIPELINE_TPL.format(
             self.cmd,
             input_filepath,
@@ -177,6 +179,7 @@ class GStreamer(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decode the test vector and do the checksum"""
         # When using videocodectestsink we can avoid writing files to disk
@@ -190,7 +193,7 @@ class GStreamer(Decoder):
             data = run_command_with_output(command, timeout=timeout, verbose=verbose).splitlines()
             return self.parse_videocodectestsink_md5sum(data)
 
-        pipeline = self.gen_pipeline(input_filepath, output_filepath, output_format)
+        pipeline = self.gen_pipeline(input_filepath, output_filepath, output_format, optional_params)
         run_command(shlex.split(pipeline), timeout=timeout, verbose=verbose)
         return file_checksum(output_filepath)
 
@@ -232,6 +235,7 @@ class GStreamerVideo(GStreamer):
         input_filepath: str,
         output_filepath: Optional[str],
         output_format: OutputFormat,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         raw_caps = "video/x-raw"
         try:
@@ -835,6 +839,7 @@ class FluendoVVCdeCH266Decoder(GStreamerVideo):
     decoder_bin = " fluh266dec "
     provider = "Fluendo"
     api = "SW"
+
     parser = "h266parse " if gst_element_exists("h266parse") else "fluh266parse"
 
 

--- a/fluster/decoders/h264_jct_vt.py
+++ b/fluster/decoders/h264_jct_vt.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -38,6 +39,7 @@ class H264JCTVTDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         run_command(

--- a/fluster/decoders/h265_jct_vt.py
+++ b/fluster/decoders/h265_jct_vt.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -38,6 +39,7 @@ class H265JCTVTDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         run_command(

--- a/fluster/decoders/h266_vvc_vtm.py
+++ b/fluster/decoders/h266_vvc_vtm.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -37,6 +38,7 @@ class H266VVCVTMDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         # pylint: disable=unused-argument

--- a/fluster/decoders/h266_vvdec.py
+++ b/fluster/decoders/h266_vvdec.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -37,6 +38,7 @@ class H266VVCDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         run_command(

--- a/fluster/decoders/iso_mpeg2_aac.py
+++ b/fluster/decoders/iso_mpeg2_aac.py
@@ -16,6 +16,7 @@
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 import glob
 import os
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -40,6 +41,7 @@ class ISOAACDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         # Addition of .pcm as extension is a must. If it is something else, e.g. ".out" the decoder will output a

--- a/fluster/decoders/iso_mpeg2_video.py
+++ b/fluster/decoders/iso_mpeg2_video.py
@@ -17,6 +17,7 @@
 import glob
 import os
 import tempfile
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -41,6 +42,7 @@ class ISOMPEG2VDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/fluster/decoders/iso_mpeg4_aac.py
+++ b/fluster/decoders/iso_mpeg4_aac.py
@@ -16,6 +16,7 @@
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
 import glob
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -40,6 +41,7 @@ class ISOAACDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         # Addition of .pcm as extension is a must. If it is something else, e.g. ".out" the decoder will output a

--- a/fluster/decoders/iso_mpeg4_aac_er.py
+++ b/fluster/decoders/iso_mpeg4_aac_er.py
@@ -16,6 +16,7 @@
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
 import glob
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -40,6 +41,7 @@ class ISOAACDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         output_filepath += ".raw"

--- a/fluster/decoders/iso_mpeg4_video.py
+++ b/fluster/decoders/iso_mpeg4_video.py
@@ -16,7 +16,7 @@
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 import os
 import subprocess
-from typing import Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -41,6 +41,7 @@ class ISOMPEG4VDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath to output_filepath"""
         width, height = self._get_video_resolution(input_filepath, verbose)

--- a/fluster/decoders/libvpx.py
+++ b/fluster/decoders/libvpx.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -42,6 +43,7 @@ class VPXDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         fmt = None

--- a/fluster/decoders/vk_video_decoder.py
+++ b/fluster/decoders/vk_video_decoder.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
+from typing import Any, Dict, Optional
 
 from fluster.codec import Codec, OutputFormat
 from fluster.decoder import Decoder, register_decoder
@@ -38,6 +39,7 @@ class VKVSDecoder(Decoder):
         timeout: int,
         verbose: bool,
         keep_files: bool,
+        optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decodes input_filepath in output_filepath"""
         codec_mapping = {

--- a/fluster/test.py
+++ b/fluster/test.py
@@ -86,6 +86,7 @@ class Test(unittest.TestCase):
             self.timeout,
             self.verbose,
             keep_files_for_decode,
+            self.test_vector.optional_params,
         )
 
     def _cleanup_if_needed(self) -> None:

--- a/fluster/test_vector.py
+++ b/fluster/test_vector.py
@@ -44,6 +44,7 @@ class TestVector:
         output_format: OutputFormat,
         result: str,
         profile: Optional[Profile] = None,
+        optional_params: Optional[Dict[str, Any]] = None,
     ):
         # JSON members
         self.name = name
@@ -51,6 +52,7 @@ class TestVector:
         self.source_checksum = source_checksum
         self.input_file = input_file
         self.profile = profile
+        self.optional_params = optional_params
         self.output_format = output_format
         self.result = result
 
@@ -84,6 +86,11 @@ class TestVector:
             data["profile"] = str(self.profile.value)
         else:
             data.pop("profile")
+        if self.optional_params is not None:
+            data["optional_params"] = self.optional_params
+        else:
+            data.pop("optional_params")
+
         return data
 
     def __str__(self) -> str:
@@ -92,6 +99,7 @@ class TestVector:
             f"            Source: {self.source}\n"
             f"            Input: {self.input_file}\n"
             f"            Profile: {self.profile}\n"
+            f"            Options: {self.optional_params}\n"
             f"            Result: {self.result}"
         )
         return ret


### PR DESCRIPTION
adding the capability to include an optional decoder parameters set for a specfic test vector in the test suite definition. optional parameters are part of Decoder class decode function abstraction and are applied in Gstreamer(Decoder) and Ffmpeg(Decoder) classes implementations. It's child class responsibility to handle the optional parameters.