### PR TITLE
RDI-3295 - Add AC4 decoder configuration sample comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ application that runs a number of test suites with the supported decoders. Its
 purpose is to check different decoder implementations against known test suites
 with known and proven results. It was originally designed to check the
 conformance of H.265/HEVC decoders, but it also supports H.264/AVC, H.266/VVC,
-VP8, VP9, AV1, MPEG2 video and AAC. It can easily be extended to add more decoders and test
+VP8, VP9, AV1, MPEG2 video, AAC and AC-4. It can easily be extended to add more decoders and test
 suites.
 
 ## Table of Contents
@@ -206,6 +206,11 @@ MPEG4_AAC-MP4-ER
     Codec: AAC
     Description: ISO IEC 14496-26 MPEG4 AAC MP4 error resilient and a few other profiles test suite
     Test vectors: 117
+
+AC4_ELEMENTARY_STREAMS
+    Codec: AC-4
+    Description: Dolby AC-4 elementary stream test suite for conformance testing against the Dolby Pro Audio Decoder reference
+    Test vectors: 10
 
 VP8-TEST-VECTORS
     Codec: VP8
@@ -482,6 +487,9 @@ AAC
     ISO-MPEG2-AAC: ISO MPEG2 AAC reference decoder
     ISO-MPEG4-AAC: ISO MPEG4 AAC reference decoder
     ISO-MPEG4-AAC-ER: ISO MPEG4 AAC error resilient reference decoder
