### PR TITLE
OCP-7182 - H.264 MSDK and QSV decoders fail to link with h264parse in parsebin pipeline, causing "not-linked" errors

### DIFF
--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -313,6 +313,7 @@ class GStreamerMsdkH265Gst10Decoder(GStreamer10Video):
     codec = Codec.H265
     decoder_bin = " msdkh265dec "
     api = "MSDK"
+    parser = " h265parse "
 
 
 @register_decoder
@@ -413,6 +414,7 @@ class GStreamerQsvH264Gst10Decoder(GStreamer10Video):
     codec = Codec.H264
     decoder_bin = " qsvh264dec "
     api = "QSV"
+    parser = " h264parse "
 
 
 @register_decoder
@@ -422,6 +424,7 @@ class GStreamerMsdkH264Gst10Decoder(GStreamer10Video):
     codec = Codec.H264
     decoder_bin = " msdkh264dec "
     api = "MSDK"
+    parser = " h264parse "
 
 
 @register_decoder


### PR DESCRIPTION
Parsebin auto-plugging selects higher-priority decoders (vah264dec, vaapih264dec) instead of the explicitly requested MSDK/QSV decoders because their rank is set to none. This causes not-linked errors when testing MSDK/QSV conformance.