### PR TITLE
fix: Docker keep libunwind/libdw and propagate VAAPI env vars over SSH

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,15 +71,13 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # VAAPI driver for NVIDIA (Ubuntu 24.04+)
-# Built from source instead of "apt install nvidia-vaapi-driver": the Ubuntu
-# package defaults to the EGL backend, which is broken on NVIDIA driver
-# >=525 (upstream regression, see elFarto/nvidia-vaapi-driver#207 and
-# project README). The source build defaults to the "direct" backend
-# instead, which works correctly.
+# apt's nvidia-vaapi-driver defaults to the broken EGL backend (driver >=525,
+# elFarto/nvidia-vaapi-driver#207). Build from source instead (direct backend).
 RUN if [ "${UBUNTU_VERSION}" = "24.04" ]; then \
         apt-get update && \
         apt-get install -y meson ninja-build git pkg-config \
             libegl1-mesa-dev libgstreamer-plugins-bad1.0-dev && \
+        apt-mark manual libunwind8 libdw1t64 && \
         git clone --depth 1 --branch n12.2.72.0 https://github.com/FFmpeg/nv-codec-headers.git /tmp/nv-codec-headers && \
         make -C /tmp/nv-codec-headers install && \
         git clone --depth 1 --branch v0.0.17 https://github.com/elFarto/nvidia-vaapi-driver.git /tmp/nvidia-vaapi-driver && \
@@ -369,6 +367,9 @@ ENV PYTHONPATH=/fluster \
     NVD_BACKEND=direct \
     GST_VA_ALL_DRIVERS=1 \
     GST_VAAPI_ALL_DRIVERS=1
+
+# sshd doesn't inherit Docker's ENV in login sessions; SetEnv fixes that.
+RUN echo "SetEnv NVD_BACKEND=direct GST_VA_ALL_DRIVERS=1 GST_VAAPI_ALL_DRIVERS=1 LIBVA_DRIVERS_PATH=/usr/lib/x86_64-linux-gnu/dri" >> /etc/ssh/sshd_config
 
 COPY docker/hw-info.sh /usr/local/bin/hw-info
 RUN chmod +x /usr/local/bin/hw-info


### PR DESCRIPTION
`apt-mark manual` protects `libunwind8`/`libdw1t64` from a later `autoremove` (GStreamer's build step purges `libgstreamer`*, which incidentally matches our build-only dependency that pulled these in). Our separately-compiled `nvidia_drv_video.so` needs them at runtime and apt has no way to know that. Confirmed: without this, `vainfo/ffmpeg` failed with `libunwind.so.8: cannot open shared object file`.

On `docker run -e `instead of `SetEnv`: we tried that first (via the Dockerfile's ENV, same effect as **-e**) and it doesn't work, `sshd` doesn't pass its own environment down to the login sessions it spawns (OpenSSH design, to avoid leaking daemon-level vars to clients). Confirmed via `/proc/1/environ` (vars present) vs `env` inside an actual SSH session (empty). **SetEnv** in **sshd_config** is the only mechanism that applies at the right layer, the session, not the daemon.