### PR TITLE
feat: add MPEG2 V4L2 decoders

### DIFF
--- a/fluster/decoders/ffmpeg.py
+++ b/fluster/decoders/ffmpeg.py
@@ -385,6 +385,14 @@ class FFmpegVP9V4L2m2mDecoder(FFmpegV4L2m2mDecoder):
 
 
 @register_decoder
+class FFmpegMPEG2V4L2m2mDecoder(FFmpegV4L2m2mDecoder):
+    """FFmpeg V4L2 mem2mem decoder for MPEG2 video"""
+
+    codec = Codec.MPEG2_VIDEO
+    api = "mpeg2_v4l2m2m"
+
+
+@register_decoder
 class FFmpegH264V4L2m2mDecoder(FFmpegV4L2m2mDecoder):
     """FFmpeg V4L2 mem2mem decoder for H.264"""
 

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -746,6 +746,24 @@ class GStreamerMPEG2VideoDecoder(GStreamerVideo):
 
 
 @register_decoder
+class GStreamerV4l2CodecsMPEG2Decoder(GStreamerVideo):
+    """GStreamer MPEG2 V4L2 stateless decoder implementation for GStreamer"""
+
+    codec = Codec.MPEG2_VIDEO
+    decoder_bin = " v4l2slmpeg2dec "
+    api = "V4L2SL"
+
+
+@register_decoder
+class GStreamerV4l2MPEG2Decoder(GStreamerVideo):
+    """GStreamer MPEG2 V4L2 stateful decoder implementation for GStreamer"""
+
+    codec = Codec.MPEG2_VIDEO
+    decoder_bin = " v4l2mpeg2dec "
+    api = "V4L2"
+
+
+@register_decoder
 class GStreamerLibavMPEG4VideoDecoder(GStreamerVideo):
     """GStreamer MPEG4 Libav video decoder implementation for GStreamer"""
 


### PR DESCRIPTION
Add GStreamer-based and FFmpeg-based V4L2 decoders for MPEG2 video. Tested on Qualcomm Robotics RB5 board with the venus driver (fixed to allow interlaced video fields):

 # GLOBAL SUMMARY
|TOTALS|FFmpeg-MPEG2_VIDEO-v4l2m2m|GStreamer-MPEG2_VIDEO-V4L2|
|-|-|-|
|TOTAL|28/52|30/52|
|TOTAL TIME|97.785s|76.934s|

|Profile|FFmpeg-MPEG2_VIDEO-v4l2m2m|GStreamer-MPEG2_VIDEO-V4L2|
|-|-|-|
|MAIN|23/32|26/32|
|PROFILE_4_2_2|0/9|0/9|
|SIMPLE|5/11|4/11|
|-|-|-|