+
+AC-4
+    Fluendo-AC4-SW-Gst1.0: Fluendo AC-4 SW decoder for GStreamer 1.0
 ```
 
 4. Run the test suite (or a number of them) for all decoders (or a number of
@@ -506,6 +514,7 @@ AAC
 - Dummy test suite for testing purposes.
 - [AAC](https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_13818-4_2004_Conformance_Testing/AAC/).
 - [AAC](https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/).
+- [AC-4](https://ott.dolby.com/OnDelKits/AC-4/Dolby_AC-4_Online_Delivery_Kit_1.5/Test_Signals/elementary_streams/Audio.zip) (Dolby AC-4 Online Delivery Kit v1.5, available to Dolby licensees).
 - [AV1](https://storage.googleapis.com/aom-test-data/).
 - [AV1](https://source.chromium.org/chromiumos/chromiumos/codesearch/+/main:src/platform/tast-tests/src/chromiumos/tast/local/bundles/cros/video/data/test_vectors/av1/).
 - [AV1](https://aom-cwg-av1-argon-streams-public.s3.us-east-1.amazonaws.com/).
@@ -525,7 +534,7 @@ AAC
   decoder for H.265/HEVC.
 - [JCT-VT H.266/VVC](https://vcgit.hhi.fraunhofer.de/jvet/VVCSoftware_VTM) as reference
   decoder for H.266/VVC.
-- Fluendo's proprietary decoders for MPEG2 video, MPEG4 video, H.264/AVC and H.265/HEVC that are included
+- Fluendo's proprietary decoders for MPEG2 video, MPEG4 video, H.264/AVC, H.265/HEVC and AC-4 that are included
   in [Fluendo Codec
   Pack](https://fluendo.com/products/fluendo-codec-pack/).
 - [GStreamer's](https://gstreamer.freedesktop.org/) for H.266/VVC.

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -141,7 +141,7 @@ class GStreamer(Decoder):
         return PIPELINE_TPL.format(
             self.cmd,
             input_filepath,
-            self.parser if self.parser else "parsebin",
+            self.parser,
             self.decoder_bin,
             self.caps,
             self.sink,
@@ -249,7 +249,7 @@ class GStreamerVideo(GStreamer):
         return PIPELINE_TPL.format(
             self.cmd,
             input_filepath,
-            self.parser if self.parser else "parsebin",
+            self.parser,
             self.decoder_bin,
             caps,
             self._get_sink_for_format(output_format),
@@ -917,7 +917,7 @@ class FluendoFluAC4DecDecoder(GStreamerAudio):
         return PIPELINE_TPL.format(
             self.cmd,
             input_filepath,
-            self.parser if self.parser else "parsebin",
+            self.parser,
             decoder_bin,
             self.caps,
             self.sink,

--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -138,11 +138,10 @@ class GStreamer(Decoder):
     ) -> str:
         """Generate the GStreamer pipeline used to decode the test vector"""
         output = f"location={output_filepath}" if output_filepath else ""
-
         return PIPELINE_TPL.format(
             self.cmd,
             input_filepath,
-            self.parser,
+            self.parser if self.parser else "parsebin",
             self.decoder_bin,
             self.caps,
             self.sink,
@@ -187,7 +186,7 @@ class GStreamer(Decoder):
         # SUM.
         if self._get_sink_for_format(output_format) == "videocodectestsink":
             output_param = output_filepath if keep_files else None
-            pipeline = self.gen_pipeline(input_filepath, output_param, output_format)
+            pipeline = self.gen_pipeline(input_filepath, output_param, output_format, optional_params)
             command = shlex.split(pipeline)
             command.append("-m")
             data = run_command_with_output(command, timeout=timeout, verbose=verbose).splitlines()
@@ -839,7 +838,6 @@ class FluendoVVCdeCH266Decoder(GStreamerVideo):
     decoder_bin = " fluh266dec "
     provider = "Fluendo"
     api = "SW"
-
     parser = "h266parse " if gst_element_exists("h266parse") else "fluh266parse"
 
 
@@ -895,8 +893,36 @@ class FluendoFluAC4DecDecoder(GStreamerAudio):
         self.decoder_bin = "fluac4dec"
         self.provider = "Fluendo"
         self.api = "SW"
-        self.parser = "audio/x-ac4"
+        self.parser = "audio/x-ac4" + (" ! ac4parse" if gst_element_exists("ac4parse") else "")
+        self.caps = "audio/x-raw ! wavenc"
         super().__init__()
+
+    def gen_pipeline(
+        self,
+        input_filepath: str,
+        output_filepath: Optional[str],
+        output_format: OutputFormat,
+        optional_params: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Generate pipeline, mapping optional decoder properties to fluac4dec.
+
+        Each key in optional_params is translated to a GStreamer property name
+        by replacing underscores with hyphens (e.g. drc_mode -> drc-mode).
+        """
+        output = f"location={output_filepath}" if output_filepath else ""
+        decoder_bin = self.decoder_bin
+        if optional_params:
+            for param, value in optional_params.items():
+                decoder_bin += f" {param.replace('_', '-')}={value}"
+        return PIPELINE_TPL.format(
+            self.cmd,
+            input_filepath,
+            self.parser if self.parser else "parsebin",
+            decoder_bin,
+            self.caps,
+            self.sink,
+            output,
+        )
 
 
 @register_decoder

--- a/fluster/test.py
+++ b/fluster/test.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from fluster.decoder import Decoder
 from fluster.test_vector import TestVector, TestVectorResult
-from fluster.utils import compare_byte_wise_files, normalize_path
+from fluster.utils import compare_wav_files, compare_yuv_files, normalize_path
 
 
 class Test(unittest.TestCase):
@@ -151,8 +151,10 @@ class MD5ComparisonTest(Test):
         self.assertEqual(expected, actual, self.test_vector.name)
 
 
-class PixelComparisonTest(Test):
-    """Test class for pixel comparison"""
+class ReferenceComparisonTest(Test):
+    """Base class for tests that compare decoded output against a reference decoder, byte-wise."""
+
+    _ref_file_extension: str
 
     def __init__(
         self,
@@ -180,12 +182,12 @@ class PixelComparisonTest(Test):
         )
         self._keep_files_during_test = True
         self.reference_decoder = reference_decoder
-        self.reference_filepath = normalize_path(os.path.join(self.output_dir, self.test_vector.name + "_ref.yuv"))
+        self.reference_filepath = normalize_path(
+            os.path.join(self.output_dir, self.test_vector.name + "_ref" + self._ref_file_extension)
+        )
 
     def _decode_reference(self) -> str:
-        """Decode the reference file."""
         keep_files_for_decode = self._keep_files_during_test or self.keep_files
-
         return self.reference_decoder.decode(
             self.input_filepath,
             self.reference_filepath,
@@ -193,28 +195,38 @@ class PixelComparisonTest(Test):
             self.timeout,
             self.verbose,
             keep_files_for_decode,
+            self.test_vector.optional_params,
         )
 
     def _cleanup_if_needed(self) -> None:
         super()._cleanup_if_needed()
-        for filepath in [self.reference_filepath, self.reference_filepath + ".yuv"]:
+        for filepath in [self.reference_filepath, self.reference_filepath + self._ref_file_extension]:
             if not self.keep_files and os.path.exists(filepath):
                 os.remove(filepath)
 
+    def _resolve_reference_file(self, decoded_path: str) -> str:
+        """Return the actual reference file path, falling back to known locations if needed."""
+        if os.path.exists(decoded_path):
+            return decoded_path
+        alt = self.reference_filepath + self._ref_file_extension
+        return alt if os.path.exists(alt) else self.reference_filepath
+
+
+class PixelComparisonTest(ReferenceComparisonTest):
+    """Test class for pixel-by-pixel comparison against a reference video decoder."""
+
+    _ref_file_extension = ".yuv"
+
     def compare_result(self, result: str) -> None:
-        """Compare decoded output with reference decoder output pixel-wise."""
-        reference_result = self._decode_reference()
+        violations = compare_yuv_files(self._resolve_reference_file(self._decode_reference()), self.output_filepath)
+        self.assertEqual(0, violations, self.test_vector.name)
 
-        actual_reference_file = reference_result
-        if not os.path.exists(reference_result):
-            actual_reference_file = (
-                self.reference_filepath + ".yuv"
-                if os.path.exists(self.reference_filepath + ".yuv")
-                else self.reference_filepath
-            )
 
-        comparison_result = compare_byte_wise_files(
-            actual_reference_file, self.output_filepath, keep_files=self.keep_files
-        )
+class SampleComparisonTest(ReferenceComparisonTest):
+    """Test class for audio sample-by-sample comparison against a reference audio decoder."""
 
-        self.assertEqual(0, comparison_result, self.test_vector.name)
+    _ref_file_extension = ".wav"
+
+    def compare_result(self, result: str) -> None:
+        violations = compare_wav_files(self._resolve_reference_file(self._decode_reference()), self.output_filepath)
+        self.assertEqual(0, violations, self.test_vector.name)

--- a/fluster/test_suite.py
+++ b/fluster/test_suite.py
@@ -32,7 +32,7 @@ from unittest.result import TestResult
 from fluster import utils
 from fluster.codec import Codec
 from fluster.decoder import Decoder, get_reference_decoder_for_codec
-from fluster.test import MD5ComparisonTest, PixelComparisonTest, Test
+from fluster.test import MD5ComparisonTest, PixelComparisonTest, ReferenceComparisonTest, SampleComparisonTest, Test
 from fluster.test_vector import TestVector, TestVectorResult
 
 
@@ -120,6 +120,7 @@ class TestMethod(Enum):
 
     MD5 = "md5"
     PIXEL = "pixel"
+    SAMPLE = "sample"
 
 
 class TestSuite:
@@ -497,7 +498,7 @@ class TestSuite:
             )
             return None
 
-        if self.test_method == TestMethod.PIXEL:
+        if self.test_method in (TestMethod.PIXEL, TestMethod.SAMPLE):
             ctx.reference_decoder = get_reference_decoder_for_codec(ctx.decoder.codec)
             if ctx.reference_decoder is None or not ctx.reference_decoder.check(ctx.verbose):
                 print(f"Skipping test suite {self.name}: no reference decoder for codec {ctx.decoder.codec.name}")
@@ -548,6 +549,11 @@ class TestSuite:
         tests: List[Test] = []
         test_vectors_run = {}
 
+        reference_test_classes: Dict[TestMethod, Type[ReferenceComparisonTest]] = {
+            TestMethod.PIXEL: PixelComparisonTest,
+            TestMethod.SAMPLE: SampleComparisonTest,
+        }
+
         for name, test_vector in self.test_vectors.items():
             skip = False
             name_lower = test_vector.name.lower()
@@ -556,10 +562,11 @@ class TestSuite:
             if ctx.skip_vectors and name_lower in ctx.skip_vectors:
                 skip = True
 
-            if self.test_method == TestMethod.PIXEL:
+            if self.test_method in reference_test_classes:
                 assert ctx.reference_decoder is not None
+                test_cls = reference_test_classes[self.test_method]
                 tests.append(
-                    PixelComparisonTest(
+                    test_cls(
                         ctx.decoder,
                         self,
                         test_vector,

--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -15,6 +15,10 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+import array
+import contextlib
 import hashlib
 import http.client
 import os
@@ -28,10 +32,11 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import wave
 import zipfile
 from functools import partial
 from threading import Lock
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 TARBALL_EXTS = ("tar.gz", "tgz", "tar.bz2", "tbz2", "tar.xz")
 
@@ -314,39 +319,87 @@ def normalize_path(path: str) -> str:
     return path
 
 
-def compare_byte_wise_files(
-    reference_file: str, test_file: str, tolerance: int = 2, keep_files: bool = False, blocksize: int = 1024
-) -> int:
-    """
-    Compares two binary files byte by byte with a given tolerance, reading in blocks.
-    """
-    total_violations = 0
+def _read_wav(path: str) -> Tuple[array.array[int], int, int]:
+    """Load a WAV file and return (interleaved_samples, n_channels, sampwidth). Supports 16 and 32-bit PCM."""
+    with wave.open(path, "rb") as w:
+        n_channels = w.getnchannels()
+        sampwidth = w.getsampwidth()
+        raw = w.readframes(w.getnframes())
+    if sampwidth == 2:
+        typecode = "h"
+    elif sampwidth == 4:
+        typecode = "i"
+    else:
+        raise ValueError(f"Unsupported sample width: {sampwidth * 8}bit")
+    buf = array.array(typecode)
+    buf.frombytes(raw)
+    if sys.byteorder == "big":
+        buf.byteswap()
+    return buf, n_channels, sampwidth
 
-    with open(reference_file, "rb") as ref_file, open(test_file, "rb") as test_file_obj:
-        ref_iter = iter(partial(ref_file.read, blocksize), b"")
-        test_iter = iter(partial(test_file_obj.read, blocksize), b"")
 
+def compare_wav_files(reference_file: str, test_file: str, tolerance: int = 128) -> int:
+    """Compare two WAV files sample-by-sample with active-channel detection and lag compensation."""
+    ref_flat, ref_nch, ref_sw = _read_wav(reference_file)
+    test_flat, test_nch, test_sw = _read_wav(test_file)
+    n_ref = len(ref_flat) // ref_nch
+    n_test = len(test_flat) // test_nch
+
+    if ref_sw != test_sw:
+        raise ValueError(f"Sample width mismatch: ref={ref_sw * 8}bit test={test_sw * 8}bit")
+
+    # Fast path: byte-identical samples → zero violations (C-level comparison)
+    if ref_flat == test_flat:
+        return 0
+
+    if ref_nch == test_nch:
+        # Same channel layout: compare all channels directly
+        active = list(range(ref_nch))
+    else:
+        # Different channel counts: select only active (non-silent) channels from reference
+        active = [ch for ch in range(ref_nch) if any(ref_flat[ch::ref_nch])]
+        if len(active) != test_nch:
+            raise ValueError(f"Channel mismatch: ref active={len(active)} test={test_nch}")
+
+    # Align to first non-zero frame to compensate for constant leading silence
+    ref_nz = next((i for i in range(n_ref) if any(ref_flat[i * ref_nch + ch] for ch in active)), None)
+    test_nz = next((i for i in range(n_test) if any(test_flat[i * test_nch + ai] for ai in range(test_nch))), None)
+
+    ref_start = test_start = 0
+    if ref_nz is not None and test_nz is not None:
+        lag = test_nz - ref_nz
+        if lag > 0:
+            test_start = lag
+        elif lag < 0:
+            ref_start = -lag
+
+    n_compare = min(n_ref - ref_start, n_test - test_start)
+    violations = 0
+    for ai, ach in enumerate(active):
+        ref_ch = ref_flat[ref_start * ref_nch + ach : (ref_start + n_compare) * ref_nch : ref_nch]
+        test_ch = test_flat[test_start * test_nch + ai : (test_start + n_compare) * test_nch : test_nch]
+        violations += sum(abs(r - t) > tolerance for r, t in zip(ref_ch, test_ch))
+    return violations
+
+
+def compare_yuv_files(reference_file: str, test_file: str, tolerance: int = 2, blocksize: int = 1024) -> int:
+    """Compare two YUV files byte-by-byte within a tolerance, streaming in blocks."""
+    violations = 0
+    with open(reference_file, "rb") as ref_fh, open(test_file, "rb") as test_fh:
+        ref_iter = iter(partial(ref_fh.read, blocksize), b"")
+        test_iter = iter(partial(test_fh.read, blocksize), b"")
         for ref_block in ref_iter:
             test_block = next(test_iter, None)
-
             if test_block is None:
                 raise ValueError("Test file is shorter than reference file")
-
             if len(ref_block) != len(test_block):
-                raise ValueError("File blocks do not match in size")
-
+                raise ValueError("File size mismatch between reference and test")
             for i in range(len(ref_block)):
-                diff = abs(ref_block[i] - test_block[i])
-                if diff > tolerance:
-                    total_violations += 1
-
+                if abs(ref_block[i] - test_block[i]) > tolerance:
+                    violations += 1
         if next(test_iter, None) is not None:
             raise ValueError("Test file is longer than reference file")
-
-    if not keep_files and os.path.isfile(test_file):
-        os.remove(test_file)
-
-    return total_violations
+    return violations
 
 
 def find_by_ext(dest_dir: str, exts: List[str], excludes: Optional[List[str]] = None) -> Optional[str]:
@@ -389,50 +442,36 @@ def find_by_ext(dest_dir: str, exts: List[str], excludes: Optional[List[str]] = 
     return candidates[0] if candidates else None
 
 
+def _parse_pcm_channel(filename: str) -> Tuple[str, int]:
+    """Return (channel_type, channel_number) from a PCM filename, or ('', 0) if unmatched."""
+    match = re.search(r"_([fbsl])(\d+)\.pcm$", os.path.basename(filename).lower())
+    if match:
+        return match.group(1), int(match.group(2))
+    return "", 0
+
+
 def interleave_pcm_files(pcm_files: List[str], output_filepath: str) -> None:
-    """
-    Interleaves PCM files with multichannel patterns (_*) in the correct channel ordering:
-    1. Front channels (f00-f0X) in numerical order
-    2. Side channels (s00-s0X) in numerical order, if present
-    3. Back channels (b00-b0X) in numerical order
-    4. LFE channel (l00) if present
-    """
-    front_channels = [f for f in pcm_files if "_f" in os.path.basename(f).lower()]
-    side_channels = [f for f in pcm_files if "_s" in os.path.basename(f).lower()]
-    back_channels = [f for f in pcm_files if "_b" in os.path.basename(f).lower()]
-    lfe_channels = [f for f in pcm_files if "_l" in os.path.basename(f).lower()]
+    """Interleave per-channel PCM files (_fNN/_sNN/_bNN/_lNN) into a single multichannel raw PCM stream."""
+    channel_order = {"f": 0, "s": 1, "b": 2, "l": 3}
+    classified = [(f, *_parse_pcm_channel(f)) for f in pcm_files]
+    sorted_files = [
+        f
+        for f, ch_type, ch_num in sorted(classified, key=lambda x: (channel_order.get(x[1], 99), x[2]))
+        if ch_type in channel_order
+    ]
 
-    front_channels.sort(key=_get_channel_number)
-    side_channels.sort(key=_get_channel_number)
-    back_channels.sort(key=_get_channel_number)
-    lfe_channels.sort(key=_get_channel_number)
-
-    sorted_files = front_channels + side_channels + back_channels + lfe_channels
-
-    pcm_files_handles = [open(pcm_file, "rb") for pcm_file in sorted_files]
-
-    with open(output_filepath, "wb") as outfile:
+    with contextlib.ExitStack() as stack:
+        handles = [stack.enter_context(open(f, "rb")) for f in sorted_files]
+        outfile = stack.enter_context(open(output_filepath, "wb"))
         while True:
-            # Read one block (2 bytes for 16-bit PCM) from each file
-            data = [f.read(2) for f in pcm_files_handles]
-
+            # Read one 16-bit sample per channel
+            data = [f.read(2) for f in handles]
             if all(block == b"" for block in data):
                 break
 
             for block in data:
                 if block:
                     outfile.write(block)
-
-    for file_handle in pcm_files_handles:
-        file_handle.close()
-
-
-def _get_channel_number(filename: str) -> int:
-    """Return channel number from filename"""
-    match = re.search(r"_[fbsl](\d+)\.pcm$", filename.lower())
-    if match:
-        return int(match.group(1))
-    return 0
 
 
 def _linux_user_data_dir(appname: str) -> str:

--- a/test_suites/ac4/AC4_ELEMENTARY_STREAMS.json
+++ b/test_suites/ac4/AC4_ELEMENTARY_STREAMS.json
@@ -9,7 +9,10 @@
             "source_checksum": "03c1abb0778a546c2c31f631e62b8c89",
             "input_file": "Audio/Audio_ID_2ch_64kbps_25fps_ac4.ac4",
             "output_format": "Unknown",
-            "result": "fafbaf85aba8a356ed5028a9bac0763a"
+            "result": "fafbaf85aba8a356ed5028a9bac0763a",
+            "optional_params": {
+                "decoder_speaker_config": 3
+            }
         },
         {
             "name": "Audio_ID_2ch_64kbps_2997fps_ac4.ac4",
@@ -17,7 +20,10 @@
             "source_checksum": "03c1abb0778a546c2c31f631e62b8c89",
             "input_file": "Audio/Audio_ID_2ch_64kbps_2997fps_ac4.ac4",
             "output_format": "Unknown",
-            "result": "dc8426318b18c294ccdb373cfdd0470e"
+            "result": "dc8426318b18c294ccdb373cfdd0470e",
+            "optional_params": {
+                "decoder_speaker_config": 3
+            }
         },
         {
             "name": "Audio_ID_514ch_192kbps_25fps_ac4.ac4",
@@ -25,7 +31,10 @@
             "source_checksum": "03c1abb0778a546c2c31f631e62b8c89",
             "input_file": "Audio/Audio_ID_514ch_192kbps_25fps_ac4.ac4",
             "output_format": "Unknown",
-            "result": "86ac79ed8802a6d99c8c6dc13709ef67"
+            "result": "86ac79ed8802a6d99c8c6dc13709ef67",
+            "optional_params": {
+                "decoder_speaker_config": 0
+            }
         },
         {
             "name": "Audio_ID_514ch_192kbps_2997fps_ac4.ac4",
@@ -33,7 +42,10 @@
             "source_checksum": "03c1abb0778a546c2c31f631e62b8c89",
             "input_file": "Audio/Audio_ID_514ch_192kbps_2997fps_ac4.ac4",
             "output_format": "Unknown",
-            "result": "495e8f8966c085e50f2c3e69829256bb"
+            "result": "495e8f8966c085e50f2c3e69829256bb",
+            "optional_params": {
+                "decoder_speaker_config": 0
+            }
         },
         {
             "name": "Audio_ID_6ch_128kbps_25fps_ac4.ac4",
@@ -41,7 +53,10 @@
             "source_checksum": "03c1abb0778a546c2c31f631e62b8c89",
             "input_file": "Audio/Audio_ID_6ch_128kbps_25fps_ac4.ac4",
             "output_format": "Unknown",
-            "result": "a014c4a87fb1ba3d6e4aa270df26003a"
+            "result": "a014c4a87fb1ba3d6e4aa270df26003a",
+            "optional_params": {
+                "decoder_speaker_config": 2
+            }
         },
         {
             "name": "Audio_ID_6ch_128kbps_2997fps_ac4.ac4",
@@ -49,23 +64,10 @@
             "source_checksum": "03c1abb0778a546c2c31f631e62b8c89",
             "input_file": "Audio/Audio_ID_6ch_128kbps_2997fps_ac4.ac4",
             "output_format": "Unknown",
-            "result": "59d2d88797f4a5873121e901ebb61db7"
-        },
-        {
-            "name": "Audio_ID_ims_112kbps_25fps_ac4.ac4",
-            "source": "https://ott.dolby.com/OnDelKits/AC-4/Dolby_AC-4_Online_Delivery_Kit_1.5/Test_Signals/elementary_streams/Audio.zip",
-            "source_checksum": "03c1abb0778a546c2c31f631e62b8c89",
-            "input_file": "Audio/Audio_ID_ims_112kbps_25fps_ac4.ac4",
-            "output_format": "Unknown",
-            "result": "3be6544de42243e72e5320efee7ad853"
-        },
-        {
-            "name": "Audio_ID_ims_112kbps_2997fps_ac4.ac4",
-            "source": "https://ott.dolby.com/OnDelKits/AC-4/Dolby_AC-4_Online_Delivery_Kit_1.5/Test_Signals/elementary_streams/Audio.zip",
-            "source_checksum": "03c1abb0778a546c2c31f631e62b8c89",
-            "input_file": "Audio/Audio_ID_ims_112kbps_2997fps_ac4.ac4",
-            "output_format": "Unknown",
-            "result": "412894104735faa4d9271ffe55606bfc"
+            "result": "59d2d88797f4a5873121e901ebb61db7",
+            "optional_params": {
+                "decoder_speaker_config": 2
+            }
         },
         {
             "name": "Holi_en_6ch_128kbps_25fps_ac4.ac4",
@@ -73,7 +75,10 @@
             "source_checksum": "03c1abb0778a546c2c31f631e62b8c89",
             "input_file": "Audio/Holi_en_6ch_128kbps_25fps_ac4.ac4",
             "output_format": "Unknown",
-            "result": "69df080a341691b7e09f8d45efe57139"
+            "result": "69df080a341691b7e09f8d45efe57139",
+            "optional_params": {
+                "decoder_speaker_config": 2
+            }
         },
         {
             "name": "Holi_en_6ch_128kbps_2997fps_ac4.ac4",
@@ -81,7 +86,10 @@
             "source_checksum": "03c1abb0778a546c2c31f631e62b8c89",
             "input_file": "Audio/Holi_en_6ch_128kbps_2997fps_ac4.ac4",
             "output_format": "Unknown",
-            "result": "b645245723ce8c3b5fd12cfd9e04ac3f"
+            "result": "b645245723ce8c3b5fd12cfd9e04ac3f",
+            "optional_params": {
+                "decoder_speaker_config": 2
+            }
         },
         {
             "name": "Holi_fr_6ch_128kbps_25fps_ac4.ac4",
@@ -89,7 +97,10 @@
             "source_checksum": "03c1abb0778a546c2c31f631e62b8c89",
             "input_file": "Audio/Holi_fr_6ch_128kbps_25fps_ac4.ac4",
             "output_format": "Unknown",
-            "result": "638d1fb73e868247fb689b04c45a6dd1"
+            "result": "638d1fb73e868247fb689b04c45a6dd1",
+            "optional_params": {
+                "decoder_speaker_config": 2
+            }
         },
         {
             "name": "Holi_fr_6ch_128kbps_2997fps_ac4.ac4",
@@ -97,8 +108,11 @@
             "source_checksum": "03c1abb0778a546c2c31f631e62b8c89",
             "input_file": "Audio/Holi_fr_6ch_128kbps_2997fps_ac4.ac4",
             "output_format": "Unknown",
-            "result": "05636608b15c8986440f9e3348c88c27"
+            "result": "05636608b15c8986440f9e3348c88c27",
+            "optional_params": {
+                "decoder_speaker_config": 2
+            }
         }
     ],
-    "test_method": "md5"
+    "test_method": "sample"
 }


### PR DESCRIPTION
To bring changes from this PR (https://github.com/fluendo/fluster/pull/321)

Map `fluac4dec` channel order&config to the reference decoder one.

<img width="1118" height="928" alt="image (1)" src="https://github.com/user-attachments/assets/fee55fa6-7fc8-40df-acb6-83d5ff03c3de" />

`$ **GST_PLUGIN_PATH=/home/rsanchez/Downloads python3 ./fluster.py run -ts AC4_ELEMENTARY_STREAMS -d DolbyPADSReferenceDecoder Fluendo-AC4-SW -s**
****************************************************************************************************
Running test suite AC4_ELEMENTARY_STREAMS with decoder DolbyPADSReferenceDecoder
Using 16 parallel job(s)
****************************************************************************************************

