### PR TITLE
fix: Use parsebin instead of h266parse

### DIFF
--- a/fluster/decoder.py
+++ b/fluster/decoder.py
@@ -18,7 +18,7 @@
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from shutil import which
-from typing import List, Optional, Type
+from typing import Dict, List, Optional, Type
 
 from fluster.codec import Codec, OutputFormat
 from fluster.utils import normalize_binary_cmd
@@ -33,8 +33,10 @@ class Decoder(ABC):
     description = ""
     binary = ""
     is_reference = False
+    decoder_name: Optional[str] = None
 
     def __init__(self) -> None:
+        self.extra_env: Dict[str, str] = {}
         if self.binary:
             self.binary = normalize_binary_cmd(self.binary)
 

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -33,7 +33,6 @@ from fluster.utils import (
 )
 
 PIPELINE_TPL = "{} --no-fault filesrc location={} ! {} ! {} ! {} ! {} {}"
-PIPELINE_TPL_FLU_H266_DEC = "{} --no-fault filesrc location={} {} ! {} ! {} ! {} {}"
 
 
 @lru_cache(maxsize=None)
@@ -779,27 +778,10 @@ class FluendoVVCdeCH266Decoder(GStreamerVideo):
 
     codec = Codec.H266
     decoder_bin = " fluh266dec "
+    decoder_name = "fluh266dec"
     provider = "Fluendo"
     api = "SW"
-
-    def gen_pipeline(
-        self,
-        input_filepath: str,
-        output_filepath: Optional[str],
-        output_format: OutputFormat,
-    ) -> str:
-        caps = f"{self.caps} ! videoconvert dither=none ! video/x-raw,format={output_format_to_gst(output_format)}"
-        output = f"location={output_filepath}" if output_filepath else ""
-
-        return PIPELINE_TPL_FLU_H266_DEC.format(
-            self.cmd,
-            input_filepath,
-            "! h266parse " if gst_element_exists("h266parse") else "",
-            self.decoder_bin,
-            caps,
-            self.sink,
-            output,
-        )
+    parser = "parsebin"
 
 
 @register_decoder

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -150,6 +150,13 @@ class GStreamer(Decoder):
         keep_files: bool,
     ) -> str:
         """Decode the test vector and do the checksum"""
+        # Ensure "decoder_name" is used in every automatic-choosing logic
+        # GStreamer has; like when "parsebin" set its caps based on the first
+        # decoder it finds
+        if self.decoder_name:
+            current_feat_rank = os.environ.get("GST_PLUGIN_FEATURE_RANK", "")
+            self.extra_env["GST_PLUGIN_FEATURE_RANK"] = f"{self.decoder_name}:MAX,{current_feat_rank}"
+
         # When using videocodectestsink we can avoid writing files to disk
         # completely, or avoid a full raw file read in order to compute the MD5
         # SUM.
@@ -158,11 +165,13 @@ class GStreamer(Decoder):
             pipeline = self.gen_pipeline(input_filepath, output_param, output_format)
             command = shlex.split(pipeline)
             command.append("-m")
-            data = run_command_with_output(command, timeout=timeout, verbose=verbose).splitlines()
+            data = run_command_with_output(
+                command, timeout=timeout, verbose=verbose, extra_env=self.extra_env
+            ).splitlines()
             return self.parse_videocodectestsink_md5sum(data)
 
         pipeline = self.gen_pipeline(input_filepath, output_filepath, output_format)
-        run_command(shlex.split(pipeline), timeout=timeout, verbose=verbose)
+        run_command(shlex.split(pipeline), timeout=timeout, verbose=verbose, extra_env=self.extra_env)
         return file_checksum(output_filepath)
 
     @lru_cache(maxsize=128)

--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -31,7 +31,7 @@ import urllib.request
 import zipfile
 from functools import partial
 from threading import Lock
-from typing import Any, List, Optional
+from typing import Any, List, Mapping, Optional
 
 TARBALL_EXTS = ("tar.gz", "tgz", "tar.bz2", "tbz2", "tar.xz")
 
@@ -200,14 +200,18 @@ def run_command(
     verbose: bool = False,
     check: bool = True,
     timeout: Optional[int] = None,
+    extra_env: Optional[Mapping[str, str]] = None,
 ) -> None:
     """Runs a command"""
     sout = subprocess.DEVNULL if not verbose else None
     serr = subprocess.DEVNULL if not verbose else None
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
     if verbose:
         print(f'\nRunning command "{" ".join(command)}"')
     try:
-        subprocess.run(command, stdout=sout, stderr=serr, check=check, timeout=timeout)
+        subprocess.run(command, stdout=sout, stderr=serr, check=check, timeout=timeout, env=env)
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
         # Developer experience improvement (facilitates copy/paste)
         ex.cmd = " ".join(ex.cmd)
@@ -220,6 +224,7 @@ def run_command_with_output(
     check: bool = True,
     timeout: Optional[int] = None,
     keep_stderr: bool = False,
+    extra_env: Optional[Mapping[str, str]] = None,
 ) -> str:
     """Runs a command and returns std output trace"""
     serr = subprocess.DEVNULL
@@ -227,9 +232,12 @@ def run_command_with_output(
         serr = subprocess.STDOUT
     if verbose:
         print(f'\nRunning command "{" ".join(command)}"')
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
 
     try:
-        output = subprocess.check_output(command, stderr=serr, timeout=timeout, universal_newlines=True)
+        output = subprocess.check_output(command, stderr=serr, timeout=timeout, universal_newlines=True, env=env)
         if verbose and output:
             print(output)
         return output or ""


### PR DESCRIPTION
This cleaner and allows to use other parsers rather than "h266parse".

Issue: OCP_7503