### PR TITLE
fix: Replace unreliable ITU download URL in dummy test suite

### DIFF
--- a/check/dummy.json
+++ b/check/dummy.json
@@ -5,11 +5,11 @@
     "test_vectors": [
         {
             "name": "one",
-            "source": "https://www.itu.int/wftp3/av-arch/jctvc-site/bitstream_exchange/draft_conformance/HEVC_v1/ipcm_A_NEC_3.zip",
-            "source_checksum": "69b58505dc88fe422e3de55251549409",
-            "input_file": "ipcm_A_NEC_3/ipcm_A_NEC_3.bit",
+            "source": "https://storage.googleapis.com/aom-test-data/av1-1-b8-01-size-200x226.ivf",
+            "source_checksum": "b5597b4ee41c15ccc323406ad7618c55",
+            "input_file": "av1-1-b8-01-size-200x226.ivf",
             "output_format": "yuv420p",
-            "result": "19b8d716307ae8b28c81b21f14f870dc"
+            "result": "b5597b4ee41c15ccc323406ad7618c55"
         }
     ],
     "test_method": "md5"

--- a/check/dummy_download_fail.json
+++ b/check/dummy_download_fail.json
@@ -5,11 +5,11 @@
     "test_vectors": [
         {
             "name": "download_fail",
-            "source": "https://www.itu.int/wftp3/av-arch/jctvc-site/bitstream_exchange/draft_conformance/HEVC_v1/ipcm_B_NEC_3.zip",
+            "source": "https://storage.googleapis.com/aom-test-data/av1-1-b8-01-size-200x226.ivf",
             "source_checksum": "bad checksum on purpose",
-            "input_file": "ipcm_B_NEC_3/ipcm_B_NEC_3.bit",
+            "input_file": "av1-1-b8-01-size-200x226.ivf",
             "output_format": "yuv420p",
-            "result": "23a3b7024fd9bc64b946b9961ab0f51e"
+            "result": "bad result on purpose"
         }
     ]
 }

--- a/check/dummy_fail.json
+++ b/check/dummy_fail.json
@@ -5,19 +5,19 @@
     "test_vectors": [
         {
             "name": "expected_fail",
-            "source": "https://www.itu.int/wftp3/av-arch/jctvc-site/bitstream_exchange/draft_conformance/HEVC_v1/ipcm_B_NEC_3.zip",
-            "source_checksum": "0efbe6e6a4a7cd259ffa241c4aee473e",
-            "input_file": "ipcm_B_NEC_3/ipcm_B_NEC_3.bit",
+            "source": "https://storage.googleapis.com/aom-test-data/av1-1-b8-01-size-200x226.ivf",
+            "source_checksum": "b5597b4ee41c15ccc323406ad7618c55",
+            "input_file": "av1-1-b8-01-size-200x226.ivf",
             "output_format": "yuv420p",
             "result": "bad result on purpose"
         },
         {
             "name": "success",
-            "source": "https://www.itu.int/wftp3/av-arch/jctvc-site/bitstream_exchange/draft_conformance/HEVC_v1/ipcm_A_NEC_3.zip",
-            "source_checksum": "69b58505dc88fe422e3de55251549409",
-            "input_file": "ipcm_A_NEC_3/ipcm_A_NEC_3.bit",
+            "source": "https://storage.googleapis.com/aom-test-data/av1-1-b8-01-size-200x226.ivf",
+            "source_checksum": "b5597b4ee41c15ccc323406ad7618c55",
+            "input_file": "av1-1-b8-01-size-200x226.ivf",
             "output_format": "yuv420p",
-            "result": "19b8d716307ae8b28c81b21f14f870dc"
+            "result": "b5597b4ee41c15ccc323406ad7618c55"
         }
     ]
 }


### PR DESCRIPTION
fix for these cases:

https://github.com/fluendo/fluster/actions/runs/25098331806
https://github.com/fluendo/fluster/actions/runs/25097268895