[TEST SUITE            ] (DECODER                  ) TEST VECTOR                            ... RESULT
----------------------------------------------------------------------
[AC4_ELEMENTARY_STREAMS] (DolbyPADSReferenceDecoder) Audio_ID_2ch_64kbps_25fps_ac4.ac4      ... Success
[AC4_ELEMENTARY_STREAMS] (DolbyPADSReferenceDecoder) Audio_ID_2ch_64kbps_2997fps_ac4.ac4    ... Success
[AC4_ELEMENTARY_STREAMS] (DolbyPADSReferenceDecoder) Audio_ID_514ch_192kbps_25fps_ac4.ac4   ... Success
[AC4_ELEMENTARY_STREAMS] (DolbyPADSReferenceDecoder) Audio_ID_6ch_128kbps_2997fps_ac4.ac4   ... Success
[AC4_ELEMENTARY_STREAMS] (DolbyPADSReferenceDecoder) Audio_ID_6ch_128kbps_25fps_ac4.ac4     ... Success
[AC4_ELEMENTARY_STREAMS] (DolbyPADSReferenceDecoder) Audio_ID_514ch_192kbps_2997fps_ac4.ac4 ... Success
[AC4_ELEMENTARY_STREAMS] (DolbyPADSReferenceDecoder) Holi_fr_6ch_128kbps_25fps_ac4.ac4      ... Success
[AC4_ELEMENTARY_STREAMS] (DolbyPADSReferenceDecoder) Holi_fr_6ch_128kbps_2997fps_ac4.ac4    ... Success
[AC4_ELEMENTARY_STREAMS] (DolbyPADSReferenceDecoder) Holi_en_6ch_128kbps_25fps_ac4.ac4      ... Success
[AC4_ELEMENTARY_STREAMS] (DolbyPADSReferenceDecoder) Holi_en_6ch_128kbps_2997fps_ac4.ac4    ... Success


