### PR TITLE
fix: move table separator under the header

### DIFF
--- a/fluster/fluster.py
+++ b/fluster/fluster.py
@@ -701,10 +701,11 @@ class Fluster:
             }
 
             if vectors_passed_per_profile_per_decoder:
-                output = separator
-                output += "\n|Profile|"
+                output = "|Profile|"
                 for decoder, _ in results:
                     output += f"{decoder.name}|"
+                output += "\n"
+                output += separator
 
             for profile in vectors_passed_per_profile_per_decoder.keys():
                 for decoder, _ in results:


### PR DESCRIPTION
The Profile stats tables are misinterepreted by the MarkDown parsers (e.g. by GitHub) because it doesn't follow the spec for the MD table. Move the separator (|-|-|-|) to follow the table header (|Profile|decoder|decoder|) to fix parsing of these tables.
