### PR TITLE
Add libav and vvdec plugins to GStreamer, enable X11 and Wayland display access in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,9 @@ FROM ubuntu:${UBUNTU_VERSION}
 ARG USERNAME='mock'
 ARG PASSWORD='mock'
 
+ARG ARCH=x86_64
+ARG CARGO_C_VERSION=v0.10.23
+
 # Re-declare args after FROM to make them available in build stages
 ARG UBUNTU_VERSION
 ARG NVIDIA_DRIVER_VERSION
@@ -63,9 +66,9 @@ RUN apt-get update && apt-get install -y \
     libva-dev \
     libva-drm2 \
     libva-x11-2 \
-  vainfo \
+    vainfo \
     mesa-va-drivers \
-  && (apt-get install -y i965-va-driver || true) \
+    && (apt-get install -y i965-va-driver || true) \
     && (apt-get install -y intel-media-va-driver-non-free || \
         apt-get install -y intel-media-va-driver || true) \
     && rm -rf /var/lib/apt/lists/*
@@ -136,6 +139,8 @@ RUN if [ "${FFMPEG_INSTALL_METHOD}" = "source" ]; then \
         libxcb1-dev \
         libxcb-shm0-dev \
         libxcb-xfixes0-dev \
+        libssl-dev \
+        libpango1.0-dev \
         meson \
         ninja-build \
         pkg-config \
@@ -173,8 +178,8 @@ RUN if [ "${FFMPEG_INSTALL_METHOD}" = "source" ]; then \
       cd / && rm -rf /tmp/dav1d && \
       git clone --depth 1 --branch n${FFMPEG_VERSION} https://github.com/FFmpeg/FFmpeg.git /tmp/ffmpeg && \
       cd /tmp/ffmpeg && \
-      export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib/x86_64-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-} && \
-      export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-} && \
+      export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib/${ARCH}-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-} && \
+      export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib/${ARCH}-linux-gnu:${LD_LIBRARY_PATH:-} && \
       ./configure \
         --prefix=/usr/local \
         --pkg-config-flags="--static" \
@@ -299,13 +304,20 @@ RUN if [ "${GSTREAMER_INSTALL_METHOD}" = "source" ]; then \
       && mkdir -p /tmp/gstreamer && cd /tmp/gstreamer \
       && curl -L "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/${GSTREAMER_VERSION}/gstreamer-${GSTREAMER_VERSION}.tar.gz" | tar xz \
       && cd gstreamer-${GSTREAMER_VERSION} \
+      # Dynamically assign -Dvaapi=enabled for ANY version < 1.28 \
+      && GST_MINOR=$(echo ${GSTREAMER_VERSION} | cut -d. -f2) \
+      && if [ "$GST_MINOR" -lt 28 ]; then \
+           VAAPI_OPT="-Dvaapi=enabled"; \
+         else \
+           VAAPI_OPT=""; \
+         fi \
       && meson setup build \
         --prefix=/usr/local \
         --buildtype=release \
         -Dgpl=enabled \
         -Dugly=enabled \
-        -Dvaapi=enabled \
-        -Dlibav=disabled \
+        ${VAAPI_OPT} \
+        -Dlibav=enabled \
         -Dbase=enabled \
         -Dgood=enabled \
         -Dbad=enabled \
@@ -322,9 +334,8 @@ RUN if [ "${GSTREAMER_INSTALL_METHOD}" = "source" ]; then \
       && meson compile -C build -j$(nproc) \
       && sudo ninja install -C build \
       && sudo ldconfig \
-      && cd / && sudo rm -rf /tmp/gstreamer \
-      && sudo apt-get purge -y 'libgstreamer*' 'gstreamer1.0-*' 2>/dev/null || true \
-      && sudo apt-get autoremove -y 2>/dev/null || true; \
+      && cd / && rm -rf /tmp/gstreamer \
+      && sudo apt-get purge -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev 2>/dev/null || true; \
     else \
       sudo DEBIAN_FRONTEND=noninteractive apt-get update && \
       sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -345,10 +356,73 @@ RUN if [ "${GSTREAMER_INSTALL_METHOD}" = "source" ]; then \
 
 USER root
 
+# =========================================================================
+# Conditionally Install Native vvdec Core, Rust & Build GStreamer Plugins
+# =========================================================================
+RUN if [ "${GSTREAMER_INSTALL_METHOD}" = "source" ]; then \
+      GST_MINOR=$(echo ${GSTREAMER_VERSION} | cut -d. -f2) && \
+      if [ "$GST_MINOR" -ge 26 ]; then \
+        # Dynamically scope the Rust home paths to this conditional execution context \
+        export CARGO_HOME="/usr/local/.cargo" && \
+        export RUSTUP_HOME="/usr/local/.rustup" && \
+        export PATH="${CARGO_HOME}/bin:${PATH}" && \
+        \
+        # 1. Ensure OpenSSL development headers are present for the Rust compilation \
+        apt-get update && apt-get install -y --no-install-recommends \
+          libssl-dev \
+          clang \
+          libclang-dev \
+        && rm -rf /var/lib/apt/lists/* && \
+        \
+        # 2. Clone, build, and install the native Fraunhofer HHI VVC Decoder core \
+        git clone --depth 1 --branch v3.1.0 https://github.com/fraunhoferhhi/vvdec.git /tmp/vvdec && \
+        cd /tmp/vvdec && \
+        mkdir build && cd build && \
+        cmake -DCMAKE_BUILD_TYPE=Release \
+              -DBUILD_SHARED_LIBS=ON \
+              -DCMAKE_INSTALL_PREFIX=/usr/local \
+              -DCMAKE_INSTALL_LIBDIR=lib/${ARCH}-linux-gnu .. && \
+        make -j$(nproc) && \
+        make install && \
+        ldconfig && \
+        cd / && rm -rf /tmp/vvdec && \
+        \
+        # 3. Configure Cargo network optimizations \
+        mkdir -p ${CARGO_HOME} && \
+        echo '[net]\ngit-fetch-with-cli = true' > ${CARGO_HOME}/config && \
+        \
+        # 4. Install Rust toolchain environment \
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path && \
+        \
+        # 5. Extract pre-compiled cargo-c binaries directly to skip compilation errors \
+        curl -L "https://github.com/lu-zero/cargo-c/releases/download/${CARGO_C_VERSION}/cargo-c-${ARCH}-unknown-linux-musl.tar.gz" | tar -xz -C ${CARGO_HOME}/bin && \
+        chmod -R 777 ${CARGO_HOME} && \
+        \
+        # 6. Map GStreamer core versions to their matching Rust plugins stable branch \
+        case "$GST_MINOR" in \
+          "26") RS_BRANCH="0.14" ;; \
+          "28") RS_BRANCH="0.15" ;; \
+          *)    RS_BRANCH="main" ;; \
+        esac && \
+        \
+        # 7. Clone and build the targeted stable gst-plugins-rs branch \
+        export PKG_CONFIG_PATH="/usr/local/lib/${ARCH}-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib/${ARCH}-linux-gnu/pkgconfig:/usr/share/pkgconfig:${PKG_CONFIG_PATH:-}" && \
+        git clone --depth 1 --branch ${RS_BRANCH} https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git /tmp/gst-plugins-rs && \
+        cd /tmp/gst-plugins-rs && \
+        cargo cinstall -p gst-plugin-vvdec --prefix=/usr/local --libdir=/usr/local/lib/${ARCH}-linux-gnu && \
+        \
+        # 8. Refresh loader runtime cache and run post-build cleanup \
+        ldconfig && \
+        rm -rf /tmp/gst-plugins-rs ${RUSTUP_HOME} ${CARGO_HOME}; \
+      else \
+        echo "GStreamer version 1.${GST_MINOR} does not natively support the vvdec plugin. Skipping compilation smoothly."; \
+      fi; \
+    fi
+
 # Set library paths - /usr/local MUST come first to prioritize compiled versions
-ENV LD_LIBRARY_PATH=/usr/local/lib/x86_64-linux-gnu:/usr/local/lib:/usr/lib/x86_64-linux-gnu \
-    GST_PLUGIN_PATH=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0:/usr/local/lib/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0 \
-    PKG_CONFIG_PATH=/usr/local/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig \
+ENV LD_LIBRARY_PATH=/usr/local/lib/${ARCH}-linux-gnu:/usr/local/lib:/usr/lib/${ARCH}-linux-gnu \
+    GST_PLUGIN_PATH=/usr/local/lib/${ARCH}-linux-gnu/gstreamer-1.0:/usr/local/lib/gstreamer-1.0:/usr/lib/${ARCH}-linux-gnu/gstreamer-1.0 \
+    PKG_CONFIG_PATH=/usr/local/lib/${ARCH}-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib/${ARCH}-linux-gnu/pkgconfig \
     PATH=/usr/local/bin:/usr/bin:/bin
 
 COPY . /fluster/
@@ -361,8 +435,8 @@ RUN mkdir -p /fluster/resources /fluster/test_suites
 
 # Additional environment variables
 ENV PYTHONPATH=/fluster \
-    LIBVA_DRIVERS_PATH=/usr/lib/x86_64-linux-gnu/dri \
-    VDPAU_DRIVER_PATH=/usr/lib/x86_64-linux-gnu/vdpau \
+    LIBVA_DRIVERS_PATH=/usr/lib/${ARCH}-linux-gnu/dri \
+    VDPAU_DRIVER_PATH=/usr/lib/${ARCH}-linux-gnu/vdpau \
     MFX_HOME=/opt/intel/mediasdk \
     NVD_BACKEND=direct \
     GST_VA_ALL_DRIVERS=1 \
@@ -372,7 +446,7 @@ RUN echo "export DISPLAY=:0" >> /home/"${USERNAME}"/.profile
 
 # sshd doesn't inherit Docker's ENV in login sessions; SetEnv fixes that.
 RUN echo "SetEnv NVD_BACKEND=direct GST_VA_ALL_DRIVERS=1 GST_VAAPI_ALL_DRIVERS=1 DISPLAY=:0 \
-    LIBVA_DRIVERS_PATH=/usr/lib/x86_64-linux-gnu/dri VDPAU_DRIVER_PATH=/usr/lib/x86_64-linux-gnu/vdpau" \
+    LIBVA_DRIVERS_PATH=/usr/lib/${ARCH}-linux-gnu/dri VDPAU_DRIVER_PATH=/usr/lib/${ARCH}-linux-gnu/vdpau" \
     >> /etc/ssh/sshd_config
 
 COPY docker/hw-info.sh /usr/local/bin/hw-info

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,11 +61,19 @@ RUN apt-get update && apt-get install -y \
     pciutils \
     && rm -rf /var/lib/apt/lists/*
 
+# X11 and Wayland dependencies
+RUN apt-get update && apt-get install -y \
+    libwayland-client0 \
+    libwayland-cursor0 \
+    wayland-protocols \
+    libwayland-egl1
+
 # VAAPI support, Intel and AMD drivers
 RUN apt-get update && apt-get install -y \
     libva-dev \
     libva-drm2 \
     libva-x11-2 \
+    libva-wayland2 \
     vainfo \
     mesa-va-drivers \
     && (apt-get install -y i965-va-driver || true) \
@@ -136,6 +144,9 @@ RUN if [ "${FFMPEG_INSTALL_METHOD}" = "source" ]; then \
         libva-dev \
         libvdpau-dev \
         libvorbis-dev \
+        libdrm-dev \
+        libwayland-dev \
+        libxkbcommon-dev \
         libxcb1-dev \
         libxcb-shm0-dev \
         libxcb-xfixes0-dev \
@@ -289,6 +300,8 @@ RUN if [ "${GSTREAMER_INSTALL_METHOD}" = "source" ]; then \
         libxv-dev \
         libx11-xcb-dev \
         libdrm-dev \
+        libwayland-dev \
+        libxkbcommon-dev \
         libgudev-1.0-dev \
         libasound2-dev \
         libopus-dev \
@@ -456,7 +469,7 @@ ENV PYTHONPATH=/fluster \
 RUN echo "export DISPLAY=:0" >> /home/"${USERNAME}"/.profile
 
 # sshd doesn't inherit Docker's ENV in login sessions; SetEnv fixes that.
-RUN echo "SetEnv NVD_BACKEND=direct GST_VA_ALL_DRIVERS=1 GST_VAAPI_ALL_DRIVERS=1 DISPLAY=:0 \
+RUN echo "SetEnv NVD_BACKEND=direct GST_VA_ALL_DRIVERS=1 GST_VAAPI_ALL_DRIVERS=1 DISPLAY=:0 WAYLAND_DISPLAY=wayland-0 \
     LIBVA_DRIVERS_PATH=/usr/lib/${ARCH}-linux-gnu/dri VDPAU_DRIVER_PATH=/usr/lib/${ARCH}-linux-gnu/vdpau" \
     >> /etc/ssh/sshd_config
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -221,8 +221,10 @@ RUN if [ "${FFMPEG_INSTALL_METHOD}" = "source" ]; then \
       apt-get install -y --no-install-recommends \
         ffmpeg \
         libavcodec-dev \
+        libavfilter-dev \
         libavformat-dev \
         libavutil-dev \
+        libswresample-dev \
         libswscale-dev \
       && rm -rf /var/lib/apt/lists/*; \
     fi
@@ -237,9 +239,8 @@ RUN if [ "${GSTREAMER_INSTALL_METHOD}" = "source" ]; then \
       fi; \
     fi
 
-
 # Ubuntu 24.04: Remove default user
-RUN if [ "${UBUNTU_VERSION}" = "24.04" ] && id ubuntu &>/dev/null; then \
+RUN if [ "${UBUNTU_VERSION}" = "24.04" ] && id ubuntu >/dev/null 2>&1; then \
       userdel -r ubuntu; \
     fi
 
@@ -262,9 +263,6 @@ RUN if [ "${GSTREAMER_INSTALL_METHOD}" = "source" ] && [ "${UBUNTU_VERSION}" = "
 
 # GStreamer installation (2 methods: system, source)
 # Method "source": Build GStreamer from source (needed for new versions on old distros)
-#   Note: gst-libav is disabled when building from source to avoid FFmpeg API incompatibilities
-#         (GStreamer 1.24.x is not compatible with FFmpeg 7+/8+ APIs)
-#         Use GStreamer native decoders or FFmpeg directly for decoding.
 # Method "system": Install GStreamer from system packages (default)
 RUN if [ "${GSTREAMER_INSTALL_METHOD}" = "source" ]; then \
       sudo apt-get update && sudo apt-get install -y --no-install-recommends \
@@ -277,6 +275,10 @@ RUN if [ "${GSTREAMER_INSTALL_METHOD}" = "source" ]; then \
         flex \
         nasm \
         libglib2.0-dev \
+        # To avoid 1.24.12 compilation error
+        libsysprof-capture-4-dev \
+        # To avoid 1.24.12 runtime error
+        libsqlite3-dev \
         liborc-0.4-dev \
         libpthread-stubs0-dev \
         libva-dev \
@@ -311,12 +313,21 @@ RUN if [ "${GSTREAMER_INSTALL_METHOD}" = "source" ]; then \
          else \
            VAAPI_OPT=""; \
          fi \
-      && meson setup build \
+      && if [ "${FFMPEG_INSTALL_METHOD}" = "static" ]; \
+         then \
+           FFMPEG_FALLBACK="--force-fallback-for=FFmpeg,libavcodec,libavformat,libavutil,libavfilter,libswscale,libswresample"; \
+         else \
+           FFMPEG_FALLBACK=""; \
+         fi \
+      && PKG_CONFIG_PATH="/usr/local/lib/${ARCH}-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib/${ARCH}-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}" \
+         LD_LIBRARY_PATH="/usr/local/lib/${ARCH}-linux-gnu:/usr/local/lib:/usr/lib/${ARCH}-linux-gnu:${LD_LIBRARY_PATH:-}" \
+        meson setup build \
         --prefix=/usr/local \
         --buildtype=release \
         -Dgpl=enabled \
         -Dugly=enabled \
         ${VAAPI_OPT} \
+        ${FFMPEG_FALLBACK} \
         -Dlibav=enabled \
         -Dbase=enabled \
         -Dgood=enabled \

--- a/docker/run-docker.sh
+++ b/docker/run-docker.sh
@@ -49,9 +49,9 @@ Build Options:
   --build-gstreamer     Build GStreamer from source (useful for new versions on old distros)
   --gstreamer-version   Specify GStreamer version for --build-gstreamer (default: 1.24.2)
   --rebuild             Force rebuilding of Docker image
-  --intel               Optimize for Intel GPU (VAAPI + QuickSync)
-  --amd                 Optimize for AMD GPU (VAAPI + VDPAU)
-  --nvidia              Enable NVIDIA GPU (NVDEC/CUDA on Ubuntu 24.04, VDPAU/VAAPI)
+  --intel               Optimize for Intel GPU (VAAPI, VDPAU, QuickSync)
+  --amd                 Optimize for AMD GPU (VAAPI, VDPAU)
+  --nvidia              Optimize for NVIDIA GPU (NVDEC/CUDA on Ubuntu 24.04, VDPAU, VAAPI)
 
 Environment Variables:
   LIBVA_DRIVER_NAME     Override VAAPI driver (e.g., i965, iHD, radeonsi, nouveau)
@@ -229,11 +229,11 @@ done
 if [ $HAS_INTEL -eq 1 ]; then
     GPU_ENV="-e LIBVA_DRIVER_NAME=${LIBVA_DRIVER_NAME:-iHD}"
     GPU_ENV="$GPU_ENV -e VDPAU_DRIVER=${VDPAU_DRIVER:-va_gl}"
-    echo -e "${BLUE}Optimizing for Intel GPU (VAAPI + QuickSync)${NC}"
+    echo -e "${BLUE}Optimizing for Intel GPU (VAAPI, VDPAU, QuickSync)${NC}"
 elif [ $HAS_AMD -eq 1 ]; then
     GPU_ENV="-e LIBVA_DRIVER_NAME=${LIBVA_DRIVER_NAME:-radeonsi}"
     GPU_ENV="$GPU_ENV -e VDPAU_DRIVER=${VDPAU_DRIVER:-radeonsi}"
-    echo -e "${BLUE}Optimizing for AMD GPU (VAAPI + VDPAU)${NC}"
+    echo -e "${BLUE}Optimizing for AMD GPU (VAAPI, VDPAU)${NC}"
 fi
 
 if [ $HAS_NVIDIA -eq 1 ]; then
@@ -242,7 +242,7 @@ if [ $HAS_NVIDIA -eq 1 ]; then
         GPU_ENV="-e LIBVA_DRIVER_NAME=${LIBVA_DRIVER_NAME:-nouveau}"
     fi
     GPU_ENV="$GPU_ENV -e VDPAU_DRIVER=${VDPAU_DRIVER:-nvidia}"
-    echo -e "${BLUE}Enabling NVIDIA GPU (NVDEC/CUDA on Ubuntu 24.04, VDPAU/VAAPI)${NC}"
+    echo -e "${BLUE}Enabling NVIDIA GPU (NVDEC/CUDA on Ubuntu 24.04, VDPAU, VAAPI)${NC}"
 fi
 
 # Warn about dual GPU setups

--- a/docker/run-docker.sh
+++ b/docker/run-docker.sh
@@ -257,16 +257,29 @@ if [ -z "$GPU_ENV" ]; then
 fi
 
 # Prepare docker run command with volumes and GPU access
-DOCKER_RUN_OPTS="-it --rm --privileged --device=/dev/dri:/dev/dri"
-DOCKER_RUN_OPTS="$DOCKER_RUN_OPTS -v $PROJECT_ROOT/resources:/fluster/resources"
-DOCKER_RUN_OPTS="$DOCKER_RUN_OPTS -v $PROJECT_ROOT/test_suites:/fluster/test_suites"
-DOCKER_RUN_OPTS="$DOCKER_RUN_OPTS -e TERM=xterm-256color"
-DOCKER_RUN_OPTS="$DOCKER_RUN_OPTS -e LANG=C.UTF-8"
-DOCKER_RUN_OPTS="$DOCKER_RUN_OPTS -e LC_ALL=C.UTF-8"
-# X11 forwarding for VDPAU (requires Xvfb on host)
-[ -d /tmp/.X11-unix ] && DOCKER_RUN_OPTS="$DOCKER_RUN_OPTS -v /tmp/.X11-unix:/tmp/.X11-unix:rw -e DISPLAY=${DISPLAY:-:99}"
-[ -n "$GPU_ENV" ] && DOCKER_RUN_OPTS="$DOCKER_RUN_OPTS $GPU_ENV"
-DOCKER_RUN_OPTS="$DOCKER_RUN_OPTS --workdir /fluster"
+DOCKER_RUN_OPTS="-it --rm --privileged"
+DOCKER_RUN_OPTS+=" -v $PROJECT_ROOT/resources:/fluster/resources"
+DOCKER_RUN_OPTS+=" -v $PROJECT_ROOT/test_suites:/fluster/test_suites"
+DOCKER_RUN_OPTS+=" -e TERM=xterm-256color"
+DOCKER_RUN_OPTS+=" -e LANG=C.UTF-8"
+DOCKER_RUN_OPTS+=" -e LC_ALL=C.UTF-8"
+# GPU access
+DOCKER_RUN_OPTS+=" --device=/dev/dri:/dev/dri"
+# Display access for rendering
+DOCKER_RUN_OPTS+=" -e DISPLAY -e XDG_SESSION_TYPE -e XDG_RUNTIME_DIR"
+# Wayland display access (must for VDPAU initialization) (requires Xvfb on host)
+if [ -n "$XDG_RUNTIME_DIR" ] && [ -n "$WAYLAND_DISPLAY" ] && [ -e "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]; then
+    DOCKER_RUN_OPTS+=" -e WAYLAND_DISPLAY -v $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY:$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY"
+fi
+# X11 display access (must for VDPAU initialization) (requires Xvfb on host)
+DOCKER_RUN_OPTS+=" -v /tmp/.X11-unix:/tmp/.X11-unix:rw"
+# X11 authentication (.Xauthority), must for X11 and XWayland
+XAUTH="${XAUTHORITY:-$HOME/.Xauthority}"
+if [ -f "$XAUTH" ]; then
+    DOCKER_RUN_OPTS+=" -v $XAUTH:/tmp/.Xauthority:ro -e XAUTHORITY=/tmp/.Xauthority"
+fi
+[ -n "$GPU_ENV" ] && DOCKER_RUN_OPTS+=" $GPU_ENV"
+DOCKER_RUN_OPTS+=" --workdir /fluster"
 
 # Detect -k/--keep for run command to persist outputs by mounting /tmp/fluster_output
 FLUSTER_ARGS=("$@")
@@ -282,10 +295,10 @@ if [[ "$COMMAND" == "run" || "$COMMAND" == "r" ]]; then
         HOST_OUTPUT_DIR="$PROJECT_ROOT/fluster_output"
         CONTAINER_OUTPUT_DIR="/tmp/fluster_output"
         mkdir -p "$HOST_OUTPUT_DIR"
-        DOCKER_RUN_OPTS="$DOCKER_RUN_OPTS -v $HOST_OUTPUT_DIR:$CONTAINER_OUTPUT_DIR"
+        DOCKER_RUN_OPTS+=" -v $HOST_OUTPUT_DIR:$CONTAINER_OUTPUT_DIR"
         HOST_UID=$(id -u)
         HOST_GID=$(id -g)
-        DOCKER_RUN_OPTS="$DOCKER_RUN_OPTS -e HOST_UID=$HOST_UID -e HOST_GID=$HOST_GID"
+        DOCKER_RUN_OPTS+=" -e HOST_UID=$HOST_UID -e HOST_GID=$HOST_GID"
         POST_RUN_CHOWN="chown -R $HOST_UID:$HOST_GID $CONTAINER_OUTPUT_DIR >/dev/null 2>&1 || true"
         echo -e "${YELLOW}Persisting output files to host directory 'fluster_output/' (flag -k).${NC}"
     fi


### PR DESCRIPTION
Adding the following in the Dockerfile
- enable previously disabled libav plugins when compiling GStreamer from source
- compile vvdec from source when GStreamer 1.26.0 or above is requested
- enable access to X11 and Wayland displays