Ran 10/10 tests successfully               in 5.791 secs
****************************************************************************************************
Running test suite AC4_ELEMENTARY_STREAMS with decoder Fluendo-AC4-SW
Using 16 parallel job(s)
****************************************************************************************************

[TEST SUITE            ] (DECODER       ) TEST VECTOR                            ... RESULT
----------------------------------------------------------------------
[AC4_ELEMENTARY_STREAMS] (Fluendo-AC4-SW) Audio_ID_2ch_64kbps_25fps_ac4.ac4      ... Success
[AC4_ELEMENTARY_STREAMS] (Fluendo-AC4-SW) Audio_ID_6ch_128kbps_25fps_ac4.ac4     ... Success
[AC4_ELEMENTARY_STREAMS] (Fluendo-AC4-SW) Audio_ID_2ch_64kbps_2997fps_ac4.ac4    ... Success
[AC4_ELEMENTARY_STREAMS] (Fluendo-AC4-SW) Audio_ID_6ch_128kbps_2997fps_ac4.ac4   ... Success
[AC4_ELEMENTARY_STREAMS] (Fluendo-AC4-SW) Audio_ID_514ch_192kbps_2997fps_ac4.ac4 ... Success
[AC4_ELEMENTARY_STREAMS] (Fluendo-AC4-SW) Audio_ID_514ch_192kbps_25fps_ac4.ac4   ... Success
[AC4_ELEMENTARY_STREAMS] (Fluendo-AC4-SW) Holi_en_6ch_128kbps_25fps_ac4.ac4      ... Success
[AC4_ELEMENTARY_STREAMS] (Fluendo-AC4-SW) Holi_fr_6ch_128kbps_25fps_ac4.ac4      ... Success
[AC4_ELEMENTARY_STREAMS] (Fluendo-AC4-SW) Holi_fr_6ch_128kbps_2997fps_ac4.ac4    ... Success
[AC4_ELEMENTARY_STREAMS] (Fluendo-AC4-SW) Holi_en_6ch_128kbps_2997fps_ac4.ac4    ... Success


Ran 10/10 tests successfully               in 6.252 secs
Generating summary for test suite AC4_ELEMENTARY_STREAMS and decoders DolbyPADSReferenceDecoder, Fluendo-AC4-SW:

## System Information

**OS:** Linux 6.17.0-20-generic

**CPU:** AMD Ryzen 7 7745HX with Radeon Graphics

**GPU:** 00.0 VGA compatible controller: NVIDIA Corporation AD107M, 00.0 VGA compatible controller: Advanced Micro Devices, Inc. [PRIMARY]

**RAM:** 30.5 GB

**Backends:**
- VDPAU: G3DVL VDPAU Driver Shared Library version 1.0
- NVDEC: Available (NVIDIA Driver 590.48.01)

|Test|DolbyPADSReferenceDecoder|Fluendo-AC4-SW|
|-|-|-|
|TOTAL|10/10|10/10|
|TOTAL TIME|5.791s|6.252s|
|-|-|-|
|Audio_ID_2ch_64kbps_25fps_ac4.ac4|✔️|✔️|
|Audio_ID_2ch_64kbps_2997fps_ac4.ac4|✔️|✔️|
|Audio_ID_514ch_192kbps_25fps_ac4.ac4|✔️|✔️|
|Audio_ID_514ch_192kbps_2997fps_ac4.ac4|✔️|✔️|
|Audio_ID_6ch_128kbps_25fps_ac4.ac4|✔️|✔️|
|Audio_ID_6ch_128kbps_2997fps_ac4.ac4|✔️|✔️|
|Holi_en_6ch_128kbps_25fps_ac4.ac4|✔️|✔️|
|Holi_en_6ch_128kbps_2997fps_ac4.ac4|✔️|✔️|
|Holi_fr_6ch_128kbps_25fps_ac4.ac4|✔️|✔️|
|Holi_fr_6ch_128kbps_2997fps_ac4.ac4|✔️|✔️|
|-|-|-|
|Test|DolbyPADSReferenceDecoder|Fluendo-AC4-SW|
|TOTAL|10/10|10/10|
|TOTAL TIME|5.791s|6.252s|


# GLOBAL SUMMARY
|TOTALS|DolbyPADSReferenceDecoder|Fluendo-AC4-SW|
|-|-|-|
|TOTAL|10/10|10/10|
|TOTAL TIME|5.791s|6.252s|
|-|-|-|`
