### PR TITLE
OCP-7512 - Add AAC profiles to codec and all AAC test suites

### DIFF
--- a/fluster/codec.py
+++ b/fluster/codec.py
@@ -107,3 +107,12 @@ class Profile(Enum):
     ADVANCED_SIMPLE_PROFILE = "Advanced Simple Profile"
     SIMPLE_STUDIO_PROFILE = "Simple Studio Profile"
     ERROR_RESILIENT_SIMPLE_SCALABLE_PROFILE = "Error Resilient Simple Scalable Profile"
+
+    # AAC
+    AAC_MAIN = "AAC Main"
+    AAC_LC = "AAC Low Complexity"
+    AAC_SSR = "AAC Scalable Sampling Rate"
+    AAC_LTP = "AAC Long Term Prediction"
+    ER_AAC_LC = "Error Resilient AAC Low Complexity"
+    ER_AAC_ELD = "Error Resilient AAC Enhanced Low Delay"
+    ER_AAC_LD = "Error Resilient AAC Low Delay"

--- a/scripts/gen_aac.py
+++ b/scripts/gen_aac.py
@@ -28,7 +28,7 @@ from typing import Any, List, Optional, Tuple
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from fluster import utils
-from fluster.codec import Codec, OutputFormat
+from fluster.codec import Codec, OutputFormat, Profile
 from fluster.test_suite import TestSuite
 from fluster.test_vector import TestVector
 
@@ -199,7 +199,7 @@ class AACGenerator:
             # Calculate source file checksum
             test_vector.source_checksum = utils.file_checksum(dest_path)
 
-            # Extract sample format of input file using ffprobe
+            # Detect profile and sample format via ffprobe
             if self.use_ffprobe:
                 ffprobe = utils.normalize_binary_cmd("ffprobe")
                 command = [
@@ -209,17 +209,27 @@ class AACGenerator:
                     "-select_streams",
                     "a:0",
                     "-show_entries",
-                    "stream=sample_fmt",
+                    "stream=profile,sample_fmt",
                     "-of",
                     "default=nokey=1:noprint_wrappers=1",
                     absolute_input_path,
                 ]
+                probe_output = utils.run_command_with_output(command, check=False).splitlines()
 
-                sample_format = utils.run_command_with_output(command).splitlines()[0]
-                try:
-                    test_vector.output_format = OutputFormat[sample_format.upper()]
-                except KeyError as key_err:
-                    raise key_err
+                profile = probe_output[0] if len(probe_output) > 0 else None
+                sample_format = probe_output[1] if len(probe_output) > 1 else None
+
+                if profile:
+                    try:
+                        test_vector.profile = Profile[f"AAC_{profile.upper()}"]
+                    except KeyError:
+                        pass
+
+                if sample_format:
+                    try:
+                        test_vector.output_format = OutputFormat[sample_format.upper()]
+                    except KeyError as key_err:
+                        raise key_err
 
         absolute_output_filepath = os.path.join(absolute_dest_dir, output_filepath)
         test_suite.to_json_file(absolute_output_filepath)

--- a/test_suites/aac/MPEG2_AAC-ADIF.json
+++ b/test_suites/aac/MPEG2_AAC-ADIF.json
@@ -9,7 +9,8 @@
             "source_checksum": "973113459f08d1bee9aea20c222385e0",
             "input_file": "as15_22.adif",
             "output_format": "Unknown",
-            "result": "3845021412db78720068ec2dcd901fc3"
+            "result": "3845021412db78720068ec2dcd901fc3",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as17_24",
@@ -17,7 +18,8 @@
             "source_checksum": "3c9a034a4477d2cb8d1b80cb6a8ce63d",
             "input_file": "as17_24.adif",
             "output_format": "Unknown",
-            "result": "5ec07fb1254f038776533d41dd00e67e"
+            "result": "5ec07fb1254f038776533d41dd00e67e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al05_96",
@@ -25,7 +27,8 @@
             "source_checksum": "de5c0fc8b7a4bf7e8ea62186016e8979",
             "input_file": "al05_96.adif",
             "output_format": "Unknown",
-            "result": "d4dfff5dbf498aabb7ab71ebf71fc6de"
+            "result": "d4dfff5dbf498aabb7ab71ebf71fc6de",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14_44",
@@ -33,7 +36,8 @@
             "source_checksum": "22a44701fb7e519fa229a0d6b2b573b1",
             "input_file": "al14_44.adif",
             "output_format": "Unknown",
-            "result": "1ea3fc56401dc70963f7a6d7897a7377"
+            "result": "1ea3fc56401dc70963f7a6d7897a7377",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16_88",
@@ -41,7 +45,8 @@
             "source_checksum": "0c9e5ff43b8627e55cc30eabf7e59cd8",
             "input_file": "al16_88.adif",
             "output_format": "Unknown",
-            "result": "55c563d8df797e4c8d308796fb511311"
+            "result": "55c563d8df797e4c8d308796fb511311",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as12_88",
@@ -49,7 +54,8 @@
             "source_checksum": "29212b6f98abeb491e26f8b84c4fd835",
             "input_file": "as12_88.adif",
             "output_format": "Unknown",
-            "result": "ed0edb7557b7ddea6e180555346c8fa4"
+            "result": "ed0edb7557b7ddea6e180555346c8fa4",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am07_12",
@@ -57,7 +63,8 @@
             "source_checksum": "4c278383fa9edb672dc4791937a88594",
             "input_file": "am07_12.adif",
             "output_format": "Unknown",
-            "result": "3e31c667670cbef6cdf7ee86a3ae285d"
+            "result": "3e31c667670cbef6cdf7ee86a3ae285d",
+            "profile": "AAC Main"
         },
         {
             "name": "as17_16",
@@ -65,7 +72,8 @@
             "source_checksum": "07c341c77150a9550d133b9ef0a86674",
             "input_file": "as17_16.adif",
             "output_format": "Unknown",
-            "result": "1aeb35eba5cdc0541e08964402f9b281"
+            "result": "1aeb35eba5cdc0541e08964402f9b281",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08_88",
@@ -73,7 +81,8 @@
             "source_checksum": "760d1e584d7ef6616e51414ebc98ed7b",
             "input_file": "al08_88.adif",
             "output_format": "Unknown",
-            "result": "c7f958f10a167fb8fdc45b83b0777386"
+            "result": "c7f958f10a167fb8fdc45b83b0777386",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am07_48",
@@ -81,7 +90,8 @@
             "source_checksum": "0705453d99447b89ca3aa8c63dd50fa6",
             "input_file": "am07_48.adif",
             "output_format": "Unknown",
-            "result": "ee5d33f95ec836e851bf19c6ae7a211d"
+            "result": "ee5d33f95ec836e851bf19c6ae7a211d",
+            "profile": "AAC Main"
         },
         {
             "name": "as15_08",
@@ -89,7 +99,8 @@
             "source_checksum": "d714e621e508696f7cfd72e51c742a54",
             "input_file": "as15_08.adif",
             "output_format": "Unknown",
-            "result": "f48ab7fc21542d1d0caf92eacb51eee3"
+            "result": "f48ab7fc21542d1d0caf92eacb51eee3",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as11_16",
@@ -97,7 +108,8 @@
             "source_checksum": "b085503eb7499f4a7235c753f27dd099",
             "input_file": "as11_16.adif",
             "output_format": "Unknown",
-            "result": "d704c48a8c7a7aadbeb0ff2cd664b065"
+            "result": "d704c48a8c7a7aadbeb0ff2cd664b065",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06_88",
@@ -105,7 +117,8 @@
             "source_checksum": "2ed28cfe746636e188a633eeb413470b",
             "input_file": "al06_88.adif",
             "output_format": "Unknown",
-            "result": "4f1c2fd36e30363132d8ed96360e3b29"
+            "result": "4f1c2fd36e30363132d8ed96360e3b29",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am03_64",
@@ -113,7 +126,8 @@
             "source_checksum": "ac7639c87ac5ddd046c11095edd5d08c",
             "input_file": "am03_64.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "",
+            "profile": "AAC Main"
         },
         {
             "name": "as09_08",
@@ -121,7 +135,8 @@
             "source_checksum": "2c2fb6a58c972c1458a88c59b7ae237b",
             "input_file": "as09_08.adif",
             "output_format": "Unknown",
-            "result": "c90abb148c09f3fe5eb768fcd283213b"
+            "result": "c90abb148c09f3fe5eb768fcd283213b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06_96",
@@ -129,7 +144,8 @@
             "source_checksum": "84662ab811bfb9aacce7fe18b963ca1d",
             "input_file": "al06_96.adif",
             "output_format": "Unknown",
-            "result": "907f07b128d154b6eedd113c495a0473"
+            "result": "907f07b128d154b6eedd113c495a0473",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as11_08",
@@ -137,7 +153,8 @@
             "source_checksum": "540ada16b29d3e0b4a87a9c10d1ed2ec",
             "input_file": "as11_08.adif",
             "output_format": "Unknown",
-            "result": "c956ff0d8d65f1157da8db8704a1aa0f"
+            "result": "c956ff0d8d65f1157da8db8704a1aa0f",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as15_96",
@@ -145,7 +162,8 @@
             "source_checksum": "3ec8c4c9415b1830a5d804db4aa81e8c",
             "input_file": "as15_96.adif",
             "output_format": "Unknown",
-            "result": "4b65363c85dedf3aaf68e78c97abb2a4"
+            "result": "4b65363c85dedf3aaf68e78c97abb2a4",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as01_11",
@@ -153,7 +171,8 @@
             "source_checksum": "e552aa00b1800eee26b7372c62b4103c",
             "input_file": "as01_11.adif",
             "output_format": "Unknown",
-            "result": "bcdc702495729e0034fbb65cfea176ec"
+            "result": "bcdc702495729e0034fbb65cfea176ec",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am06_32",
@@ -161,7 +180,8 @@
             "source_checksum": "1475e6cd49ed90c4c5d05e4ad5e1da7d",
             "input_file": "am06_32.adif",
             "output_format": "Unknown",
-            "result": "4ef096224da763ac43090955d64cfba1"
+            "result": "4ef096224da763ac43090955d64cfba1",
+            "profile": "AAC Main"
         },
         {
             "name": "as01_44",
@@ -169,7 +189,8 @@
             "source_checksum": "af6d7e3f66bd1f435c541858c3a6ace6",
             "input_file": "as01_44.adif",
             "output_format": "Unknown",
-            "result": "341a1c0cbe9cfb820c5b8ac6ffba3504"
+            "result": "341a1c0cbe9cfb820c5b8ac6ffba3504",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al14_12",
@@ -177,7 +198,8 @@
             "source_checksum": "3870df37b1489d659e1195f6ce6a9ac1",
             "input_file": "al14_12.adif",
             "output_format": "Unknown",
-            "result": "0838992422e28225ee77bd8f50505d0a"
+            "result": "0838992422e28225ee77bd8f50505d0a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_16",
@@ -185,7 +207,8 @@
             "source_checksum": "628e504848bec348ffafa530c139ae1e",
             "input_file": "al04_16.adif",
             "output_format": "Unknown",
-            "result": "e9a74efa429e0d6ca38b2c59bdf61652"
+            "result": "e9a74efa429e0d6ca38b2c59bdf61652",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16_08",
@@ -193,7 +216,8 @@
             "source_checksum": "983e7b809b6080843cd953d755540eb3",
             "input_file": "al16_08.adif",
             "output_format": "Unknown",
-            "result": "830d1866388b7301c96146e0e0614397"
+            "result": "830d1866388b7301c96146e0e0614397",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as15_32",
@@ -201,7 +225,8 @@
             "source_checksum": "44c2bebaa5c276c1f636f09997e42a2b",
             "input_file": "as15_32.adif",
             "output_format": "Unknown",
-            "result": "b68d6ea8dd4223af7d1e57497aaea2e8"
+            "result": "b68d6ea8dd4223af7d1e57497aaea2e8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as12_32",
@@ -209,7 +234,8 @@
             "source_checksum": "1b73f5a5b52b0df9e11d1307170781b5",
             "input_file": "as12_32.adif",
             "output_format": "Unknown",
-            "result": "473779bf860222b0f5ba126f140ae89f"
+            "result": "473779bf860222b0f5ba126f140ae89f",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as08_48",
@@ -217,7 +243,8 @@
             "source_checksum": "0de5d45e2751d8ba2099c03d2f5897ea",
             "input_file": "as08_48.adif",
             "output_format": "Unknown",
-            "result": "a9e35a70084e01070ce82663131c4b97"
+            "result": "a9e35a70084e01070ce82663131c4b97",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al01_08",
@@ -225,7 +252,8 @@
             "source_checksum": "72d93896b76dcc73fc22d7b02ccda49f",
             "input_file": "al01_08.adif",
             "output_format": "Unknown",
-            "result": "341ba3ace921eb3a805d31cb5c69852a"
+            "result": "341ba3ace921eb3a805d31cb5c69852a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as16_32",
@@ -233,7 +261,8 @@
             "source_checksum": "d7990e721618f56105cf013952d4ed96",
             "input_file": "as16_32.adif",
             "output_format": "Unknown",
-            "result": "b4b3c045e136191c6d42df8fc352d3cf"
+            "result": "b4b3c045e136191c6d42df8fc352d3cf",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am01_08",
@@ -241,7 +270,8 @@
             "source_checksum": "c98dff5e8b6e432e4b760c3dbaf4e4a8",
             "input_file": "am01_08.adif",
             "output_format": "Unknown",
-            "result": "2fcc843014bca5b1ac137a5227478579"
+            "result": "2fcc843014bca5b1ac137a5227478579",
+            "profile": "AAC Main"
         },
         {
             "name": "as11_96",
@@ -249,7 +279,8 @@
             "source_checksum": "48b97673168a5c5e963b4f1594df7e13",
             "input_file": "as11_96.adif",
             "output_format": "Unknown",
-            "result": "3877801e23700673823b2678c93c8e3e"
+            "result": "3877801e23700673823b2678c93c8e3e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as01_22",
@@ -257,7 +288,8 @@
             "source_checksum": "374ecfe83db057a962ee023a55b6b5cb",
             "input_file": "as01_22.adif",
             "output_format": "Unknown",
-            "result": "575bde090656bf44b9b7d1031cc7b4ac"
+            "result": "575bde090656bf44b9b7d1031cc7b4ac",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as03_44",
@@ -265,7 +297,8 @@
             "source_checksum": "be1fe7e9a26df9824c89d5daae7d3599",
             "input_file": "as03_44.adif",
             "output_format": "Unknown",
-            "result": "b9d7b1fcf7a918ddf1cd51ef97314043"
+            "result": "b9d7b1fcf7a918ddf1cd51ef97314043",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al02_88",
@@ -273,7 +306,8 @@
             "source_checksum": "5e128b64b5af63935a40301ca6b1113f",
             "input_file": "al02_88.adif",
             "output_format": "Unknown",
-            "result": "ea940a21c761f8e87cb3b2b8ceb91ebd"
+            "result": "ea940a21c761f8e87cb3b2b8ceb91ebd",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_64",
@@ -281,7 +315,8 @@
             "source_checksum": "9e9c153d09af52d1488d2dfd5c653b6d",
             "input_file": "am00_64.adif",
             "output_format": "Unknown",
-            "result": "3fb7576e4821be816a5a20f373fe8779"
+            "result": "3fb7576e4821be816a5a20f373fe8779",
+            "profile": "AAC Main"
         },
         {
             "name": "al15_96",
@@ -289,7 +324,8 @@
             "source_checksum": "8503ac2de5f3c2b0f9bc946dd8ef5fae",
             "input_file": "al15_96.adif",
             "output_format": "Unknown",
-            "result": "ae85130efd90f5418c3c36fee8189e00"
+            "result": "ae85130efd90f5418c3c36fee8189e00",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08_24",
@@ -297,7 +333,8 @@
             "source_checksum": "1c78301297eed8088e1218c2c3e83660",
             "input_file": "al08_24.adif",
             "output_format": "Unknown",
-            "result": "25e9f186f207c855879a5f4a18686110"
+            "result": "25e9f186f207c855879a5f4a18686110",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as07_11",
@@ -305,7 +342,8 @@
             "source_checksum": "07def67b46e1779313933a3baa1635ad",
             "input_file": "as07_11.adif",
             "output_format": "Unknown",
-            "result": "e88a0c08a34fdcce2f9f917b871240e0"
+            "result": "e88a0c08a34fdcce2f9f917b871240e0",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am02_12",
@@ -313,7 +351,8 @@
             "source_checksum": "724abd826d9714603bdeacd89297c8a3",
             "input_file": "am02_12.adif",
             "output_format": "Unknown",
-            "result": "81e3ce4054eac8fc69e85c305aacee0a"
+            "result": "81e3ce4054eac8fc69e85c305aacee0a",
+            "profile": "AAC Main"
         },
         {
             "name": "am00_32",
@@ -321,7 +360,8 @@
             "source_checksum": "3be458cd387a67ad17f593fd3d00f87b",
             "input_file": "am00_32.adif",
             "output_format": "Unknown",
-            "result": "dff0a5b583b837e9b7586b54299dddba"
+            "result": "dff0a5b583b837e9b7586b54299dddba",
+            "profile": "AAC Main"
         },
         {
             "name": "as11_12",
@@ -329,7 +369,8 @@
             "source_checksum": "0d1a809e365766873b35878f326f0cda",
             "input_file": "as11_12.adif",
             "output_format": "Unknown",
-            "result": "3ce237e2c0b6e10f47d7c50c8938148b"
+            "result": "3ce237e2c0b6e10f47d7c50c8938148b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al07_11",
@@ -337,7 +378,8 @@
             "source_checksum": "fc8d76f27f177dfaed08cc3c734cd5c2",
             "input_file": "al07_11.adif",
             "output_format": "Unknown",
-            "result": "d4de30fb19a0873a2357523a21a7c11f"
+            "result": "d4de30fb19a0873a2357523a21a7c11f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01_22",
@@ -345,7 +387,8 @@
             "source_checksum": "a74c1ab5ebe080e351f72f41c8ffda50",
             "input_file": "al01_22.adif",
             "output_format": "Unknown",
-            "result": "bac71f1c4723760f6c595287d8e8f7a1"
+            "result": "bac71f1c4723760f6c595287d8e8f7a1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as11_11",
@@ -353,7 +396,8 @@
             "source_checksum": "8d931fbfbee067cc9952433b43dd3357",
             "input_file": "as11_11.adif",
             "output_format": "Unknown",
-            "result": "e9ffff20d1b7741befe645289ad0a79d"
+            "result": "e9ffff20d1b7741befe645289ad0a79d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al16_32",
@@ -361,7 +405,8 @@
             "source_checksum": "404a70a483710c0c1a2f7b4e9ae9e125",
             "input_file": "al16_32.adif",
             "output_format": "Unknown",
-            "result": "d5a7bb819c3da7edb65c802b1f06dd8d"
+            "result": "d5a7bb819c3da7edb65c802b1f06dd8d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am03_32",
@@ -369,7 +414,8 @@
             "source_checksum": "fa9ab0f94e2934e87762b273c373248a",
             "input_file": "am03_32.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "",
+            "profile": "AAC Main"
         },
         {
             "name": "as06_88",
@@ -377,7 +423,8 @@
             "source_checksum": "74ab3c39ab5d61042f38365f56abaa1f",
             "input_file": "as06_88.adif",
             "output_format": "Unknown",
-            "result": "d9fcaa849e98d43d5c9e1272cb45ed5a"
+            "result": "d9fcaa849e98d43d5c9e1272cb45ed5a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al16_11",
@@ -385,7 +432,8 @@
             "source_checksum": "d94fedfab1c1cf7c0e28b531be376601",
             "input_file": "al16_11.adif",
             "output_format": "Unknown",
-            "result": "db12a7bd65b38be3c2483a85f38e2247"
+            "result": "db12a7bd65b38be3c2483a85f38e2247",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as04_48",
@@ -393,7 +441,8 @@
             "source_checksum": "36c9d2324a728561b4e4e05c2a06e496",
             "input_file": "as04_48.adif",
             "output_format": "Unknown",
-            "result": "7ccf38ad07dce3b25b59283013770709"
+            "result": "7ccf38ad07dce3b25b59283013770709",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as15_88",
@@ -401,7 +450,8 @@
             "source_checksum": "63c123936bef41ff3090a6df4ce35382",
             "input_file": "as15_88.adif",
             "output_format": "Unknown",
-            "result": "6b658a186b7b45033d2ec0fce12379cd"
+            "result": "6b658a186b7b45033d2ec0fce12379cd",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al02_16",
@@ -409,7 +459,8 @@
             "source_checksum": "8d0403006c3925ba2737c1ceaf75c563",
             "input_file": "al02_16.adif",
             "output_format": "Unknown",
-            "result": "3895a8eb4c3f795f621c0591dac9e076"
+            "result": "3895a8eb4c3f795f621c0591dac9e076",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as07_96",
@@ -417,7 +468,8 @@
             "source_checksum": "26d0d2dbb0c155880d21f70b7a2c7c7a",
             "input_file": "as07_96.adif",
             "output_format": "Unknown",
-            "result": "a0e96752daf6523ef7b97ee65781e4a6"
+            "result": "a0e96752daf6523ef7b97ee65781e4a6",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as04_32",
@@ -425,7 +477,8 @@
             "source_checksum": "43f68a48e10577c3bb17c138ad65430a",
             "input_file": "as04_32.adif",
             "output_format": "Unknown",
-            "result": "5d727123f8f9b07c5e0eae9bf445b72e"
+            "result": "5d727123f8f9b07c5e0eae9bf445b72e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as11_88",
@@ -433,7 +486,8 @@
             "source_checksum": "2ce47d17798cdbfa92e68906d4f6973a",
             "input_file": "as11_88.adif",
             "output_format": "Unknown",
-            "result": "77b571d0663181c946c4707c98dda8fd"
+            "result": "77b571d0663181c946c4707c98dda8fd",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as14_96",
@@ -441,7 +495,8 @@
             "source_checksum": "2f696bac95f54675704cbdc03f6af605",
             "input_file": "as14_96.adif",
             "output_format": "Unknown",
-            "result": "cb972cdb4e5c63d467f7776fa3828699"
+            "result": "cb972cdb4e5c63d467f7776fa3828699",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am05_16",
@@ -449,7 +504,8 @@
             "source_checksum": "c179ce68743ccbe32eb9c0525604cfde",
             "input_file": "am05_16.adif",
             "output_format": "Unknown",
-            "result": "5064cca0c1dee59a214d9e20165af1e1"
+            "result": "5064cca0c1dee59a214d9e20165af1e1",
+            "profile": "AAC Main"
         },
         {
             "name": "as03_48",
@@ -457,7 +513,8 @@
             "source_checksum": "2ba4cf06b57bd65700ed1d147319c0c7",
             "input_file": "as03_48.adif",
             "output_format": "Unknown",
-            "result": "340d9fe3dc66b3a18d59d62df1d71954"
+            "result": "340d9fe3dc66b3a18d59d62df1d71954",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08_11",
@@ -465,7 +522,8 @@
             "source_checksum": "29221d97459370932770c22b16be666e",
             "input_file": "al08_11.adif",
             "output_format": "Unknown",
-            "result": "8f15c703a727432ceb9102ba19accc12"
+            "result": "8f15c703a727432ceb9102ba19accc12",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as08_08",
@@ -473,7 +531,8 @@
             "source_checksum": "2032ffba5befa139640339f924d37c77",
             "input_file": "as08_08.adif",
             "output_format": "Unknown",
-            "result": "e62bcd4999610e37ee6b257bc01542d9"
+            "result": "e62bcd4999610e37ee6b257bc01542d9",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am00_88",
@@ -481,7 +540,8 @@
             "source_checksum": "55be33373a7bc4505b919a0e1caef076",
             "input_file": "am00_88.adif",
             "output_format": "Unknown",
-            "result": "2c28bbe633abb0995a7d9d6b2bbd163c"
+            "result": "2c28bbe633abb0995a7d9d6b2bbd163c",
+            "profile": "AAC Main"
         },
         {
             "name": "al01_16",
@@ -489,7 +549,8 @@
             "source_checksum": "9392bf9c67380e4aa788d620c6d78b1e",
             "input_file": "al01_16.adif",
             "output_format": "Unknown",
-            "result": "e2f030fc972340b05f2519b282cdbac3"
+            "result": "e2f030fc972340b05f2519b282cdbac3",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al10_48",
@@ -497,7 +558,8 @@
             "source_checksum": "ef077bb618b412335f7373f1850b22aa",
             "input_file": "al10_48.adif",
             "output_format": "Unknown",
-            "result": "2f2c3edf206e466526c1a6f3bc2a41dd"
+            "result": "2f2c3edf206e466526c1a6f3bc2a41dd",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as17_96",
@@ -505,7 +567,8 @@
             "source_checksum": "7e193c8fee053788e4142d4494c122cc",
             "input_file": "as17_96.adif",
             "output_format": "Unknown",
-            "result": "e5b7d4506a2a7e476c5e173afcf19226"
+            "result": "e5b7d4506a2a7e476c5e173afcf19226",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al04_22",
@@ -513,7 +576,8 @@
             "source_checksum": "21192bb9ae3f4670183b53c7882cd9e3",
             "input_file": "al04_22.adif",
             "output_format": "Unknown",
-            "result": "4fc2b48d87982cf7a70e12d167d3c1dd"
+            "result": "4fc2b48d87982cf7a70e12d167d3c1dd",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as10_08",
@@ -521,7 +585,8 @@
             "source_checksum": "70cba3170e4e72dcdc7ef441e1988ee0",
             "input_file": "as10_08.adif",
             "output_format": "Unknown",
-            "result": "4e6e445af75a79b600f4759c45dca3c8"
+            "result": "4e6e445af75a79b600f4759c45dca3c8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as14_16",
@@ -529,7 +594,8 @@
             "source_checksum": "a7a0808170a07b1bf6d80c0143da9ec2",
             "input_file": "as14_16.adif",
             "output_format": "Unknown",
-            "result": "481c7a271bd4621dac6475e038a66998"
+            "result": "481c7a271bd4621dac6475e038a66998",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as13_16",
@@ -537,7 +603,8 @@
             "source_checksum": "2efff7c432e06a50d8802d0fcb9e9a81",
             "input_file": "as13_16.adif",
             "output_format": "Unknown",
-            "result": "a4c66f7b5287477f02e2e46482b93fd2"
+            "result": "a4c66f7b5287477f02e2e46482b93fd2",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al14_32",
@@ -545,7 +612,8 @@
             "source_checksum": "2e21528599362b81050e11a6466080b4",
             "input_file": "al14_32.adif",
             "output_format": "Unknown",
-            "result": "72f133b209330a1f080383a4023dd753"
+            "result": "72f133b209330a1f080383a4023dd753",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as16_22",
@@ -553,7 +621,8 @@
             "source_checksum": "edb4039d3bf55825ae8630a97270e398",
             "input_file": "as16_22.adif",
             "output_format": "Unknown",
-            "result": "02856cceb12e9637bb98fc210daf193b"
+            "result": "02856cceb12e9637bb98fc210daf193b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am06_48",
@@ -561,7 +630,8 @@
             "source_checksum": "1cc2e1231962e87ab3f04461fb352cb7",
             "input_file": "am06_48.adif",
             "output_format": "Unknown",
-            "result": "a2c5debfac5d778137cff876f8787bb2"
+            "result": "a2c5debfac5d778137cff876f8787bb2",
+            "profile": "AAC Main"
         },
         {
             "name": "al07_48",
@@ -569,7 +639,8 @@
             "source_checksum": "81f4775c6ee2bde4c826de960087b415",
             "input_file": "al07_48.adif",
             "output_format": "Unknown",
-            "result": "70d924177e92b84d441cc00df378b2c0"
+            "result": "70d924177e92b84d441cc00df378b2c0",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am06_08",
@@ -577,7 +648,8 @@
             "source_checksum": "338dcd98cded8c3f528d369a5479aaf3",
             "input_file": "am06_08.adif",
             "output_format": "Unknown",
-            "result": "d164df2cf24ddf609c46a31a74e69f99"
+            "result": "d164df2cf24ddf609c46a31a74e69f99",
+            "profile": "AAC Main"
         },
         {
             "name": "as13_44",
@@ -585,7 +657,8 @@
             "source_checksum": "0ccd6dafe771f131a0d30a96d124511d",
             "input_file": "as13_44.adif",
             "output_format": "Unknown",
-            "result": "14888c909d35b55e76edfb2696f5c0d9"
+            "result": "14888c909d35b55e76edfb2696f5c0d9",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as17_88",
@@ -593,7 +666,8 @@
             "source_checksum": "c69ef051f916a2c1c131881b00c01832",
             "input_file": "as17_88.adif",
             "output_format": "Unknown",
-            "result": "3bf98e171d2dec7242e96170d718c2f7"
+            "result": "3bf98e171d2dec7242e96170d718c2f7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as13_96",
@@ -601,7 +675,8 @@
             "source_checksum": "d25700c8344a570cfd7be6bf220b6a93",
             "input_file": "as13_96.adif",
             "output_format": "Unknown",
-            "result": "4b65363c85dedf3aaf68e78c97abb2a4"
+            "result": "4b65363c85dedf3aaf68e78c97abb2a4",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as13_11",
@@ -609,7 +684,8 @@
             "source_checksum": "cff2c379277e92d2799d8eeb76f77578",
             "input_file": "as13_11.adif",
             "output_format": "Unknown",
-            "result": "6c6115066d647d5409a2c2fa9d6f6329"
+            "result": "6c6115066d647d5409a2c2fa9d6f6329",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al10_11",
@@ -617,7 +693,8 @@
             "source_checksum": "a7a47614df6c54beec2d743a049a3277",
             "input_file": "al10_11.adif",
             "output_format": "Unknown",
-            "result": "84a10f63ba5870201172712e9284702a"
+            "result": "84a10f63ba5870201172712e9284702a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as03_64",
@@ -625,7 +702,8 @@
             "source_checksum": "4630f9e041b11a0f6a39249f90860ce4",
             "input_file": "as03_64.adif",
             "output_format": "Unknown",
-            "result": "4309816d3606d6c508746f843df54599"
+            "result": "4309816d3606d6c508746f843df54599",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al07_88",
@@ -633,7 +711,8 @@
             "source_checksum": "d141d21c99cafc3b72005b7773a96aa5",
             "input_file": "al07_88.adif",
             "output_format": "Unknown",
-            "result": "dfe19829b88062d92c52c209e41153c3"
+            "result": "dfe19829b88062d92c52c209e41153c3",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05_44",
@@ -641,7 +720,8 @@
             "source_checksum": "a165e5273bb7eb719089fe8ddfd820f2",
             "input_file": "al05_44.adif",
             "output_format": "Unknown",
-            "result": "33f981c92cde037b3941040e2ae8bafa"
+            "result": "33f981c92cde037b3941040e2ae8bafa",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as00_16",
@@ -649,7 +729,8 @@
             "source_checksum": "21eb98b691addda9edcfccd10a17c94b",
             "input_file": "as00_16.adif",
             "output_format": "Unknown",
-            "result": "3fca6788dceea0bfdb8629150d30a0a4"
+            "result": "3fca6788dceea0bfdb8629150d30a0a4",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am01_11",
@@ -657,7 +738,8 @@
             "source_checksum": "6bfcef3f5ce0f22232fc28520e43f516",
             "input_file": "am01_11.adif",
             "output_format": "Unknown",
-            "result": "104361bdcc1b9d4d24e5863e2c35e050"
+            "result": "104361bdcc1b9d4d24e5863e2c35e050",
+            "profile": "AAC Main"
         },
         {
             "name": "as17_08",
@@ -665,7 +747,8 @@
             "source_checksum": "059782358d221faac763a6c270d2da94",
             "input_file": "as17_08.adif",
             "output_format": "Unknown",
-            "result": "43e5ba87c26f08d32b8b89469c9a3d7e"
+            "result": "43e5ba87c26f08d32b8b89469c9a3d7e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am04_44",
@@ -673,7 +756,8 @@
             "source_checksum": "2cd0217b1e1ea822e7894ea67efd111b",
             "input_file": "am04_44.adif",
             "output_format": "Unknown",
-            "result": "6b124b1f9b0d8b5942b803db436ba439"
+            "result": "6b124b1f9b0d8b5942b803db436ba439",
+            "profile": "AAC Main"
         },
         {
             "name": "as13_24",
@@ -681,7 +765,8 @@
             "source_checksum": "c04efbbd3ab66080b2a06f5f77dfc067",
             "input_file": "as13_24.adif",
             "output_format": "Unknown",
-            "result": "02bfc42a74201206630237e4c7ad381e"
+            "result": "02bfc42a74201206630237e4c7ad381e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al07_08",
@@ -689,7 +774,8 @@
             "source_checksum": "20bcf96171efdc4a554133336b65f3ed",
             "input_file": "al07_08.adif",
             "output_format": "Unknown",
-            "result": "eaac5252e1c57e7572110d69f4256a22"
+            "result": "eaac5252e1c57e7572110d69f4256a22",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as10_32",
@@ -697,7 +783,8 @@
             "source_checksum": "fcbfa2eeba126394b35f1ad96c0232c4",
             "input_file": "as10_32.adif",
             "output_format": "Unknown",
-            "result": "ab0ddce25aaa8554c5eec91b10c0c546"
+            "result": "ab0ddce25aaa8554c5eec91b10c0c546",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al00_12",
@@ -705,7 +792,8 @@
             "source_checksum": "27ba3b8d0d1be447640d018c5b2fd147",
             "input_file": "al00_12.adif",
             "output_format": "Unknown",
-            "result": "1003860d480d488f2093171008643ca2"
+            "result": "1003860d480d488f2093171008643ca2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as03_12",
@@ -713,7 +801,8 @@
             "source_checksum": "a3d86163d27462157df0f2b25e648c29",
             "input_file": "as03_12.adif",
             "output_format": "Unknown",
-            "result": "abe28e655b5db49b04de9ea99b431e4e"
+            "result": "abe28e655b5db49b04de9ea99b431e4e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as03_88",
@@ -721,7 +810,8 @@
             "source_checksum": "b230fa4c0be87fb2b3f14b9bb6635b8f",
             "input_file": "as03_88.adif",
             "output_format": "Unknown",
-            "result": "7c1d95a7d4e0291f22079effbf894a78"
+            "result": "7c1d95a7d4e0291f22079effbf894a78",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am01_96",
@@ -729,7 +819,8 @@
             "source_checksum": "f8a86e9fc00e991edc14d197b53b1474",
             "input_file": "am01_96.adif",
             "output_format": "Unknown",
-            "result": "12ea7bf04bce95c5c3ae286b17f6907e"
+            "result": "12ea7bf04bce95c5c3ae286b17f6907e",
+            "profile": "AAC Main"
         },
         {
             "name": "as14_24",
@@ -737,7 +828,8 @@
             "source_checksum": "b7e1f50d540403a71153a3b5d2c02674",
             "input_file": "as14_24.adif",
             "output_format": "Unknown",
-            "result": "9576e0ff192755ea369507485c58279e"
+            "result": "9576e0ff192755ea369507485c58279e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am04_64",
@@ -745,7 +837,8 @@
             "source_checksum": "cec91a4c806b6b73dfc3241f62e840e9",
             "input_file": "am04_64.adif",
             "output_format": "Unknown",
-            "result": "9526a9dca60fba036bb04ad28e8deacc"
+            "result": "9526a9dca60fba036bb04ad28e8deacc",
+            "profile": "AAC Main"
         },
         {
             "name": "al07_44",
@@ -753,7 +846,8 @@
             "source_checksum": "8fb33e40c8ef874454fd515dd7d5f183",
             "input_file": "al07_44.adif",
             "output_format": "Unknown",
-            "result": "70d924177e92b84d441cc00df378b2c0"
+            "result": "70d924177e92b84d441cc00df378b2c0",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as13_32",
@@ -761,7 +855,8 @@
             "source_checksum": "77b537b1e3a2c9fca87f0b61b72d7933",
             "input_file": "as13_32.adif",
             "output_format": "Unknown",
-            "result": "b68d6ea8dd4223af7d1e57497aaea2e8"
+            "result": "b68d6ea8dd4223af7d1e57497aaea2e8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am02_88",
@@ -769,7 +864,8 @@
             "source_checksum": "ea11c15002bc0ce36cbd25a61c6a5993",
             "input_file": "am02_88.adif",
             "output_format": "Unknown",
-            "result": "4fe01b15aaf82e7121652ffffb489d36"
+            "result": "4fe01b15aaf82e7121652ffffb489d36",
+            "profile": "AAC Main"
         },
         {
             "name": "al14_96",
@@ -777,7 +873,8 @@
             "source_checksum": "792dc57b8b5017a7cb53610c38133d1e",
             "input_file": "al14_96.adif",
             "output_format": "Unknown",
-            "result": "ab6c0c02ab8224bc5f126264ee403a42"
+            "result": "ab6c0c02ab8224bc5f126264ee403a42",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am03_44",
@@ -785,7 +882,8 @@
             "source_checksum": "d952f2d29163e60a599df1e82865e633",
             "input_file": "am03_44.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "",
+            "profile": "AAC Main"
         },
         {
             "name": "al01_44",
@@ -793,7 +891,8 @@
             "source_checksum": "0ea2cad65977cceb8ed6e21addb15ded",
             "input_file": "al01_44.adif",
             "output_format": "Unknown",
-            "result": "0ac8f10d9023e838fd99b79fbd158eab"
+            "result": "0ac8f10d9023e838fd99b79fbd158eab",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am03_12",
@@ -801,7 +900,8 @@
             "source_checksum": "2f86ee7f89c2c739b55bacd51f0d380b",
             "input_file": "am03_12.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "",
+            "profile": "AAC Main"
         },
         {
             "name": "as15_64",
@@ -809,7 +909,8 @@
             "source_checksum": "fab782be3635222fdacc2c1d6b7ffb04",
             "input_file": "as15_64.adif",
             "output_format": "Unknown",
-            "result": "9f960c8f0636c7a90bba45ca0cb95de0"
+            "result": "9f960c8f0636c7a90bba45ca0cb95de0",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al00_88",
@@ -817,7 +918,8 @@
             "source_checksum": "f1b80753bffbc0cb90800cb5ae7a30d6",
             "input_file": "al00_88.adif",
             "output_format": "Unknown",
-            "result": "70118d5e3c508f4709d4944e098c1c9b"
+            "result": "70118d5e3c508f4709d4944e098c1c9b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16_22",
@@ -825,7 +927,8 @@
             "source_checksum": "eaf6160cd413973ba94a6c3c2698c92d",
             "input_file": "al16_22.adif",
             "output_format": "Unknown",
-            "result": "d764858d2fa96357a3214bbb34d75224"
+            "result": "d764858d2fa96357a3214bbb34d75224",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as01_96",
@@ -833,7 +936,8 @@
             "source_checksum": "1b379e22176737c08a7247f1df30f31b",
             "input_file": "as01_96.adif",
             "output_format": "Unknown",
-            "result": "27786e9b7d83abafd8c0bff805d429b9"
+            "result": "27786e9b7d83abafd8c0bff805d429b9",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al10_96",
@@ -841,7 +945,8 @@
             "source_checksum": "b9b90fc331eb062e8a58dcf4d138c48c",
             "input_file": "al10_96.adif",
             "output_format": "Unknown",
-            "result": "683fbd00d9dcf296f014bb62fd180f1d"
+            "result": "683fbd00d9dcf296f014bb62fd180f1d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al10_08",
@@ -849,7 +954,8 @@
             "source_checksum": "091edfc078279bd603cd271ee2701206",
             "input_file": "al10_08.adif",
             "output_format": "Unknown",
-            "result": "667e14ac5c9fd1183f1f243e23947939"
+            "result": "667e14ac5c9fd1183f1f243e23947939",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_96",
@@ -857,7 +963,8 @@
             "source_checksum": "88ac1a9710fff86f8b8e2a2d63d28b35",
             "input_file": "am00_96.adif",
             "output_format": "Unknown",
-            "result": "60095c11878cfbedd806518168312f3d"
+            "result": "60095c11878cfbedd806518168312f3d",
+            "profile": "AAC Main"
         },
         {
             "name": "as06_12",
@@ -865,7 +972,8 @@
             "source_checksum": "2ab530176b6ddbe5ece2bbf80fad0e0f",
             "input_file": "as06_12.adif",
             "output_format": "Unknown",
-            "result": "adaa0667e7581ff3d6f56ba40bb1c457"
+            "result": "adaa0667e7581ff3d6f56ba40bb1c457",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am06_88",
@@ -873,7 +981,8 @@
             "source_checksum": "7194a61412f153fc0582ba81d817da1d",
             "input_file": "am06_88.adif",
             "output_format": "Unknown",
-            "result": "e6494513d14046b56ab2ca98def4d2ca"
+            "result": "e6494513d14046b56ab2ca98def4d2ca",
+            "profile": "AAC Main"
         },
         {
             "name": "al05_64",
@@ -881,7 +990,8 @@
             "source_checksum": "62b9321e187a67c0fcb79c38d6fac2df",
             "input_file": "al05_64.adif",
             "output_format": "Unknown",
-            "result": "fd32fac5c93040674baf30e5ebf57c52"
+            "result": "fd32fac5c93040674baf30e5ebf57c52",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as12_24",
@@ -889,7 +999,8 @@
             "source_checksum": "d3df57fdd36a9a36ab85baba1b8132c5",
             "input_file": "as12_24.adif",
             "output_format": "Unknown",
-            "result": "cfabdc64e2e652806354ed8b821690c5"
+            "result": "cfabdc64e2e652806354ed8b821690c5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as07_32",
@@ -897,7 +1008,8 @@
             "source_checksum": "471ecadda7593e19e078c126a7ab3b82",
             "input_file": "as07_32.adif",
             "output_format": "Unknown",
-            "result": "0915e1fbc77e87737d528a0c43051124"
+            "result": "0915e1fbc77e87737d528a0c43051124",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am05_24",
@@ -905,7 +1017,8 @@
             "source_checksum": "cd8ea7bbdb10df386596da86d68a2f6d",
             "input_file": "am05_24.adif",
             "output_format": "Unknown",
-            "result": "938c26465f99f8c49948a749e3549f96"
+            "result": "938c26465f99f8c49948a749e3549f96",
+            "profile": "AAC Main"
         },
         {
             "name": "as02_44",
@@ -913,7 +1026,8 @@
             "source_checksum": "6333226b0730d35be6fa587ee77be123",
             "input_file": "as02_44.adif",
             "output_format": "Unknown",
-            "result": "1d3d1e73b19feeb4ecbe4a702a4361dc"
+            "result": "1d3d1e73b19feeb4ecbe4a702a4361dc",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am03_16",
@@ -921,7 +1035,8 @@
             "source_checksum": "136c778c455d2f06327875be6af96f2e",
             "input_file": "am03_16.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "",
+            "profile": "AAC Main"
         },
         {
             "name": "am00_12",
@@ -929,7 +1044,8 @@
             "source_checksum": "4bcafc3db934eea2555383c7cdb575bc",
             "input_file": "am00_12.adif",
             "output_format": "Unknown",
-            "result": "2365631d91808e0aaf921944dd078466"
+            "result": "2365631d91808e0aaf921944dd078466",
+            "profile": "AAC Main"
         },
         {
             "name": "al17_08",
@@ -937,7 +1053,8 @@
             "source_checksum": "d88c04ad6a3140a58c2bd66c9f95f28c",
             "input_file": "al17_08.adif",
             "output_format": "Unknown",
-            "result": "9ce0c79e5a3b97ba1cd7f9051b9cb813"
+            "result": "9ce0c79e5a3b97ba1cd7f9051b9cb813",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01_12",
@@ -945,7 +1062,8 @@
             "source_checksum": "6e999ac94a3dd9ec0a3c6895fc484bac",
             "input_file": "al01_12.adif",
             "output_format": "Unknown",
-            "result": "1bf3c602a298c1b7b2f65080c83d4b49"
+            "result": "1bf3c602a298c1b7b2f65080c83d4b49",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as01_64",
@@ -953,7 +1071,8 @@
             "source_checksum": "aa4924767047ea38ad277c5b8c0346db",
             "input_file": "as01_64.adif",
             "output_format": "Unknown",
-            "result": "a94e930b4474e51dffb012d46af338d5"
+            "result": "a94e930b4474e51dffb012d46af338d5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al11_08",
@@ -961,7 +1080,8 @@
             "source_checksum": "5d0a4f363fcac705522c185fdc7ef9ad",
             "input_file": "al11_08.adif",
             "output_format": "Unknown",
-            "result": "ccea2c92561ddbf2e798fbfa14dc46bb"
+            "result": "ccea2c92561ddbf2e798fbfa14dc46bb",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as02_08",
@@ -969,7 +1089,8 @@
             "source_checksum": "51b7a069765a38b8ba1a32d12c9adb3a",
             "input_file": "as02_08.adif",
             "output_format": "Unknown",
-            "result": "19b5d8f467aac0f0f9c3cd5b841f392e"
+            "result": "19b5d8f467aac0f0f9c3cd5b841f392e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08_12",
@@ -977,7 +1098,8 @@
             "source_checksum": "64a84baa2e725cb9393a4c487a9b49aa",
             "input_file": "al08_12.adif",
             "output_format": "Unknown",
-            "result": "85695b2defca606c821ed77f12a3d491"
+            "result": "85695b2defca606c821ed77f12a3d491",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am02_64",
@@ -985,7 +1107,8 @@
             "source_checksum": "0bda098d9898033a46f48e2720c78ccf",
             "input_file": "am02_64.adif",
             "output_format": "Unknown",
-            "result": "f2a0570e3ee6227c76d2b151cf959347"
+            "result": "f2a0570e3ee6227c76d2b151cf959347",
+            "profile": "AAC Main"
         },
         {
             "name": "al05_08",
@@ -993,7 +1116,8 @@
             "source_checksum": "44dfe04e6ae3afc18cbfbf20816e626f",
             "input_file": "al05_08.adif",
             "output_format": "Unknown",
-            "result": "0af6ed73f0e59937b0ffff6da27a9bc8"
+            "result": "0af6ed73f0e59937b0ffff6da27a9bc8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as01_88",
@@ -1001,7 +1125,8 @@
             "source_checksum": "4229e961f46e211815254a2c7a96fde6",
             "input_file": "as01_88.adif",
             "output_format": "Unknown",
-            "result": "537a0a3189c650bc1d9e06011f636b26"
+            "result": "537a0a3189c650bc1d9e06011f636b26",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as06_08",
@@ -1009,7 +1134,8 @@
             "source_checksum": "a90338f833cbe20bc93b646d9f960f55",
             "input_file": "as06_08.adif",
             "output_format": "Unknown",
-            "result": "555df93edaf95cbe5197e493659311f0"
+            "result": "555df93edaf95cbe5197e493659311f0",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as10_44",
@@ -1017,7 +1143,8 @@
             "source_checksum": "3a3bd577479896764e5846773b0d12b4",
             "input_file": "as10_44.adif",
             "output_format": "Unknown",
-            "result": "66442b358ffc0b17ff458ebcb910a78d"
+            "result": "66442b358ffc0b17ff458ebcb910a78d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am02_44",
@@ -1025,7 +1152,8 @@
             "source_checksum": "65e81cad01a0e6af123a9bef9799a280",
             "input_file": "am02_44.adif",
             "output_format": "Unknown",
-            "result": "a6411c703a1ac140889d5eb6dd0d9bf1"
+            "result": "a6411c703a1ac140889d5eb6dd0d9bf1",
+            "profile": "AAC Main"
         },
         {
             "name": "al14_11",
@@ -1033,7 +1161,8 @@
             "source_checksum": "cbebdea1e1fb02303ef6a49b039ee77f",
             "input_file": "al14_11.adif",
             "output_format": "Unknown",
-            "result": "e0f68df4182839866feb36ec0dfa23a2"
+            "result": "e0f68df4182839866feb36ec0dfa23a2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17_64",
@@ -1041,7 +1170,8 @@
             "source_checksum": "d7ac48c5e94a457802956ad7843de4aa",
             "input_file": "al17_64.adif",
             "output_format": "Unknown",
-            "result": "9c3bc834d40d27a441ab80ae72eda8c4"
+            "result": "9c3bc834d40d27a441ab80ae72eda8c4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as07_08",
@@ -1049,7 +1179,8 @@
             "source_checksum": "7da1536b27398aeb95abea0b07356574",
             "input_file": "as07_08.adif",
             "output_format": "Unknown",
-            "result": "4374f44fca297d68a85e64e1c2ad591d"
+            "result": "4374f44fca297d68a85e64e1c2ad591d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as06_64",
@@ -1057,7 +1188,8 @@
             "source_checksum": "d135dafc5671184c6209da8d6762c7b0",
             "input_file": "as06_64.adif",
             "output_format": "Unknown",
-            "result": "b269ccbec78278261e9f9d829366b686"
+            "result": "b269ccbec78278261e9f9d829366b686",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as13_64",
@@ -1065,7 +1197,8 @@
             "source_checksum": "332cef51a6bd356e0543c787170e2a01",
             "input_file": "as13_64.adif",
             "output_format": "Unknown",
-            "result": "9f960c8f0636c7a90bba45ca0cb95de0"
+            "result": "9f960c8f0636c7a90bba45ca0cb95de0",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al14_08",
@@ -1073,7 +1206,8 @@
             "source_checksum": "23ff9b844b6e74c3403376c3db1399f3",
             "input_file": "al14_08.adif",
             "output_format": "Unknown",
-            "result": "c25a053760f16d8340be000648f0a426"
+            "result": "c25a053760f16d8340be000648f0a426",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as15_12",
@@ -1081,7 +1215,8 @@
             "source_checksum": "d0b0206d412294f9213da07403d85e26",
             "input_file": "as15_12.adif",
             "output_format": "Unknown",
-            "result": "971a2bff11d06bc3c578efda34aefa4b"
+            "result": "971a2bff11d06bc3c578efda34aefa4b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as10_11",
@@ -1089,7 +1224,8 @@
             "source_checksum": "9b04af39e3e363be4aefe1fb6283620e",
             "input_file": "as10_11.adif",
             "output_format": "Unknown",
-            "result": "48faf4c4165ff42a3ed86f7102e266f6"
+            "result": "48faf4c4165ff42a3ed86f7102e266f6",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al17_32",
@@ -1097,7 +1233,8 @@
             "source_checksum": "e2e7edc8ae817bd03b41757909a39b07",
             "input_file": "al17_32.adif",
             "output_format": "Unknown",
-            "result": "fb0aaa3f83522df7406f67744aa5ac0f"
+            "result": "fb0aaa3f83522df7406f67744aa5ac0f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as09_24",
@@ -1105,7 +1242,8 @@
             "source_checksum": "ecde57ece173d963040f160088f9826d",
             "input_file": "as09_24.adif",
             "output_format": "Unknown",
-            "result": "851b0946a36ffb0d4d309c2a4010ec9b"
+            "result": "851b0946a36ffb0d4d309c2a4010ec9b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as00_11",
@@ -1113,7 +1251,8 @@
             "source_checksum": "d72dc24367e405b6709ea7b8875b4f2c",
             "input_file": "as00_11.adif",
             "output_format": "Unknown",
-            "result": "3629580db303963cdea8dc8d3ecc28e1"
+            "result": "3629580db303963cdea8dc8d3ecc28e1",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as10_12",
@@ -1121,7 +1260,8 @@
             "source_checksum": "61b5be53000e5a6cf676481ced6ede24",
             "input_file": "as10_12.adif",
             "output_format": "Unknown",
-            "result": "f057d8a0ad40f59015672c8d713d44ee"
+            "result": "f057d8a0ad40f59015672c8d713d44ee",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as09_12",
@@ -1129,7 +1269,8 @@
             "source_checksum": "8122b895d9fa0577ad3eef9b62697b96",
             "input_file": "as09_12.adif",
             "output_format": "Unknown",
-            "result": "ec6dc14c20693f61c10844ed800a375d"
+            "result": "ec6dc14c20693f61c10844ed800a375d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as12_12",
@@ -1137,7 +1278,8 @@
             "source_checksum": "25ff13144c947506b4ef6bd01e7a0372",
             "input_file": "as12_12.adif",
             "output_format": "Unknown",
-            "result": "bda16028a6bf0f84d2466e3689bf73bb"
+            "result": "bda16028a6bf0f84d2466e3689bf73bb",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am05_96",
@@ -1145,7 +1287,8 @@
             "source_checksum": "a07b6a477935908696a1a8754435dd7b",
             "input_file": "am05_96.adif",
             "output_format": "Unknown",
-            "result": "c07028fc7e64703ba94ba863fcb14802"
+            "result": "c07028fc7e64703ba94ba863fcb14802",
+            "profile": "AAC Main"
         },
         {
             "name": "as17_11",
@@ -1153,7 +1296,8 @@
             "source_checksum": "e5ef54402a2fe8ca131381d219379ab7",
             "input_file": "as17_11.adif",
             "output_format": "Unknown",
-            "result": "300e847b3b81826305e6b4c6dc611235"
+            "result": "300e847b3b81826305e6b4c6dc611235",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al11_12",
@@ -1161,7 +1305,8 @@
             "source_checksum": "5ea6c0b20b0fc60d2c61c1333732253e",
             "input_file": "al11_12.adif",
             "output_format": "Unknown",
-            "result": "7ab9935dd1adae5fb5b921c51fb6e3a7"
+            "result": "7ab9935dd1adae5fb5b921c51fb6e3a7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02_64",
@@ -1169,7 +1314,8 @@
             "source_checksum": "543417e6aac553a482581ed015b60835",
             "input_file": "al02_64.adif",
             "output_format": "Unknown",
-            "result": "5a1b7aaee8c3e44254fb010268cdcabe"
+            "result": "5a1b7aaee8c3e44254fb010268cdcabe",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_11",
@@ -1177,7 +1323,8 @@
             "source_checksum": "6bbe5612cbafcda2b91cb58b9536731e",
             "input_file": "al04_11.adif",
             "output_format": "Unknown",
-            "result": "ce01170c4b3bbadfb22580879745bb79"
+            "result": "ce01170c4b3bbadfb22580879745bb79",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as01_48",
@@ -1185,7 +1332,8 @@
             "source_checksum": "5779062d3f406e97375920aaad8b4b81",
             "input_file": "as01_48.adif",
             "output_format": "Unknown",
-            "result": "39601f6c36e9bed60b5e2b1d700a9acf"
+            "result": "39601f6c36e9bed60b5e2b1d700a9acf",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am07_32",
@@ -1193,7 +1341,8 @@
             "source_checksum": "6e16189535ee42a3b74f9b9e79907a1f",
             "input_file": "am07_32.adif",
             "output_format": "Unknown",
-            "result": "642fcea1aa872cb9deb8051eb67b723f"
+            "result": "642fcea1aa872cb9deb8051eb67b723f",
+            "profile": "AAC Main"
         },
         {
             "name": "am01_24",
@@ -1201,7 +1350,8 @@
             "source_checksum": "806d34a4e2cbe4e73a249e51d5dbe0fc",
             "input_file": "am01_24.adif",
             "output_format": "Unknown",
-            "result": "383fe028008446dc9540854da6b1122a"
+            "result": "383fe028008446dc9540854da6b1122a",
+            "profile": "AAC Main"
         },
         {
             "name": "as02_11",
@@ -1209,7 +1359,8 @@
             "source_checksum": "f489f54829abcffad471f7cae943006e",
             "input_file": "as02_11.adif",
             "output_format": "Unknown",
-            "result": "a9dbc7369832bc9ce70391719891fb98"
+            "result": "a9dbc7369832bc9ce70391719891fb98",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al11_11",
@@ -1217,7 +1368,8 @@
             "source_checksum": "e8998fbbf779d630b9bc8c52587a809f",
             "input_file": "al11_11.adif",
             "output_format": "Unknown",
-            "result": "7ab9935dd1adae5fb5b921c51fb6e3a7"
+            "result": "7ab9935dd1adae5fb5b921c51fb6e3a7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07_32",
@@ -1225,7 +1377,8 @@
             "source_checksum": "1951b2cdc62f469aff0c33e6238ec6ed",
             "input_file": "al07_32.adif",
             "output_format": "Unknown",
-            "result": "70d924177e92b84d441cc00df378b2c0"
+            "result": "70d924177e92b84d441cc00df378b2c0",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as14_44",
@@ -1233,7 +1386,8 @@
             "source_checksum": "d34b6e847823670133a78409150bd4d6",
             "input_file": "as14_44.adif",
             "output_format": "Unknown",
-            "result": "e9ede9a5a4dad2a4c35d239aec4889fc"
+            "result": "e9ede9a5a4dad2a4c35d239aec4889fc",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al10_32",
@@ -1241,7 +1395,8 @@
             "source_checksum": "714ce237510281f9f26399249400c051",
             "input_file": "al10_32.adif",
             "output_format": "Unknown",
-            "result": "64c7e981f255cb6317c361c93e8df348"
+            "result": "64c7e981f255cb6317c361c93e8df348",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am05_11",
@@ -1249,7 +1404,8 @@
             "source_checksum": "f9cb1b11e8571ab7b8c5c0e713cc2666",
             "input_file": "am05_11.adif",
             "output_format": "Unknown",
-            "result": "30b703181556f60e1befb1ced67338be"
+            "result": "30b703181556f60e1befb1ced67338be",
+            "profile": "AAC Main"
         },
         {
             "name": "al11_96",
@@ -1257,7 +1413,8 @@
             "source_checksum": "935e4d6703ce671da87bce96b98675ca",
             "input_file": "al11_96.adif",
             "output_format": "Unknown",
-            "result": "b8c525add273b5c290f71a807a1c4b69"
+            "result": "b8c525add273b5c290f71a807a1c4b69",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as03_24",
@@ -1265,7 +1422,8 @@
             "source_checksum": "414c5378d08014af10eb7afddc01e5f6",
             "input_file": "as03_24.adif",
             "output_format": "Unknown",
-            "result": "7824e57e3964d56457224f67a9383e7b"
+            "result": "7824e57e3964d56457224f67a9383e7b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as00_96",
@@ -1273,7 +1431,8 @@
             "source_checksum": "edb7e3e997dd0683016f66f49f66b307",
             "input_file": "as00_96.adif",
             "output_format": "Unknown",
-            "result": "44ea7c5eec39221a7d480380ff7a3ce9"
+            "result": "44ea7c5eec39221a7d480380ff7a3ce9",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as09_32",
@@ -1281,7 +1440,8 @@
             "source_checksum": "370de848773760e4864fb4d46e482890",
             "input_file": "as09_32.adif",
             "output_format": "Unknown",
-            "result": "c30c42a679a63bb4764920eb82e34101"
+            "result": "c30c42a679a63bb4764920eb82e34101",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as16_88",
@@ -1289,7 +1449,8 @@
             "source_checksum": "f0ef214db637a349e87c6a37a751083d",
             "input_file": "as16_88.adif",
             "output_format": "Unknown",
-            "result": "28e85247ea8004cd8253429f6c1e7248"
+            "result": "28e85247ea8004cd8253429f6c1e7248",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as05_11",
@@ -1297,7 +1458,8 @@
             "source_checksum": "51f5815f7309678cbe33afb7007dc810",
             "input_file": "as05_11.adif",
             "output_format": "Unknown",
-            "result": "4304c8ed55dac9a12a96e88528ce97b7"
+            "result": "4304c8ed55dac9a12a96e88528ce97b7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am05_12",
@@ -1305,7 +1467,8 @@
             "source_checksum": "bf4a83b0b6c3b94746b3462d68f654c4",
             "input_file": "am05_12.adif",
             "output_format": "Unknown",
-            "result": "31cc64498f9c11ed507a24ca3bd169ec"
+            "result": "31cc64498f9c11ed507a24ca3bd169ec",
+            "profile": "AAC Main"
         },
         {
             "name": "al15_22",
@@ -1313,7 +1476,8 @@
             "source_checksum": "9f6aca5fb1fd3603cee3ef0bc9196f09",
             "input_file": "al15_22.adif",
             "output_format": "Unknown",
-            "result": "16e1e7aa3336dd99203ce7b16087719d"
+            "result": "16e1e7aa3336dd99203ce7b16087719d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06_12",
@@ -1321,7 +1485,8 @@
             "source_checksum": "983d2fe5e350df1ce724163046115786",
             "input_file": "al06_12.adif",
             "output_format": "Unknown",
-            "result": "0478cbd3efa8e014ca82954e31084f20"
+            "result": "0478cbd3efa8e014ca82954e31084f20",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am06_24",
@@ -1329,7 +1494,8 @@
             "source_checksum": "a9421c6811dafd836da05d037f9fcbf4",
             "input_file": "am06_24.adif",
             "output_format": "Unknown",
-            "result": "19eea88a19f933b2c6a98b555d427fa7"
+            "result": "19eea88a19f933b2c6a98b555d427fa7",
+            "profile": "AAC Main"
         },
         {
             "name": "as16_12",
@@ -1337,7 +1503,8 @@
             "source_checksum": "537e63ad7170042b4de8638e9f99fbf2",
             "input_file": "as16_12.adif",
             "output_format": "Unknown",
-            "result": "cb0d5dbdfddc30ad05585e911fc73d59"
+            "result": "cb0d5dbdfddc30ad05585e911fc73d59",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al05_32",
@@ -1345,7 +1512,8 @@
             "source_checksum": "c9dc7ea87bb8c2138accb373ecb93f6b",
             "input_file": "al05_32.adif",
             "output_format": "Unknown",
-            "result": "d8fd8cbd4707458c7dbc2331ad792e67"
+            "result": "d8fd8cbd4707458c7dbc2331ad792e67",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06_08",
@@ -1353,7 +1521,8 @@
             "source_checksum": "b6c41f3ddf3d1d84aeab46be9672b810",
             "input_file": "al06_08.adif",
             "output_format": "Unknown",
-            "result": "0e0cc8a25f7eb161f66ee3bc65199d04"
+            "result": "0e0cc8a25f7eb161f66ee3bc65199d04",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am04_48",
@@ -1361,7 +1530,8 @@
             "source_checksum": "3aff314027f3b08129ba3cfedca95011",
             "input_file": "am04_48.adif",
             "output_format": "Unknown",
-            "result": "21787f144ab240452a7c0b32016f0c0c"
+            "result": "21787f144ab240452a7c0b32016f0c0c",
+            "profile": "AAC Main"
         },
         {
             "name": "am01_16",
@@ -1369,7 +1539,8 @@
             "source_checksum": "60fe7b6600282ba2932e052916358e20",
             "input_file": "am01_16.adif",
             "output_format": "Unknown",
-            "result": "f49b1f4d1aa9471cf83b838eaac185a7"
+            "result": "f49b1f4d1aa9471cf83b838eaac185a7",
+            "profile": "AAC Main"
         },
         {
             "name": "as03_16",
@@ -1377,7 +1548,8 @@
             "source_checksum": "54b0faf23d3f08535cfaec672e32c3fe",
             "input_file": "as03_16.adif",
             "output_format": "Unknown",
-            "result": "0298779243f1f989e4aea5aa255f57ea"
+            "result": "0298779243f1f989e4aea5aa255f57ea",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as02_96",
@@ -1385,7 +1557,8 @@
             "source_checksum": "0910681bd4c31d8dacd8f5d4cb5e35bc",
             "input_file": "as02_96.adif",
             "output_format": "Unknown",
-            "result": "d5c8999daac06c904e5327603f51f0cb"
+            "result": "d5c8999daac06c904e5327603f51f0cb",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as14_48",
@@ -1393,7 +1566,8 @@
             "source_checksum": "9fc154f89b929e81b04981ddb8d05cc6",
             "input_file": "as14_48.adif",
             "output_format": "Unknown",
-            "result": "58f3a2a2c3bb76ddcdecb80e54e32cda"
+            "result": "58f3a2a2c3bb76ddcdecb80e54e32cda",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am01_48",
@@ -1401,7 +1575,8 @@
             "source_checksum": "75268f551cca8f1cf69755a80ca59243",
             "input_file": "am01_48.adif",
             "output_format": "Unknown",
-            "result": "caefa9d212de6d4553691071d144d98c"
+            "result": "caefa9d212de6d4553691071d144d98c",
+            "profile": "AAC Main"
         },
         {
             "name": "al10_64",
@@ -1409,7 +1584,8 @@
             "source_checksum": "66854739b84336de79d86148bb43bbce",
             "input_file": "al10_64.adif",
             "output_format": "Unknown",
-            "result": "60353cbfdf32fc2539dab16995aef0f2"
+            "result": "60353cbfdf32fc2539dab16995aef0f2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as10_64",
@@ -1417,7 +1593,8 @@
             "source_checksum": "531de5e77171cca0bb4c8233616c2fd7",
             "input_file": "as10_64.adif",
             "output_format": "Unknown",
-            "result": "f098fc1ece5df2f3e5ae72b49f7801ec"
+            "result": "f098fc1ece5df2f3e5ae72b49f7801ec",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al11_24",
@@ -1425,7 +1602,8 @@
             "source_checksum": "484f7a6979741a3d5d307c2951bc49a8",
             "input_file": "al11_24.adif",
             "output_format": "Unknown",
-            "result": "e6c07de6c6cbf92bd9c53308443f8c35"
+            "result": "e6c07de6c6cbf92bd9c53308443f8c35",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08_48",
@@ -1433,7 +1611,8 @@
             "source_checksum": "ae2dfe8516355a4902a9cceb3dc4e1fc",
             "input_file": "al08_48.adif",
             "output_format": "Unknown",
-            "result": "97e049c5ca237411214a5ba9f0733dbc"
+            "result": "97e049c5ca237411214a5ba9f0733dbc",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as02_24",
@@ -1441,7 +1620,8 @@
             "source_checksum": "3fdfad2cc900055aa3e08b0d4518f7dc",
             "input_file": "as02_24.adif",
             "output_format": "Unknown",
-            "result": "90ebe7c4b7924fd5bd0c8a26d904ac79"
+            "result": "90ebe7c4b7924fd5bd0c8a26d904ac79",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as02_32",
@@ -1449,7 +1629,8 @@
             "source_checksum": "6f969fe3439f169794b257227a908373",
             "input_file": "as02_32.adif",
             "output_format": "Unknown",
-            "result": "f3ee637a48cf6737058daef20576406c"
+            "result": "f3ee637a48cf6737058daef20576406c",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as03_32",
@@ -1457,7 +1638,8 @@
             "source_checksum": "a709f78ed8075fc43ecf64e7aae2f0b4",
             "input_file": "as03_32.adif",
             "output_format": "Unknown",
-            "result": "920794a07f55ca188bb2fdcc09dd990a"
+            "result": "920794a07f55ca188bb2fdcc09dd990a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as02_88",
@@ -1465,7 +1647,8 @@
             "source_checksum": "06d90c71bc5d7d65be25d6ac9d87471d",
             "input_file": "as02_88.adif",
             "output_format": "Unknown",
-            "result": "f669b471bf5bfd82e5a24f6715ca5e8b"
+            "result": "f669b471bf5bfd82e5a24f6715ca5e8b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as13_88",
@@ -1473,7 +1656,8 @@
             "source_checksum": "265d5ba6dd9aa495a72be1218ca582cd",
             "input_file": "as13_88.adif",
             "output_format": "Unknown",
-            "result": "6b658a186b7b45033d2ec0fce12379cd"
+            "result": "6b658a186b7b45033d2ec0fce12379cd",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al00_64",
@@ -1481,7 +1665,8 @@
             "source_checksum": "5265ac7d2779a6c8935a8a7ba0df7ef0",
             "input_file": "al00_64.adif",
             "output_format": "Unknown",
-            "result": "0acee3957588ecf625efa56540f02f6a"
+            "result": "0acee3957588ecf625efa56540f02f6a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07_16",
@@ -1489,7 +1674,8 @@
             "source_checksum": "fd94710d05ccaf37a1460aae76573a2e",
             "input_file": "al07_16.adif",
             "output_format": "Unknown",
-            "result": "d4de30fb19a0873a2357523a21a7c11f"
+            "result": "d4de30fb19a0873a2357523a21a7c11f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al15_44",
@@ -1497,7 +1683,8 @@
             "source_checksum": "dda8f7dd23a5a91459e83734dceb189c",
             "input_file": "al15_44.adif",
             "output_format": "Unknown",
-            "result": "2767d1b2de38d169cc1928312efc95a0"
+            "result": "2767d1b2de38d169cc1928312efc95a0",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02_48",
@@ -1505,7 +1692,8 @@
             "source_checksum": "78308842a6a9f66cf1856a21c2015478",
             "input_file": "al02_48.adif",
             "output_format": "Unknown",
-            "result": "efce3a472bba51ef2c22a68981f7bd40"
+            "result": "efce3a472bba51ef2c22a68981f7bd40",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as07_24",
@@ -1513,7 +1701,8 @@
             "source_checksum": "4404503a3bb2d603d8b7094e121b2c16",
             "input_file": "as07_24.adif",
             "output_format": "Unknown",
-            "result": "8a6f5b90e5fdd48feb04a0d7bbe10b73"
+            "result": "8a6f5b90e5fdd48feb04a0d7bbe10b73",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al15_12",
@@ -1521,7 +1710,8 @@
             "source_checksum": "cf936789f590c3de434da91bcb1fd47f",
             "input_file": "al15_12.adif",
             "output_format": "Unknown",
-            "result": "613e8b751fe47328154d1459b0675880"
+            "result": "613e8b751fe47328154d1459b0675880",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as03_08",
@@ -1529,7 +1719,8 @@
             "source_checksum": "c20766117feabf1ad20c3a6de239229d",
             "input_file": "as03_08.adif",
             "output_format": "Unknown",
-            "result": "873c6825dee58dba747bb0d1713c9876"
+            "result": "873c6825dee58dba747bb0d1713c9876",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al15_16",
@@ -1537,7 +1728,8 @@
             "source_checksum": "6f208714b73294baa6ab96150f1b6585",
             "input_file": "al15_16.adif",
             "output_format": "Unknown",
-            "result": "84a8b1a037c4c3385c37aa6b106ed4e8"
+            "result": "84a8b1a037c4c3385c37aa6b106ed4e8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as16_44",
@@ -1545,7 +1737,8 @@
             "source_checksum": "b3c46830c7b4dc0ed6ef969536b3b682",
             "input_file": "as16_44.adif",
             "output_format": "Unknown",
-            "result": "e9ede9a5a4dad2a4c35d239aec4889fc"
+            "result": "e9ede9a5a4dad2a4c35d239aec4889fc",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as05_48",
@@ -1553,7 +1746,8 @@
             "source_checksum": "37f4af2d7fca05fbfc0ce8c01dbe0bd8",
             "input_file": "as05_48.adif",
             "output_format": "Unknown",
-            "result": "92776cb4dcaa00660145739ac77f3c40"
+            "result": "92776cb4dcaa00660145739ac77f3c40",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as02_48",
@@ -1561,7 +1755,8 @@
             "source_checksum": "7f430b134f210e7d51f4fc8784cf0031",
             "input_file": "as02_48.adif",
             "output_format": "Unknown",
-            "result": "8f0fec654f8b846b229f8a656c6aca0d"
+            "result": "8f0fec654f8b846b229f8a656c6aca0d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am01_88",
@@ -1569,7 +1764,8 @@
             "source_checksum": "36c3ac9e1cdfaee199fece84578a89e1",
             "input_file": "am01_88.adif",
             "output_format": "Unknown",
-            "result": "aa3b7e61c9327bd386bbddf54519a571"
+            "result": "aa3b7e61c9327bd386bbddf54519a571",
+            "profile": "AAC Main"
         },
         {
             "name": "am06_11",
@@ -1577,7 +1773,8 @@
             "source_checksum": "463fd1a62a3d64b9f0f870c31b18cdc5",
             "input_file": "am06_11.adif",
             "output_format": "Unknown",
-            "result": "35d539f4bf37499cf1b0f5e960ffcdc8"
+            "result": "35d539f4bf37499cf1b0f5e960ffcdc8",
+            "profile": "AAC Main"
         },
         {
             "name": "al06_16",
@@ -1585,7 +1782,8 @@
             "source_checksum": "53291b8acc28f4263f0257483d566f65",
             "input_file": "al06_16.adif",
             "output_format": "Unknown",
-            "result": "ae346b6e8f7053883dc823c3f4288ff5"
+            "result": "ae346b6e8f7053883dc823c3f4288ff5",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as00_44",
@@ -1593,7 +1791,8 @@
             "source_checksum": "1eb2e2a70405662c2bd2b8e2c3433e92",
             "input_file": "as00_44.adif",
             "output_format": "Unknown",
-            "result": "b54c4156d525170f40cff12eb4f0afd8"
+            "result": "b54c4156d525170f40cff12eb4f0afd8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as10_22",
@@ -1601,7 +1800,8 @@
             "source_checksum": "185616ba252a1c63f2fb57c62f08d39a",
             "input_file": "as10_22.adif",
             "output_format": "Unknown",
-            "result": "bc7e903ad7664ee5e0fbbb655e1e32ee"
+            "result": "bc7e903ad7664ee5e0fbbb655e1e32ee",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as00_32",
@@ -1609,7 +1809,8 @@
             "source_checksum": "fa532cc4486c814259b8405a1a28b06b",
             "input_file": "as00_32.adif",
             "output_format": "Unknown",
-            "result": "ba87750cd665c8d17d0515d5162b6899"
+            "result": "ba87750cd665c8d17d0515d5162b6899",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as12_16",
@@ -1617,7 +1818,8 @@
             "source_checksum": "046c1f0d8fa6f4fff06ca4d3edb84546",
             "input_file": "as12_16.adif",
             "output_format": "Unknown",
-            "result": "a987f1846c38136e503b386b0eb1bec8"
+            "result": "a987f1846c38136e503b386b0eb1bec8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03_48",
@@ -1625,7 +1827,8 @@
             "source_checksum": "83d96a25a3e3009eee4166523380cf3b",
             "input_file": "al03_48.adif",
             "output_format": "Unknown",
-            "result": "908d650ff51a6b6f09d22d70ed0eafc3"
+            "result": "908d650ff51a6b6f09d22d70ed0eafc3",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_08",
@@ -1633,7 +1836,8 @@
             "source_checksum": "486014e224f9979e004d171cb6d89301",
             "input_file": "am00_08.adif",
             "output_format": "Unknown",
-            "result": "5421b0bfa2287dd9a0b4abbcd784d924"
+            "result": "5421b0bfa2287dd9a0b4abbcd784d924",
+            "profile": "AAC Main"
         },
         {
             "name": "al15_64",
@@ -1641,7 +1845,8 @@
             "source_checksum": "f7daa778a7429520312a19495a45d7d7",
             "input_file": "al15_64.adif",
             "output_format": "Unknown",
-            "result": "9a57af3c5a820f0d72cc46a9742b844e"
+            "result": "9a57af3c5a820f0d72cc46a9742b844e",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_48",
@@ -1649,7 +1854,8 @@
             "source_checksum": "27dfe1f7efaea1d2ef83a33ca8592211",
             "input_file": "al04_48.adif",
             "output_format": "Unknown",
-            "result": "1f04cda750065aad2633d369241e9aed"
+            "result": "1f04cda750065aad2633d369241e9aed",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as02_12",
@@ -1657,7 +1863,8 @@
             "source_checksum": "f2b22f2d40c765306aac63f12a289e85",
             "input_file": "as02_12.adif",
             "output_format": "Unknown",
-            "result": "11af3f565ca36a6ceab18aaabdca4f46"
+            "result": "11af3f565ca36a6ceab18aaabdca4f46",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as05_44",
@@ -1665,7 +1872,8 @@
             "source_checksum": "1bf578f4ecc4c8e1f2d32e09f9ec7b50",
             "input_file": "as05_44.adif",
             "output_format": "Unknown",
-            "result": "6d52bc409273a725d7d0688d2be08421"
+            "result": "6d52bc409273a725d7d0688d2be08421",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as06_22",
@@ -1673,7 +1881,8 @@
             "source_checksum": "102a336da252003df1be050fe530fb47",
             "input_file": "as06_22.adif",
             "output_format": "Unknown",
-            "result": "3d1602d419ff72fd988407ac777dc09d"
+            "result": "3d1602d419ff72fd988407ac777dc09d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al05_24",
@@ -1681,7 +1890,8 @@
             "source_checksum": "ef7273bef5348e4f25b4f74d06a94149",
             "input_file": "al05_24.adif",
             "output_format": "Unknown",
-            "result": "6420d66039cd4cef3ff15fbbbe94459b"
+            "result": "6420d66039cd4cef3ff15fbbbe94459b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as16_48",
@@ -1689,7 +1899,8 @@
             "source_checksum": "c1d02c5aa5d128dae8f4840957b7e974",
             "input_file": "as16_48.adif",
             "output_format": "Unknown",
-            "result": "58f3a2a2c3bb76ddcdecb80e54e32cda"
+            "result": "58f3a2a2c3bb76ddcdecb80e54e32cda",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as04_96",
@@ -1697,7 +1908,8 @@
             "source_checksum": "8af7979e2812243b4c8d289998977b5a",
             "input_file": "as04_96.adif",
             "output_format": "Unknown",
-            "result": "427a7b0857a8a9b9e5d10c57c3d7f56d"
+            "result": "427a7b0857a8a9b9e5d10c57c3d7f56d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am04_96",
@@ -1705,7 +1917,8 @@
             "source_checksum": "2f8610445d67d522dfae66c55791844d",
             "input_file": "am04_96.adif",
             "output_format": "Unknown",
-            "result": "82e79eac474dc6bda0337aa3871ee962"
+            "result": "82e79eac474dc6bda0337aa3871ee962",
+            "profile": "AAC Main"
         },
         {
             "name": "al03_22",
@@ -1713,7 +1926,8 @@
             "source_checksum": "5390b6ff9692ceea6c7ffc34e2ef827c",
             "input_file": "al03_22.adif",
             "output_format": "Unknown",
-            "result": "6819ba04cee182d2aa3247ed93b9923d"
+            "result": "6819ba04cee182d2aa3247ed93b9923d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02_32",
@@ -1721,7 +1935,8 @@
             "source_checksum": "011f1ba40f43cbcaa21ccaeb7ff1acad",
             "input_file": "al02_32.adif",
             "output_format": "Unknown",
-            "result": "6ba7ac6c9ce17617f2b8e192d64111ca"
+            "result": "6ba7ac6c9ce17617f2b8e192d64111ca",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as02_16",
@@ -1729,7 +1944,8 @@
             "source_checksum": "fcae91f018fae9802f0282b1ef667ef1",
             "input_file": "as02_16.adif",
             "output_format": "Unknown",
-            "result": "21842cc363c6ba31f829806c76c0d488"
+            "result": "21842cc363c6ba31f829806c76c0d488",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as08_64",
@@ -1737,7 +1953,8 @@
             "source_checksum": "42554670387838a1405236f84f9f75e4",
             "input_file": "as08_64.adif",
             "output_format": "Unknown",
-            "result": "967475be69d08b82e6b150b78a86f44d"
+            "result": "967475be69d08b82e6b150b78a86f44d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al10_22",
@@ -1745,7 +1962,8 @@
             "source_checksum": "8ba01b5432895372cfcd729765bbc661",
             "input_file": "al10_22.adif",
             "output_format": "Unknown",
-            "result": "4c1f58d8aa0646636fc1b6ffce4aaf20"
+            "result": "4c1f58d8aa0646636fc1b6ffce4aaf20",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00_96",
@@ -1753,7 +1971,8 @@
             "source_checksum": "a4341f186efda6dad24b64577b77c639",
             "input_file": "al00_96.adif",
             "output_format": "Unknown",
-            "result": "7dc7b3c9f121b6afe05020dcd7316f45"
+            "result": "7dc7b3c9f121b6afe05020dcd7316f45",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am04_12",
@@ -1761,7 +1980,8 @@
             "source_checksum": "2b26096ce17d6e6fc3cfbdb23fb36ee7",
             "input_file": "am04_12.adif",
             "output_format": "Unknown",
-            "result": "e34d7c1761878e8a32dad69d8065ee37"
+            "result": "e34d7c1761878e8a32dad69d8065ee37",
+            "profile": "AAC Main"
         },
         {
             "name": "as17_64",
@@ -1769,7 +1989,8 @@
             "source_checksum": "82ca1da4cc28179b9b13b96646a724dd",
             "input_file": "as17_64.adif",
             "output_format": "Unknown",
-            "result": "95e70c5865bb22a9b7389af0b3d024fb"
+            "result": "95e70c5865bb22a9b7389af0b3d024fb",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al10_44",
@@ -1777,7 +1998,8 @@
             "source_checksum": "6b3b2e83b9812c54d65ba83e6fe94066",
             "input_file": "al10_44.adif",
             "output_format": "Unknown",
-            "result": "d1d7df79481b20a7cbff0726807bb161"
+            "result": "d1d7df79481b20a7cbff0726807bb161",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16_24",
@@ -1785,7 +2007,8 @@
             "source_checksum": "e1600a8935d316a51e84b6e1f464ae30",
             "input_file": "al16_24.adif",
             "output_format": "Unknown",
-            "result": "504ea25bf408453edb069c8874792863"
+            "result": "504ea25bf408453edb069c8874792863",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as09_64",
@@ -1793,7 +2016,8 @@
             "source_checksum": "1d4df190aecd137c2b53ffd97ac7d350",
             "input_file": "as09_64.adif",
             "output_format": "Unknown",
-            "result": "eaf17ab6b54acc45bd1bf4a0c50b99a1"
+            "result": "eaf17ab6b54acc45bd1bf4a0c50b99a1",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as08_32",
@@ -1801,7 +2025,8 @@
             "source_checksum": "4cbd1a709580c9a4cb3419ee46956c62",
             "input_file": "as08_32.adif",
             "output_format": "Unknown",
-            "result": "11a3cfd97a1fdb82c0a2c46df65514b6"
+            "result": "11a3cfd97a1fdb82c0a2c46df65514b6",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as07_48",
@@ -1809,7 +2034,8 @@
             "source_checksum": "5795d6a65fc76242207fc5730e57b992",
             "input_file": "as07_48.adif",
             "output_format": "Unknown",
-            "result": "06baf14e1baa6f403761fb4aff978608"
+            "result": "06baf14e1baa6f403761fb4aff978608",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am04_08",
@@ -1817,7 +2043,8 @@
             "source_checksum": "f9d9a02cd9595587cc59a2f05e9b7a58",
             "input_file": "am04_08.adif",
             "output_format": "Unknown",
-            "result": "c38e48672d70d47fbf2712935eb94cc4"
+            "result": "c38e48672d70d47fbf2712935eb94cc4",
+            "profile": "AAC Main"
         },
         {
             "name": "as01_16",
@@ -1825,7 +2052,8 @@
             "source_checksum": "3243787f89da65be6b0fa90b24f90ade",
             "input_file": "as01_16.adif",
             "output_format": "Unknown",
-            "result": "0bda27fe86e947592e92ec47c050621a"
+            "result": "0bda27fe86e947592e92ec47c050621a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as00_88",
@@ -1833,7 +2061,8 @@
             "source_checksum": "c5e93d25747956d8c037cdcfb9681168",
             "input_file": "as00_88.adif",
             "output_format": "Unknown",
-            "result": "9fad6dc2afb3e4dfe2c48736dc612302"
+            "result": "9fad6dc2afb3e4dfe2c48736dc612302",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al17_22",
@@ -1841,7 +2070,8 @@
             "source_checksum": "4816ccb2676cf31919106c7b90b9d16e",
             "input_file": "al17_22.adif",
             "output_format": "Unknown",
-            "result": "282a105e716a8a6280f5fd9c162dbbce"
+            "result": "282a105e716a8a6280f5fd9c162dbbce",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08_22",
@@ -1849,7 +2079,8 @@
             "source_checksum": "831863f51f6305bdfabbd849cec02a7c",
             "input_file": "al08_22.adif",
             "output_format": "Unknown",
-            "result": "05c041101be07734c5b7eb4619dea481"
+            "result": "05c041101be07734c5b7eb4619dea481",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17_24",
@@ -1857,7 +2088,8 @@
             "source_checksum": "eea5321dd06f793a4e26a5f619a8ea09",
             "input_file": "al17_24.adif",
             "output_format": "Unknown",
-            "result": "81e7f63e34e349fd6138172552c55936"
+            "result": "81e7f63e34e349fd6138172552c55936",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_22",
@@ -1865,7 +2097,8 @@
             "source_checksum": "5953a6cf627bab3032706c4f67baa709",
             "input_file": "am00_22.adif",
             "output_format": "Unknown",
-            "result": "3a5c20bbd8e6da448b58f24fcc1406e4"
+            "result": "3a5c20bbd8e6da448b58f24fcc1406e4",
+            "profile": "AAC Main"
         },
         {
             "name": "al02_96",
@@ -1873,7 +2106,8 @@
             "source_checksum": "4bb6735b2e164cfc1978bc28940eca97",
             "input_file": "al02_96.adif",
             "output_format": "Unknown",
-            "result": "c91d263e846628e4060cdef6c9b5c81d"
+            "result": "c91d263e846628e4060cdef6c9b5c81d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as13_08",
@@ -1881,7 +2115,8 @@
             "source_checksum": "f86b772eeb27e2005986a1f47f96b99d",
             "input_file": "as13_08.adif",
             "output_format": "Unknown",
-            "result": "f48ab7fc21542d1d0caf92eacb51eee3"
+            "result": "f48ab7fc21542d1d0caf92eacb51eee3",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as10_88",
@@ -1889,7 +2124,8 @@
             "source_checksum": "a1e82e62f8f3c4b9157f80d8a14f488a",
             "input_file": "as10_88.adif",
             "output_format": "Unknown",
-            "result": "89d1a1d770e20273220f50c283de459a"
+            "result": "89d1a1d770e20273220f50c283de459a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am02_16",
@@ -1897,7 +2133,8 @@
             "source_checksum": "fc2f23c3e0018defc658e7ba53285fc3",
             "input_file": "am02_16.adif",
             "output_format": "Unknown",
-            "result": "424bf0862916cb427c09a4c3a1a1f05a"
+            "result": "424bf0862916cb427c09a4c3a1a1f05a",
+            "profile": "AAC Main"
         },
         {
             "name": "as04_64",
@@ -1905,7 +2142,8 @@
             "source_checksum": "c5fd2bf14c328dbe198e5610b4c8bc75",
             "input_file": "as04_64.adif",
             "output_format": "Unknown",
-            "result": "e8ba5e37c694b3669d197c8ba5f980a1"
+            "result": "e8ba5e37c694b3669d197c8ba5f980a1",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as06_96",
@@ -1913,7 +2151,8 @@
             "source_checksum": "abd0dd523acc11cef329f3df8b5ef090",
             "input_file": "as06_96.adif",
             "output_format": "Unknown",
-            "result": "186d598b2d6798f3e41cdb3fe57f4469"
+            "result": "186d598b2d6798f3e41cdb3fe57f4469",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al05_88",
@@ -1921,7 +2160,8 @@
             "source_checksum": "d23201f4f0d47e8d2434f52c69ee9645",
             "input_file": "al05_88.adif",
             "output_format": "Unknown",
-            "result": "6b609311bb4090654a70cda3b6df7ee4"
+            "result": "6b609311bb4090654a70cda3b6df7ee4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_24",
@@ -1929,7 +2169,8 @@
             "source_checksum": "7c0c22ed3b15be29afcbc46f179fddf7",
             "input_file": "am00_24.adif",
             "output_format": "Unknown",
-            "result": "d91800bc70282ef0bfca4c96812e03fe"
+            "result": "d91800bc70282ef0bfca4c96812e03fe",
+            "profile": "AAC Main"
         },
         {
             "name": "al03_32",
@@ -1937,7 +2178,8 @@
             "source_checksum": "edad5b37697ee9b29aad9dd0352ae20a",
             "input_file": "al03_32.adif",
             "output_format": "Unknown",
-            "result": "5262e32342bfac7cfbad37a17fbdaba2"
+            "result": "5262e32342bfac7cfbad37a17fbdaba2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am01_12",
@@ -1945,7 +2187,8 @@
             "source_checksum": "09ac88daefcf469da375592eee3d2d10",
             "input_file": "am01_12.adif",
             "output_format": "Unknown",
-            "result": "0257eecdaaf011bd58ea3000fcbd089d"
+            "result": "0257eecdaaf011bd58ea3000fcbd089d",
+            "profile": "AAC Main"
         },
         {
             "name": "al08_32",
@@ -1953,7 +2196,8 @@
             "source_checksum": "e6f3dbbc3bca93e7360f55e25f0ac168",
             "input_file": "al08_32.adif",
             "output_format": "Unknown",
-            "result": "f02dcaed96aa7113f6f34ab33a786383"
+            "result": "f02dcaed96aa7113f6f34ab33a786383",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as17_32",
@@ -1961,7 +2205,8 @@
             "source_checksum": "04794b3fc57432105789f4b896690ff4",
             "input_file": "as17_32.adif",
             "output_format": "Unknown",
-            "result": "f905cf951369cd78ff5dbc5fc03b82a7"
+            "result": "f905cf951369cd78ff5dbc5fc03b82a7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al00_48",
@@ -1969,7 +2214,8 @@
             "source_checksum": "a8d8c0115b96a1b970bc5706484c250f",
             "input_file": "al00_48.adif",
             "output_format": "Unknown",
-            "result": "81aed3ed01060d1453cc96ad6e8e7222"
+            "result": "81aed3ed01060d1453cc96ad6e8e7222",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as06_48",
@@ -1977,7 +2223,8 @@
             "source_checksum": "67b3f544eccd37987b4ab7c6edfc0628",
             "input_file": "as06_48.adif",
             "output_format": "Unknown",
-            "result": "b244b4e92cad9813cd100e1dd92ae8a4"
+            "result": "b244b4e92cad9813cd100e1dd92ae8a4",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as06_16",
@@ -1985,7 +2232,8 @@
             "source_checksum": "0991f82910e3a3ceb7411fa3ecd2579b",
             "input_file": "as06_16.adif",
             "output_format": "Unknown",
-            "result": "481e95a7bc8864e6b97edb66cc561aaa"
+            "result": "481e95a7bc8864e6b97edb66cc561aaa",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am03_11",
@@ -1993,7 +2241,8 @@
             "source_checksum": "9412a5a8303420f1fa2233b3ce3b8e0a",
             "input_file": "am03_11.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "",
+            "profile": "AAC Main"
         },
         {
             "name": "as15_11",
@@ -2001,7 +2250,8 @@
             "source_checksum": "c861c83476f57db3d430939222969962",
             "input_file": "as15_11.adif",
             "output_format": "Unknown",
-            "result": "6c6115066d647d5409a2c2fa9d6f6329"
+            "result": "6c6115066d647d5409a2c2fa9d6f6329",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al05_12",
@@ -2009,7 +2259,8 @@
             "source_checksum": "8eb62e29a607e52f54fcb83d0dbba9ea",
             "input_file": "al05_12.adif",
             "output_format": "Unknown",
-            "result": "afbc1483e6a4a6dc56901b63b047969f"
+            "result": "afbc1483e6a4a6dc56901b63b047969f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as05_32",
@@ -2017,7 +2268,8 @@
             "source_checksum": "786ff25ecfab56e2f8568c5ac4416e71",
             "input_file": "as05_32.adif",
             "output_format": "Unknown",
-            "result": "81c8e7279518789f3aca4218330f3dc3"
+            "result": "81c8e7279518789f3aca4218330f3dc3",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as08_44",
@@ -2025,7 +2277,8 @@
             "source_checksum": "cfc463ff339a0e17451ffac899840f93",
             "input_file": "as08_44.adif",
             "output_format": "Unknown",
-            "result": "cf0ed6a192d5677699cdd2d0ed48690e"
+            "result": "cf0ed6a192d5677699cdd2d0ed48690e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am05_64",
@@ -2033,7 +2286,8 @@
             "source_checksum": "2be3b02613dd9b680ddc3c1dec538190",
             "input_file": "am05_64.adif",
             "output_format": "Unknown",
-            "result": "5b096940b5f4f548e8be21081dd8e188"
+            "result": "5b096940b5f4f548e8be21081dd8e188",
+            "profile": "AAC Main"
         },
         {
             "name": "as04_11",
@@ -2041,7 +2295,8 @@
             "source_checksum": "5c413397a5056fa581af6fea2c95eb9a",
             "input_file": "as04_11.adif",
             "output_format": "Unknown",
-            "result": "9b1e1cb3d539ac3c605175a667cc426a"
+            "result": "9b1e1cb3d539ac3c605175a667cc426a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03_12",
@@ -2049,7 +2304,8 @@
             "source_checksum": "f7f1df748e4c5d74add7a46d11191114",
             "input_file": "al03_12.adif",
             "output_format": "Unknown",
-            "result": "97c9a4a96818ef0c03dc1c8797aa7279"
+            "result": "97c9a4a96818ef0c03dc1c8797aa7279",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am05_44",
@@ -2057,7 +2313,8 @@
             "source_checksum": "07592518d2fbc33f5f2e5ba04c72be05",
             "input_file": "am05_44.adif",
             "output_format": "Unknown",
-            "result": "561255dc09da4e3cc62a6a568c023186"
+            "result": "561255dc09da4e3cc62a6a568c023186",
+            "profile": "AAC Main"
         },
         {
             "name": "al00_11",
@@ -2065,7 +2322,8 @@
             "source_checksum": "29c354ff3674a291e859644d38607c06",
             "input_file": "al00_11.adif",
             "output_format": "Unknown",
-            "result": "6eb23f7d1b322d167f0c075234ad66ec"
+            "result": "6eb23f7d1b322d167f0c075234ad66ec",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am04_16",
@@ -2073,7 +2331,8 @@
             "source_checksum": "75cb5ed0631e83714602af7f70c92920",
             "input_file": "am04_16.adif",
             "output_format": "Unknown",
-            "result": "558b5b0b4eb34fc35f0a81289f710458"
+            "result": "558b5b0b4eb34fc35f0a81289f710458",
+            "profile": "AAC Main"
         },
         {
             "name": "al01_32",
@@ -2081,7 +2340,8 @@
             "source_checksum": "2c7cb9ae862f21c6d979a7ff03da979b",
             "input_file": "al01_32.adif",
             "output_format": "Unknown",
-            "result": "11be4fd08e53a9ee75abaca22469f6dd"
+            "result": "11be4fd08e53a9ee75abaca22469f6dd",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as05_96",
@@ -2089,7 +2349,8 @@
             "source_checksum": "bf3e69ff5e104c80a8562471529f6e2a",
             "input_file": "as05_96.adif",
             "output_format": "Unknown",
-            "result": "692a1720c71b0f8ed917ddf21a38f390"
+            "result": "692a1720c71b0f8ed917ddf21a38f390",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as13_22",
@@ -2097,7 +2358,8 @@
             "source_checksum": "393b584638bbd8f3da30bc22387c64e7",
             "input_file": "as13_22.adif",
             "output_format": "Unknown",
-            "result": "3845021412db78720068ec2dcd901fc3"
+            "result": "3845021412db78720068ec2dcd901fc3",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al15_24",
@@ -2105,7 +2367,8 @@
             "source_checksum": "b82c5db2c5e53d83d6ea5c1a5d42d889",
             "input_file": "al15_24.adif",
             "output_format": "Unknown",
-            "result": "938c26465f99f8c49948a749e3549f96"
+            "result": "938c26465f99f8c49948a749e3549f96",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01_64",
@@ -2113,7 +2376,8 @@
             "source_checksum": "d3d72f21cf951cf4e7a7c1d979773844",
             "input_file": "al01_64.adif",
             "output_format": "Unknown",
-            "result": "567affc7a30b2b05804877c986b93849"
+            "result": "567affc7a30b2b05804877c986b93849",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al11_32",
@@ -2121,7 +2385,8 @@
             "source_checksum": "138c6689f4070dc3a963d3cced8414c9",
             "input_file": "al11_32.adif",
             "output_format": "Unknown",
-            "result": "8d04675fe3c49edc18dd47e0d7a52e8b"
+            "result": "8d04675fe3c49edc18dd47e0d7a52e8b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al15_88",
@@ -2129,7 +2394,8 @@
             "source_checksum": "a735f7added079fdd22bb561640d3870",
             "input_file": "al15_88.adif",
             "output_format": "Unknown",
-            "result": "dab50d4dda248e969302ebf08cc123e1"
+            "result": "dab50d4dda248e969302ebf08cc123e1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_96",
@@ -2137,7 +2403,8 @@
             "source_checksum": "aa43752745b2184c57d908ca14c39744",
             "input_file": "al04_96.adif",
             "output_format": "Unknown",
-            "result": "edb05b74da0fb44f78dc51c5c8e7369f"
+            "result": "edb05b74da0fb44f78dc51c5c8e7369f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as12_11",
@@ -2145,7 +2412,8 @@
             "source_checksum": "fd831aa0b6cb7abab09cb669e8e97da5",
             "input_file": "as12_11.adif",
             "output_format": "Unknown",
-            "result": "78df5d5b0f389a36d0965568e053b126"
+            "result": "78df5d5b0f389a36d0965568e053b126",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al04_08",
@@ -2153,7 +2421,8 @@
             "source_checksum": "9de5dc95fcd431d38085c3fd1b67ceaf",
             "input_file": "al04_08.adif",
             "output_format": "Unknown",
-            "result": "19d650af57f6baa32202f3100aeb1eda"
+            "result": "19d650af57f6baa32202f3100aeb1eda",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as07_64",
@@ -2161,7 +2430,8 @@
             "source_checksum": "25590e412968c02af2557a94debe9512",
             "input_file": "as07_64.adif",
             "output_format": "Unknown",
-            "result": "c8dccbd7a2c94b812341b369757f2cf6"
+            "result": "c8dccbd7a2c94b812341b369757f2cf6",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as02_22",
@@ -2169,7 +2439,8 @@
             "source_checksum": "b406f6beff96dac480270e4bd6ada9ce",
             "input_file": "as02_22.adif",
             "output_format": "Unknown",
-            "result": "01451e220069c903d77ca277444480c5"
+            "result": "01451e220069c903d77ca277444480c5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al02_22",
@@ -2177,7 +2448,8 @@
             "source_checksum": "bbf19a61465e31c556ffd5e67a273e81",
             "input_file": "al02_22.adif",
             "output_format": "Unknown",
-            "result": "f17cde07183e4e9e9986248b099d098c"
+            "result": "f17cde07183e4e9e9986248b099d098c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as11_22",
@@ -2185,7 +2457,8 @@
             "source_checksum": "97d485ba1ec66a192aea236bfc194ba1",
             "input_file": "as11_22.adif",
             "output_format": "Unknown",
-            "result": "240d65d4f0e91934c0385d84db957d4a"
+            "result": "240d65d4f0e91934c0385d84db957d4a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as08_11",
@@ -2193,7 +2466,8 @@
             "source_checksum": "dd9f3618b2f918404d80ec2984022e8d",
             "input_file": "as08_11.adif",
             "output_format": "Unknown",
-            "result": "ba9b6025a324f400b8974402fc0cb31d"
+            "result": "ba9b6025a324f400b8974402fc0cb31d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am07_16",
@@ -2201,7 +2475,8 @@
             "source_checksum": "6907839260332d03ab0fe526487f6a2e",
             "input_file": "am07_16.adif",
             "output_format": "Unknown",
-            "result": "7ff6c169606329283d442bdf69017cb7"
+            "result": "7ff6c169606329283d442bdf69017cb7",
+            "profile": "AAC Main"
         },
         {
             "name": "al07_64",
@@ -2209,7 +2484,8 @@
             "source_checksum": "7c39cf45af0ffbf4f2e333fc720b594a",
             "input_file": "al07_64.adif",
             "output_format": "Unknown",
-            "result": "45fc46d86e78b09f6277591a34fc2793"
+            "result": "45fc46d86e78b09f6277591a34fc2793",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05_16",
@@ -2217,7 +2493,8 @@
             "source_checksum": "46466377ece9f768efd423836a600bd2",
             "input_file": "al05_16.adif",
             "output_format": "Unknown",
-            "result": "3e17aa815d1dfbb8228c0723179d9840"
+            "result": "3e17aa815d1dfbb8228c0723179d9840",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17_88",
@@ -2225,7 +2502,8 @@
             "source_checksum": "e7087dd37dd943ed8c718916472bd34f",
             "input_file": "al17_88.adif",
             "output_format": "Unknown",
-            "result": "ad70e0b02635cfcb30c928dc70b4ef05"
+            "result": "ad70e0b02635cfcb30c928dc70b4ef05",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al11_16",
@@ -2233,7 +2511,8 @@
             "source_checksum": "48c617c21b8f39d49539cf70864e37b3",
             "input_file": "al11_16.adif",
             "output_format": "Unknown",
-            "result": "56c62176823bf381fb8544ab7afac53f"
+            "result": "56c62176823bf381fb8544ab7afac53f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as14_88",
@@ -2241,7 +2520,8 @@
             "source_checksum": "162557a17004be6e524cff529b5c9f81",
             "input_file": "as14_88.adif",
             "output_format": "Unknown",
-            "result": "28e85247ea8004cd8253429f6c1e7248"
+            "result": "28e85247ea8004cd8253429f6c1e7248",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al17_16",
@@ -2249,7 +2529,8 @@
             "source_checksum": "27123fef4142e7839d94297ddafe3635",
             "input_file": "al17_16.adif",
             "output_format": "Unknown",
-            "result": "578f691643c105bc6e12665c4f595a0a"
+            "result": "578f691643c105bc6e12665c4f595a0a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am01_64",
@@ -2257,7 +2538,8 @@
             "source_checksum": "c700995285943645467e0bca4be4203b",
             "input_file": "am01_64.adif",
             "output_format": "Unknown",
-            "result": "a6f2f72dbb23e693d815cdcb77d4e0e7"
+            "result": "a6f2f72dbb23e693d815cdcb77d4e0e7",
+            "profile": "AAC Main"
         },
         {
             "name": "as09_96",
@@ -2265,7 +2547,8 @@
             "source_checksum": "469b6a7aaf50fa2b8a346f19b70fe7d7",
             "input_file": "as09_96.adif",
             "output_format": "Unknown",
-            "result": "dacba353af93ca1befcabcc4e4d28e0a"
+            "result": "dacba353af93ca1befcabcc4e4d28e0a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as11_44",
@@ -2273,7 +2556,8 @@
             "source_checksum": "2a4da877c3efba23e6b17a97fde04ef7",
             "input_file": "as11_44.adif",
             "output_format": "Unknown",
-            "result": "6faa8f6cad155d54f232fdfcc1c1a001"
+            "result": "6faa8f6cad155d54f232fdfcc1c1a001",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al00_08",
@@ -2281,7 +2565,8 @@
             "source_checksum": "28f92ffac6e9d6902d48b5deabc5f19c",
             "input_file": "al00_08.adif",
             "output_format": "Unknown",
-            "result": "974fc5db0dd85a5240956a8a5e593469"
+            "result": "974fc5db0dd85a5240956a8a5e593469",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as12_64",
@@ -2289,7 +2574,8 @@
             "source_checksum": "fda3af28f356a0d24ba9afc2f46ec6bd",
             "input_file": "as12_64.adif",
             "output_format": "Unknown",
-            "result": "8839665fc97bff6a189aff3bc2d914e9"
+            "result": "8839665fc97bff6a189aff3bc2d914e9",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am04_32",
@@ -2297,7 +2583,8 @@
             "source_checksum": "651df35d42e4ff5c2de6012778578a56",
             "input_file": "am04_32.adif",
             "output_format": "Unknown",
-            "result": "ec52fee00142a4c1c7777d5ed7348ac6"
+            "result": "ec52fee00142a4c1c7777d5ed7348ac6",
+            "profile": "AAC Main"
         },
         {
             "name": "as06_32",
@@ -2305,7 +2592,8 @@
             "source_checksum": "d1604f527022a000c07ee30e9fad75bf",
             "input_file": "as06_32.adif",
             "output_format": "Unknown",
-            "result": "fcf22800a2bd08404106ba73071589e9"
+            "result": "fcf22800a2bd08404106ba73071589e9",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as12_48",
@@ -2313,7 +2601,8 @@
             "source_checksum": "e0ace25c053ce4e8af121375d7b1a5a6",
             "input_file": "as12_48.adif",
             "output_format": "Unknown",
-            "result": "4dc47947189b4cf08e4f5feee6b2ea48"
+            "result": "4dc47947189b4cf08e4f5feee6b2ea48",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03_16",
@@ -2321,7 +2610,8 @@
             "source_checksum": "d8409e2181a0afe5a23bfebd466f663e",
             "input_file": "al03_16.adif",
             "output_format": "Unknown",
-            "result": "98b5f0df41b303b02037224f09cf45ea"
+            "result": "98b5f0df41b303b02037224f09cf45ea",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_12",
@@ -2329,7 +2619,8 @@
             "source_checksum": "e431501fbb8f33b65a4662dd7e9218f7",
             "input_file": "al04_12.adif",
             "output_format": "Unknown",
-            "result": "4320324e32f3eb59a745643911e04e99"
+            "result": "4320324e32f3eb59a745643911e04e99",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am03_88",
@@ -2337,7 +2628,8 @@
             "source_checksum": "045650406792561579df0dfec7b170bd",
             "input_file": "am03_88.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "",
+            "profile": "AAC Main"
         },
         {
             "name": "am02_24",
@@ -2345,7 +2637,8 @@
             "source_checksum": "318901fe746911a3ab79b7705298a089",
             "input_file": "am02_24.adif",
             "output_format": "Unknown",
-            "result": "5af42c51a7b2968efb484f0ad933a157"
+            "result": "5af42c51a7b2968efb484f0ad933a157",
+            "profile": "AAC Main"
         },
         {
             "name": "al15_08",
@@ -2353,7 +2646,8 @@
             "source_checksum": "c351bb10904374e006adbedc3a94ad82",
             "input_file": "al15_08.adif",
             "output_format": "Unknown",
-            "result": "cc0eaf34dccfa2702c3dc87e41eae088"
+            "result": "cc0eaf34dccfa2702c3dc87e41eae088",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as07_44",
@@ -2361,7 +2655,8 @@
             "source_checksum": "a91d0157422b124bda52c187b3a53cf1",
             "input_file": "as07_44.adif",
             "output_format": "Unknown",
-            "result": "085350565881a963a3ad4cae99a91f02"
+            "result": "085350565881a963a3ad4cae99a91f02",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06_48",
@@ -2369,7 +2664,8 @@
             "source_checksum": "f5dfeb9040b05bc9f254f87e39f37978",
             "input_file": "al06_48.adif",
             "output_format": "Unknown",
-            "result": "4979e6a7e1e61e051c85d1b7d738845f"
+            "result": "4979e6a7e1e61e051c85d1b7d738845f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as08_16",
@@ -2377,7 +2673,8 @@
             "source_checksum": "3fa5924deb11931fe2f743a96054058a",
             "input_file": "as08_16.adif",
             "output_format": "Unknown",
-            "result": "de780ed0c5bc65a8b7fc268dda22b8b5"
+            "result": "de780ed0c5bc65a8b7fc268dda22b8b5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al10_12",
@@ -2385,7 +2682,8 @@
             "source_checksum": "8d0bb47777f83aa00c0a3ed9553b5e9b",
             "input_file": "al10_12.adif",
             "output_format": "Unknown",
-            "result": "38c1ba5d4543309ae6c9aa1ee38eb242"
+            "result": "38c1ba5d4543309ae6c9aa1ee38eb242",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as00_08",
@@ -2393,7 +2691,8 @@
             "source_checksum": "c29f62f26e46869b584c509a91465894",
             "input_file": "as00_08.adif",
             "output_format": "Unknown",
-            "result": "f852727b02e8195bc975fe7342821cb3"
+            "result": "f852727b02e8195bc975fe7342821cb3",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08_16",
@@ -2401,7 +2700,8 @@
             "source_checksum": "1247c1221eaeae9f3ca1f0c8c3aa531d",
             "input_file": "al08_16.adif",
             "output_format": "Unknown",
-            "result": "cbb19d0daf6f45e3cfafbf2d9780d758"
+            "result": "cbb19d0daf6f45e3cfafbf2d9780d758",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am07_44",
@@ -2409,7 +2709,8 @@
             "source_checksum": "7055d3ac07b0e7240fdb385b682bcc93",
             "input_file": "am07_44.adif",
             "output_format": "Unknown",
-            "result": "6ecc879ff4cf68e13ac061e8408c98cd"
+            "result": "6ecc879ff4cf68e13ac061e8408c98cd",
+            "profile": "AAC Main"
         },
         {
             "name": "al14_22",
@@ -2417,7 +2718,8 @@
             "source_checksum": "bd7bb659b39ec5b79ef1917b995dd427",
             "input_file": "al14_22.adif",
             "output_format": "Unknown",
-            "result": "9e85dec1e7c4e72e889eeb3b9a7c5d02"
+            "result": "9e85dec1e7c4e72e889eeb3b9a7c5d02",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_16",
@@ -2425,7 +2727,8 @@
             "source_checksum": "da2ce2e8909132d9fe7d5965b13b2398",
             "input_file": "am00_16.adif",
             "output_format": "Unknown",
-            "result": "2f5b31721e04afd861d59a6194308565"
+            "result": "2f5b31721e04afd861d59a6194308565",
+            "profile": "AAC Main"
         },
         {
             "name": "al06_24",
@@ -2433,7 +2736,8 @@
             "source_checksum": "473bd942a3fe600536000145a182ed5b",
             "input_file": "al06_24.adif",
             "output_format": "Unknown",
-            "result": "7608666b6e0dfeca71883389302f2fe0"
+            "result": "7608666b6e0dfeca71883389302f2fe0",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02_24",
@@ -2441,7 +2745,8 @@
             "source_checksum": "e09d9c42e1638fe643201c101626a57c",
             "input_file": "al02_24.adif",
             "output_format": "Unknown",
-            "result": "db09ed12bdb1cbaf49dfe9bd7e1046b5"
+            "result": "db09ed12bdb1cbaf49dfe9bd7e1046b5",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as03_22",
@@ -2449,7 +2754,8 @@
             "source_checksum": "2c6ad17ff9f1d2ead09ca0ba7bd28b69",
             "input_file": "as03_22.adif",
             "output_format": "Unknown",
-            "result": "60873fde0040eae4680267487c338185"
+            "result": "60873fde0040eae4680267487c338185",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am07_24",
@@ -2457,7 +2763,8 @@
             "source_checksum": "3bbc106d00d15af257c60ed8c919bb06",
             "input_file": "am07_24.adif",
             "output_format": "Unknown",
-            "result": "4478b0d80332c389dfd048641dd225c8"
+            "result": "4478b0d80332c389dfd048641dd225c8",
+            "profile": "AAC Main"
         },
         {
             "name": "as16_24",
@@ -2465,7 +2772,8 @@
             "source_checksum": "b860919f417f12608818613027221504",
             "input_file": "as16_24.adif",
             "output_format": "Unknown",
-            "result": "9576e0ff192755ea369507485c58279e"
+            "result": "9576e0ff192755ea369507485c58279e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al16_96",
@@ -2473,7 +2781,8 @@
             "source_checksum": "49d0c08f2e76329ef65ba8cd5de02a1a",
             "input_file": "al16_96.adif",
             "output_format": "Unknown",
-            "result": "0f621d7167bfe6b3bacd7d74b2369875"
+            "result": "0f621d7167bfe6b3bacd7d74b2369875",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as06_24",
@@ -2481,7 +2790,8 @@
             "source_checksum": "0bdde69c632529ed01881784ba2b20b9",
             "input_file": "as06_24.adif",
             "output_format": "Unknown",
-            "result": "2d6e341afd09aa7225a3286e6aeca4e7"
+            "result": "2d6e341afd09aa7225a3286e6aeca4e7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al16_16",
@@ -2489,7 +2799,8 @@
             "source_checksum": "8ef8cf87ae8f0b95c1c62efd8a851dd7",
             "input_file": "al16_16.adif",
             "output_format": "Unknown",
-            "result": "0f98f372b70cdb58f24d868c6c792610"
+            "result": "0f98f372b70cdb58f24d868c6c792610",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05_48",
@@ -2497,7 +2808,8 @@
             "source_checksum": "d7f21b4772a6d7200311ed2748f2243e",
             "input_file": "al05_48.adif",
             "output_format": "Unknown",
-            "result": "d72ef57b7bad160905b7d1650360c474"
+            "result": "d72ef57b7bad160905b7d1650360c474",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14_24",
@@ -2505,7 +2817,8 @@
             "source_checksum": "2c1bf0af880429c3131379670884a87d",
             "input_file": "al14_24.adif",
             "output_format": "Unknown",
-            "result": "744f7fd7aef4005110b26134c89938f6"
+            "result": "744f7fd7aef4005110b26134c89938f6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02_11",
@@ -2513,7 +2826,8 @@
             "source_checksum": "dd0f6ad621f67b522954ea86b51261fd",
             "input_file": "al02_11.adif",
             "output_format": "Unknown",
-            "result": "6919665a2023157452cff79d0ea54f4c"
+            "result": "6919665a2023157452cff79d0ea54f4c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as16_96",
@@ -2521,7 +2835,8 @@
             "source_checksum": "ef061cb8ec1b71cfa772e8acecd3a3b6",
             "input_file": "as16_96.adif",
             "output_format": "Unknown",
-            "result": "cb972cdb4e5c63d467f7776fa3828699"
+            "result": "cb972cdb4e5c63d467f7776fa3828699",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as10_24",
@@ -2529,7 +2844,8 @@
             "source_checksum": "3b5a1835c89796817665e46085616a6f",
             "input_file": "as10_24.adif",
             "output_format": "Unknown",
-            "result": "b3e9246d5753333f14341f4cefd6edf2"
+            "result": "b3e9246d5753333f14341f4cefd6edf2",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as05_16",
@@ -2537,7 +2853,8 @@
             "source_checksum": "69197de50712adb3921331fea1325fbe",
             "input_file": "as05_16.adif",
             "output_format": "Unknown",
-            "result": "748cfa097ad0e6fce489f0a44a788742"
+            "result": "748cfa097ad0e6fce489f0a44a788742",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al17_96",
@@ -2545,7 +2862,8 @@
             "source_checksum": "6c47815257e74d28fe1536bdce8070bb",
             "input_file": "al17_96.adif",
             "output_format": "Unknown",
-            "result": "2db5470e36e27f85dbbe9e49d1ff0c13"
+            "result": "2db5470e36e27f85dbbe9e49d1ff0c13",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as04_12",
@@ -2553,7 +2871,8 @@
             "source_checksum": "06380ae021e223877b57d8d8ae757aa0",
             "input_file": "as04_12.adif",
             "output_format": "Unknown",
-            "result": "1f56b8ef778b40628b873e55c03dba60"
+            "result": "1f56b8ef778b40628b873e55c03dba60",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03_64",
@@ -2561,7 +2880,8 @@
             "source_checksum": "21d2d76310871a46b9ee72198d384a02",
             "input_file": "al03_64.adif",
             "output_format": "Unknown",
-            "result": "352d2c45ae42514dde7d018bbcdd538c"
+            "result": "352d2c45ae42514dde7d018bbcdd538c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02_44",
@@ -2569,7 +2889,8 @@
             "source_checksum": "ecbed11de361afd7cfb639f95957e9fa",
             "input_file": "al02_44.adif",
             "output_format": "Unknown",
-            "result": "976f11accce8764adff7f6fe13c1d204"
+            "result": "976f11accce8764adff7f6fe13c1d204",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as17_22",
@@ -2577,7 +2898,8 @@
             "source_checksum": "6d91a0fc5b7694b410f5c4fa8a3b785d",
             "input_file": "as17_22.adif",
             "output_format": "Unknown",
-            "result": "8f1c79031d95623682ecf9fd8e33392a"
+            "result": "8f1c79031d95623682ecf9fd8e33392a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as01_24",
@@ -2585,7 +2907,8 @@
             "source_checksum": "1c892b72b201ad7727e15d29156e1c90",
             "input_file": "as01_24.adif",
             "output_format": "Unknown",
-            "result": "a8f4b97f487b82cbe3267f4e06c0f487"
+            "result": "a8f4b97f487b82cbe3267f4e06c0f487",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am02_32",
@@ -2593,7 +2916,8 @@
             "source_checksum": "3595d955fc9d5b1e8f9e12bd03d784a8",
             "input_file": "am02_32.adif",
             "output_format": "Unknown",
-            "result": "a88295fef84eb1c1d62083daec20c9b2"
+            "result": "a88295fef84eb1c1d62083daec20c9b2",
+            "profile": "AAC Main"
         },
         {
             "name": "am07_22",
@@ -2601,7 +2925,8 @@
             "source_checksum": "3a8242c2464e4a0b3225d6a1874b638d",
             "input_file": "am07_22.adif",
             "output_format": "Unknown",
-            "result": "bfd80104fd69bdea14cc746d185d6b44"
+            "result": "bfd80104fd69bdea14cc746d185d6b44",
+            "profile": "AAC Main"
         },
         {
             "name": "am05_08",
@@ -2609,7 +2934,8 @@
             "source_checksum": "07a00475dd08af84b7c5b5b3a18d7bb2",
             "input_file": "am05_08.adif",
             "output_format": "Unknown",
-            "result": "e76a4fad9680315bdebd7df663554222"
+            "result": "e76a4fad9680315bdebd7df663554222",
+            "profile": "AAC Main"
         },
         {
             "name": "al05_11",
@@ -2617,7 +2943,8 @@
             "source_checksum": "e35a25f489d4aa3f319af84b262d7c61",
             "input_file": "al05_11.adif",
             "output_format": "Unknown",
-            "result": "915e57e4e3865a3ea6a0d4e89f81ba45"
+            "result": "915e57e4e3865a3ea6a0d4e89f81ba45",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01_96",
@@ -2625,7 +2952,8 @@
             "source_checksum": "60907ad644ed1720c4ba1b36cfef10db",
             "input_file": "al01_96.adif",
             "output_format": "Unknown",
-            "result": "4677b93aa04c55103ebd1dce77c6f4c8"
+            "result": "4677b93aa04c55103ebd1dce77c6f4c8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as03_96",
@@ -2633,7 +2961,8 @@
             "source_checksum": "9d33b9418f75be820c9361f3933cf53b",
             "input_file": "as03_96.adif",
             "output_format": "Unknown",
-            "result": "821297607b9b166cebad6a5ba5de4dc7"
+            "result": "821297607b9b166cebad6a5ba5de4dc7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as08_24",
@@ -2641,7 +2970,8 @@
             "source_checksum": "8b4298e5f1f7f76b88220a3f758ed975",
             "input_file": "as08_24.adif",
             "output_format": "Unknown",
-            "result": "b081fdd346de4da4a7896cfaecba28e1"
+            "result": "b081fdd346de4da4a7896cfaecba28e1",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08_08",
@@ -2649,7 +2979,8 @@
             "source_checksum": "ccff973470212ceb4d4423dbd29adf31",
             "input_file": "al08_08.adif",
             "output_format": "Unknown",
-            "result": "6d7174d75cfe8faf8de3b66f5258f595"
+            "result": "6d7174d75cfe8faf8de3b66f5258f595",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am01_44",
@@ -2657,7 +2988,8 @@
             "source_checksum": "103a80fd7149ca10c77a06d0cec6b4bd",
             "input_file": "am01_44.adif",
             "output_format": "Unknown",
-            "result": "bd59a63283c94d5f5c0c0046d06481e9"
+            "result": "bd59a63283c94d5f5c0c0046d06481e9",
+            "profile": "AAC Main"
         },
         {
             "name": "as12_08",
@@ -2665,7 +2997,8 @@
             "source_checksum": "0f88f3f7bf05f5a44fd203b84b445118",
             "input_file": "as12_08.adif",
             "output_format": "Unknown",
-            "result": "ada25d771c467cdc3112323b11cb9251"
+            "result": "ada25d771c467cdc3112323b11cb9251",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as16_64",
@@ -2673,7 +3006,8 @@
             "source_checksum": "fd04e42e382f2bed77f9f31b9dfd612f",
             "input_file": "as16_64.adif",
             "output_format": "Unknown",
-            "result": "f2c8633c48bbec94ce6d900aaf4d1bd2"
+            "result": "f2c8633c48bbec94ce6d900aaf4d1bd2",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as05_64",
@@ -2681,7 +3015,8 @@
             "source_checksum": "5ad04e2e5dac2447b8b3694597b4d4ee",
             "input_file": "as05_64.adif",
             "output_format": "Unknown",
-            "result": "82667487c94e609a16cd32285574253c"
+            "result": "82667487c94e609a16cd32285574253c",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as13_48",
@@ -2689,7 +3024,8 @@
             "source_checksum": "b6925dbbee31aeb5dd086fc098610412",
             "input_file": "as13_48.adif",
             "output_format": "Unknown",
-            "result": "c9a81a0fa18615801cdc39e5b163f671"
+            "result": "c9a81a0fa18615801cdc39e5b163f671",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al11_88",
@@ -2697,7 +3033,8 @@
             "source_checksum": "2b5ab09c85a9822ad067f8c3f8959d66",
             "input_file": "al11_88.adif",
             "output_format": "Unknown",
-            "result": "b8c525add273b5c290f71a807a1c4b69"
+            "result": "b8c525add273b5c290f71a807a1c4b69",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am07_11",
@@ -2705,7 +3042,8 @@
             "source_checksum": "9ee732353f7e053d2ee756f768d10a7e",
             "input_file": "am07_11.adif",
             "output_format": "Unknown",
-            "result": "ea443195941ce65c0cf6be5e64433271"
+            "result": "ea443195941ce65c0cf6be5e64433271",
+            "profile": "AAC Main"
         },
         {
             "name": "am07_64",
@@ -2713,7 +3051,8 @@
             "source_checksum": "db76927fcbc32bea6e604479f32f67d4",
             "input_file": "am07_64.adif",
             "output_format": "Unknown",
-            "result": "c46be40e124ce8c2aea9610d61e25e26"
+            "result": "c46be40e124ce8c2aea9610d61e25e26",
+            "profile": "AAC Main"
         },
         {
             "name": "al00_32",
@@ -2721,7 +3060,8 @@
             "source_checksum": "7edef8328dd3141626a961eae4189016",
             "input_file": "al00_32.adif",
             "output_format": "Unknown",
-            "result": "9379f05a63dbbf78e458e88f8b36a4bc"
+            "result": "9379f05a63dbbf78e458e88f8b36a4bc",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as05_24",
@@ -2729,7 +3069,8 @@
             "source_checksum": "1fa99bef828ec0c1952d9b79cd4e5588",
             "input_file": "as05_24.adif",
             "output_format": "Unknown",
-            "result": "671432646fd41c54fe0b025f278ad3d5"
+            "result": "671432646fd41c54fe0b025f278ad3d5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al04_64",
@@ -2737,7 +3078,8 @@
             "source_checksum": "6427cd4305de6aaee0132d654dcd11a7",
             "input_file": "al04_64.adif",
             "output_format": "Unknown",
-            "result": "334e1e916f28c240965ed8e8f3ce6b38"
+            "result": "334e1e916f28c240965ed8e8f3ce6b38",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as16_16",
@@ -2745,7 +3087,8 @@
             "source_checksum": "7143d8c054135ef339481af572236aa9",
             "input_file": "as16_16.adif",
             "output_format": "Unknown",
-            "result": "481c7a271bd4621dac6475e038a66998"
+            "result": "481c7a271bd4621dac6475e038a66998",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am02_08",
@@ -2753,7 +3096,8 @@
             "source_checksum": "339a14afbdff567391e8e7637add2997",
             "input_file": "am02_08.adif",
             "output_format": "Unknown",
-            "result": "c1e3516dadbb4efbae4dd6103276e4e2"
+            "result": "c1e3516dadbb4efbae4dd6103276e4e2",
+            "profile": "AAC Main"
         },
         {
             "name": "as04_44",
@@ -2761,7 +3105,8 @@
             "source_checksum": "bac487b913571943a47eb3a3afac51a7",
             "input_file": "as04_44.adif",
             "output_format": "Unknown",
-            "result": "ae6dbe2fb03f50ef1498e9b483c988c5"
+            "result": "ae6dbe2fb03f50ef1498e9b483c988c5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am05_22",
@@ -2769,7 +3114,8 @@
             "source_checksum": "90a0e04fc17447cc2f788e11ebabe204",
             "input_file": "am05_22.adif",
             "output_format": "Unknown",
-            "result": "86fb8e82f33af5d740b856f81a80eb71"
+            "result": "86fb8e82f33af5d740b856f81a80eb71",
+            "profile": "AAC Main"
         },
         {
             "name": "am07_96",
@@ -2777,7 +3123,8 @@
             "source_checksum": "404dd06f53f9daed60c5a7b785da28e2",
             "input_file": "am07_96.adif",
             "output_format": "Unknown",
-            "result": "06e1bc42c0173b3f1541983b8ab8d5d9"
+            "result": "06e1bc42c0173b3f1541983b8ab8d5d9",
+            "profile": "AAC Main"
         },
         {
             "name": "as03_11",
@@ -2785,7 +3132,8 @@
             "source_checksum": "d9f2b0ab1bd8c5d36985d6c1a2174292",
             "input_file": "as03_11.adif",
             "output_format": "Unknown",
-            "result": "5ae89c7acd05098ab622609fc0ea2750"
+            "result": "5ae89c7acd05098ab622609fc0ea2750",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as00_64",
@@ -2793,7 +3141,8 @@
             "source_checksum": "27acef7c347a077db5c08457fba3eafe",
             "input_file": "as00_64.adif",
             "output_format": "Unknown",
-            "result": "1b1b0e509d85afae5f2b6df6ddecbadd"
+            "result": "1b1b0e509d85afae5f2b6df6ddecbadd",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al04_88",
@@ -2801,7 +3150,8 @@
             "source_checksum": "7f9458adfc0a322ca02df23800606e08",
             "input_file": "al04_88.adif",
             "output_format": "Unknown",
-            "result": "854a65ea3d37c7357482d415acaf826e"
+            "result": "854a65ea3d37c7357482d415acaf826e",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as05_22",
@@ -2809,7 +3159,8 @@
             "source_checksum": "06956f3952b58791c6186c1b0b136c5e",
             "input_file": "as05_22.adif",
             "output_format": "Unknown",
-            "result": "bbd39cff4466d45eb47427488d5332db"
+            "result": "bbd39cff4466d45eb47427488d5332db",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am07_88",
@@ -2817,7 +3168,8 @@
             "source_checksum": "739386e9c6d4095912e6e3a4da5d4e85",
             "input_file": "am07_88.adif",
             "output_format": "Unknown",
-            "result": "06ef16e7803a494af0c19ad949273c62"
+            "result": "06ef16e7803a494af0c19ad949273c62",
+            "profile": "AAC Main"
         },
         {
             "name": "al06_64",
@@ -2825,7 +3177,8 @@
             "source_checksum": "af7ce6e94f9b72c2b116993ca223a6cc",
             "input_file": "al06_64.adif",
             "output_format": "Unknown",
-            "result": "2680ff601df3c7a330656ef0d6d76f6b"
+            "result": "2680ff601df3c7a330656ef0d6d76f6b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as06_44",
@@ -2833,7 +3186,8 @@
             "source_checksum": "4bed53ce51b8b9c9757b59a57c97aff5",
             "input_file": "as06_44.adif",
             "output_format": "Unknown",
-            "result": "23f4438eb7a24465d9c1ad6b18d3fe94"
+            "result": "23f4438eb7a24465d9c1ad6b18d3fe94",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as05_12",
@@ -2841,7 +3195,8 @@
             "source_checksum": "ec86382f15428f62d241e2e9271e294b",
             "input_file": "as05_12.adif",
             "output_format": "Unknown",
-            "result": "5f962095c6a282b2d1de1628b91ff623"
+            "result": "5f962095c6a282b2d1de1628b91ff623",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am02_11",
@@ -2849,7 +3204,8 @@
             "source_checksum": "e6572538093228240b1b37f7114c59da",
             "input_file": "am02_11.adif",
             "output_format": "Unknown",
-            "result": "90a57c1f6b8d6d79b8356b734c1c98e4"
+            "result": "90a57c1f6b8d6d79b8356b734c1c98e4",
+            "profile": "AAC Main"
         },
         {
             "name": "as07_88",
@@ -2857,7 +3213,8 @@
             "source_checksum": "f3537e73bd64ddf571b49e8b9fd1c2c6",
             "input_file": "as07_88.adif",
             "output_format": "Unknown",
-            "result": "5f8f5e004f4e5ab7e72e5fdf87451f18"
+            "result": "5f8f5e004f4e5ab7e72e5fdf87451f18",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03_08",
@@ -2865,7 +3222,8 @@
             "source_checksum": "989b4f80831b565e0b864644023dbcf1",
             "input_file": "al03_08.adif",
             "output_format": "Unknown",
-            "result": "9e0c9f7586ea7460b87d47f03a2e64d9"
+            "result": "9e0c9f7586ea7460b87d47f03a2e64d9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al11_22",
@@ -2873,7 +3231,8 @@
             "source_checksum": "9f905477f219d8272bc9b3e1d1d444ab",
             "input_file": "al11_22.adif",
             "output_format": "Unknown",
-            "result": "e6c07de6c6cbf92bd9c53308443f8c35"
+            "result": "e6c07de6c6cbf92bd9c53308443f8c35",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as17_12",
@@ -2881,7 +3240,8 @@
             "source_checksum": "b8f02bf79a327bbdad850bdeb0518cee",
             "input_file": "as17_12.adif",
             "output_format": "Unknown",
-            "result": "5a4f0593e9931db3b638b234a6796cc0"
+            "result": "5a4f0593e9931db3b638b234a6796cc0",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as14_11",
@@ -2889,7 +3249,8 @@
             "source_checksum": "eba878a65975e0257a034d889b6eabf2",
             "input_file": "as14_11.adif",
             "output_format": "Unknown",
-            "result": "66be4d61aa2181af657c5da70f141a96"
+            "result": "66be4d61aa2181af657c5da70f141a96",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al17_44",
@@ -2897,7 +3258,8 @@
             "source_checksum": "25124ba3c9b3eef6b5b2cd340565aeae",
             "input_file": "al17_44.adif",
             "output_format": "Unknown",
-            "result": "784fdd0888e46c9ec4eb50a08fdb3cc6"
+            "result": "784fdd0888e46c9ec4eb50a08fdb3cc6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14_64",
@@ -2905,7 +3267,8 @@
             "source_checksum": "2eaef1ec336dc8f133a204be988afa2d",
             "input_file": "al14_64.adif",
             "output_format": "Unknown",
-            "result": "fee87c426ffe310d83008121fa592bd9"
+            "result": "fee87c426ffe310d83008121fa592bd9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14_88",
@@ -2913,7 +3276,8 @@
             "source_checksum": "1e36945ac8697b0a8ca02f0b6c00f6e7",
             "input_file": "al14_88.adif",
             "output_format": "Unknown",
-            "result": "93099bfdaf22a5847e010eef08f10537"
+            "result": "93099bfdaf22a5847e010eef08f10537",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am03_22",
@@ -2921,7 +3285,8 @@
             "source_checksum": "5558b006df8b5aa624c2dccc688d5cca",
             "input_file": "am03_22.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "",
+            "profile": "AAC Main"
         },
         {
             "name": "as07_16",
@@ -2929,7 +3294,8 @@
             "source_checksum": "ab280a740f420e42b58345b9825eb67c",
             "input_file": "as07_16.adif",
             "output_format": "Unknown",
-            "result": "d5378da42756fbee3af7ed323020dea8"
+            "result": "d5378da42756fbee3af7ed323020dea8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03_24",
@@ -2937,7 +3303,8 @@
             "source_checksum": "13efd26dcc7242256978bd4525123b5d",
             "input_file": "al03_24.adif",
             "output_format": "Unknown",
-            "result": "b1b73118761159fff81b5c7af18892c7"
+            "result": "b1b73118761159fff81b5c7af18892c7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14_16",
@@ -2945,7 +3312,8 @@
             "source_checksum": "5ad60fcc3883956a31308062052075ec",
             "input_file": "al14_16.adif",
             "output_format": "Unknown",
-            "result": "adcf17383ea63c860aca7c047bb4acd5"
+            "result": "adcf17383ea63c860aca7c047bb4acd5",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as15_24",
@@ -2953,7 +3321,8 @@
             "source_checksum": "e6f2d3f188e6f6a3f5e24cf6addc508c",
             "input_file": "as15_24.adif",
             "output_format": "Unknown",
-            "result": "02bfc42a74201206630237e4c7ad381e"
+            "result": "02bfc42a74201206630237e4c7ad381e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03_88",
@@ -2961,7 +3330,8 @@
             "source_checksum": "e249e577aa5b3ba59e60c0a9094d4dfb",
             "input_file": "al03_88.adif",
             "output_format": "Unknown",
-            "result": "582225859b9df6f9bb2a25c7ec843fdd"
+            "result": "582225859b9df6f9bb2a25c7ec843fdd",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as11_24",
@@ -2969,7 +3339,8 @@
             "source_checksum": "c9f65e9c419ec6bd98a2d8f5e9fa29bb",
             "input_file": "as11_24.adif",
             "output_format": "Unknown",
-            "result": "e293ad22f9eb770a524d17288b774880"
+            "result": "e293ad22f9eb770a524d17288b774880",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al01_24",
@@ -2977,7 +3348,8 @@
             "source_checksum": "572b9c5f055fb034ff5532cc727876eb",
             "input_file": "al01_24.adif",
             "output_format": "Unknown",
-            "result": "2a1f9b80e590bf4009bdcc7feab11a47"
+            "result": "2a1f9b80e590bf4009bdcc7feab11a47",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as14_12",
@@ -2985,7 +3357,8 @@
             "source_checksum": "2d7bfb85397ce77c49803a5116dcc7f8",
             "input_file": "as14_12.adif",
             "output_format": "Unknown",
-            "result": "cb0d5dbdfddc30ad05585e911fc73d59"
+            "result": "cb0d5dbdfddc30ad05585e911fc73d59",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as07_22",
@@ -2993,7 +3366,8 @@
             "source_checksum": "3f037c07a8504868b5a0621987ce50ab",
             "input_file": "as07_22.adif",
             "output_format": "Unknown",
-            "result": "ab4981a6ac7a37d903277c886a14b893"
+            "result": "ab4981a6ac7a37d903277c886a14b893",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al04_44",
@@ -3001,7 +3375,8 @@
             "source_checksum": "31fa1db0b5049970a552b663053c50f3",
             "input_file": "al04_44.adif",
             "output_format": "Unknown",
-            "result": "c0955b55a2703be93ad451a3c0cde34d"
+            "result": "c0955b55a2703be93ad451a3c0cde34d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al15_11",
@@ -3009,7 +3384,8 @@
             "source_checksum": "552f8031828503e675de899c9d1eb6ef",
             "input_file": "al15_11.adif",
             "output_format": "Unknown",
-            "result": "c3622054f2b0ca90bc221444060f19ed"
+            "result": "c3622054f2b0ca90bc221444060f19ed",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as00_22",
@@ -3017,7 +3393,8 @@
             "source_checksum": "7bbd9ee9b83922fde8364fd5d5b7620a",
             "input_file": "as00_22.adif",
             "output_format": "Unknown",
-            "result": "a4a12aa95046d129e976ce367ca751a7"
+            "result": "a4a12aa95046d129e976ce367ca751a7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as02_64",
@@ -3025,7 +3402,8 @@
             "source_checksum": "c065eebafbe7657da9b53dafe57cc546",
             "input_file": "as02_64.adif",
             "output_format": "Unknown",
-            "result": "251ea0e1b3821235909aba69892ad7d8"
+            "result": "251ea0e1b3821235909aba69892ad7d8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06_32",
@@ -3033,7 +3411,8 @@
             "source_checksum": "2bce6678ff9e9f1cb85484716ed53a67",
             "input_file": "al06_32.adif",
             "output_format": "Unknown",
-            "result": "b4992535a9e4ce3ce07c8b32cee3de7f"
+            "result": "b4992535a9e4ce3ce07c8b32cee3de7f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01_48",
@@ -3041,7 +3420,8 @@
             "source_checksum": "3eb30143e9bf29d8410a22c3e1926f27",
             "input_file": "al01_48.adif",
             "output_format": "Unknown",
-            "result": "300f8cc27d8b5abfe5720b69f398bad2"
+            "result": "300f8cc27d8b5abfe5720b69f398bad2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as10_16",
@@ -3049,7 +3429,8 @@
             "source_checksum": "f9c624958552b23464d324fa4acee851",
             "input_file": "as10_16.adif",
             "output_format": "Unknown",
-            "result": "075d22277ae9e0a8b47cd7c028a4d3c0"
+            "result": "075d22277ae9e0a8b47cd7c028a4d3c0",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al01_88",
@@ -3057,7 +3438,8 @@
             "source_checksum": "4dc619d077188541e235c878fb16aa18",
             "input_file": "al01_88.adif",
             "output_format": "Unknown",
-            "result": "444692a2f66a9e51e07daec8a1d1a584"
+            "result": "444692a2f66a9e51e07daec8a1d1a584",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as17_44",
@@ -3065,7 +3447,8 @@
             "source_checksum": "7ff8c6ece773f09a305145cd3b9694b3",
             "input_file": "as17_44.adif",
             "output_format": "Unknown",
-            "result": "6cb48e019e3819c3b29af695278d478f"
+            "result": "6cb48e019e3819c3b29af695278d478f",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al01_11",
@@ -3073,7 +3456,8 @@
             "source_checksum": "ebc2916454bcfacabd96767727bde517",
             "input_file": "al01_11.adif",
             "output_format": "Unknown",
-            "result": "68ebaf2c433c13381e815db62a7c3385"
+            "result": "68ebaf2c433c13381e815db62a7c3385",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00_44",
@@ -3081,7 +3465,8 @@
             "source_checksum": "36a42e265e8bd1f89a2cf61fd5ea6c61",
             "input_file": "al00_44.adif",
             "output_format": "Unknown",
-            "result": "31f0d7315b2d03acb22d7920f5814855"
+            "result": "31f0d7315b2d03acb22d7920f5814855",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00_24",
@@ -3089,7 +3474,8 @@
             "source_checksum": "9214f56b70778eedf86efce5cbe01abb",
             "input_file": "al00_24.adif",
             "output_format": "Unknown",
-            "result": "3440a3a7649138c087f6b6136314d19d"
+            "result": "3440a3a7649138c087f6b6136314d19d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as04_22",
@@ -3097,7 +3483,8 @@
             "source_checksum": "9e5d9aab1288a9e4587bd9b53ef453a5",
             "input_file": "as04_22.adif",
             "output_format": "Unknown",
-            "result": "8df4dd9c6101bc3fc187683955fbc2b6"
+            "result": "8df4dd9c6101bc3fc187683955fbc2b6",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as09_88",
@@ -3105,7 +3492,8 @@
             "source_checksum": "1de519becf6b1a695c30bc3437a1dcf0",
             "input_file": "as09_88.adif",
             "output_format": "Unknown",
-            "result": "3c45cb22edbf1ffbd69471f1f9e3057e"
+            "result": "3c45cb22edbf1ffbd69471f1f9e3057e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08_64",
@@ -3113,7 +3501,8 @@
             "source_checksum": "77fdf57c4afd908078c9b281aa5746d7",
             "input_file": "al08_64.adif",
             "output_format": "Unknown",
-            "result": "ef16dca24dd66e277185606679118055"
+            "result": "ef16dca24dd66e277185606679118055",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as16_08",
@@ -3121,7 +3510,8 @@
             "source_checksum": "fcb9f0badeb7d4e3211835bb7edac771",
             "input_file": "as16_08.adif",
             "output_format": "Unknown",
-            "result": "0e25ef87bf68f77a6aef86b1b91354cd"
+            "result": "0e25ef87bf68f77a6aef86b1b91354cd",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al07_24",
@@ -3129,7 +3519,8 @@
             "source_checksum": "c4bf3925aeb3af467244745b4ebc540c",
             "input_file": "al07_24.adif",
             "output_format": "Unknown",
-            "result": "3b76ec8fd5fa3d75b1ed903b712a8cad"
+            "result": "3b76ec8fd5fa3d75b1ed903b712a8cad",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am06_64",
@@ -3137,7 +3528,8 @@
             "source_checksum": "06d8d6da499c16119d0e5a7780af81ea",
             "input_file": "am06_64.adif",
             "output_format": "Unknown",
-            "result": "22cddc2b971b072b7f2157fd5d07f67a"
+            "result": "22cddc2b971b072b7f2157fd5d07f67a",
+            "profile": "AAC Main"
         },
         {
             "name": "as00_48",
@@ -3145,7 +3537,8 @@
             "source_checksum": "e76a5eb989020b4f069fd7a00a86ccc2",
             "input_file": "as00_48.adif",
             "output_format": "Unknown",
-            "result": "a061cf8a04c5706e71186aa23d4ee307"
+            "result": "a061cf8a04c5706e71186aa23d4ee307",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al17_12",
@@ -3153,7 +3546,8 @@
             "source_checksum": "43c19c3d7d4f964a60831732e00d6c71",
             "input_file": "al17_12.adif",
             "output_format": "Unknown",
-            "result": "bca856a6877d9a5324d8a1cf5cf8864c"
+            "result": "bca856a6877d9a5324d8a1cf5cf8864c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as09_16",
@@ -3161,7 +3555,8 @@
             "source_checksum": "76c179b6045123d5f907b79c35e7fcf0",
             "input_file": "as09_16.adif",
             "output_format": "Unknown",
-            "result": "5a610ae32b3dc675c9b76f7d31426795"
+            "result": "5a610ae32b3dc675c9b76f7d31426795",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as05_88",
@@ -3169,7 +3564,8 @@
             "source_checksum": "963a99bd47662cd1186ef0d73fe3e2e7",
             "input_file": "as05_88.adif",
             "output_format": "Unknown",
-            "result": "20b38c0d21a134e573d4d1ca748aad40"
+            "result": "20b38c0d21a134e573d4d1ca748aad40",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as14_08",
@@ -3177,7 +3573,8 @@
             "source_checksum": "52451ee7f52e11ddb8da1a7eb386c9e5",
             "input_file": "as14_08.adif",
             "output_format": "Unknown",
-            "result": "0e25ef87bf68f77a6aef86b1b91354cd"
+            "result": "0e25ef87bf68f77a6aef86b1b91354cd",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as14_64",
@@ -3185,7 +3582,8 @@
             "source_checksum": "0d945f6f35f9a0cfb3ad0c421bda76a1",
             "input_file": "as14_64.adif",
             "output_format": "Unknown",
-            "result": "f2c8633c48bbec94ce6d900aaf4d1bd2"
+            "result": "f2c8633c48bbec94ce6d900aaf4d1bd2",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al07_96",
@@ -3193,7 +3591,8 @@
             "source_checksum": "2bba4e42ed9b2c6f65c0d736c9548c8d",
             "input_file": "al07_96.adif",
             "output_format": "Unknown",
-            "result": "dfe19829b88062d92c52c209e41153c3"
+            "result": "dfe19829b88062d92c52c209e41153c3",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as11_32",
@@ -3201,7 +3600,8 @@
             "source_checksum": "51694dcbb79c47052551564a17fc3b88",
             "input_file": "as11_32.adif",
             "output_format": "Unknown",
-            "result": "52b9b783e682ce807b26425bfd01bbe7"
+            "result": "52b9b783e682ce807b26425bfd01bbe7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as09_22",
@@ -3209,7 +3609,8 @@
             "source_checksum": "22c671135ca4bc6a39a08fe1a4ca4d74",
             "input_file": "as09_22.adif",
             "output_format": "Unknown",
-            "result": "6b70f0fe4befa112330a1b4ca9ddd465"
+            "result": "6b70f0fe4befa112330a1b4ca9ddd465",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as04_08",
@@ -3217,7 +3618,8 @@
             "source_checksum": "dc59f40ec1a536b313c85db1e9e375f5",
             "input_file": "as04_08.adif",
             "output_format": "Unknown",
-            "result": "b981e023626023db892096c76c051e28"
+            "result": "b981e023626023db892096c76c051e28",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03_44",
@@ -3225,7 +3627,8 @@
             "source_checksum": "9805c2cff8d562f4bb50b7f7751bd45b",
             "input_file": "al03_44.adif",
             "output_format": "Unknown",
-            "result": "bc6428f68eeac99961b07928d5efb76f"
+            "result": "bc6428f68eeac99961b07928d5efb76f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as04_24",
@@ -3233,7 +3636,8 @@
             "source_checksum": "820dfc96a32d051d563ed9502876a86f",
             "input_file": "as04_24.adif",
             "output_format": "Unknown",
-            "result": "05807367a5683dedb6d3d549cd10db77"
+            "result": "05807367a5683dedb6d3d549cd10db77",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as09_44",
@@ -3241,7 +3645,8 @@
             "source_checksum": "0c403ad3a983a0e5479436171641e1b1",
             "input_file": "as09_44.adif",
             "output_format": "Unknown",
-            "result": "1c94b07c439b666ba0a70cac1f6738fc"
+            "result": "1c94b07c439b666ba0a70cac1f6738fc",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al07_22",
@@ -3249,7 +3654,8 @@
             "source_checksum": "23bd303c7e2e5005d0577273b64e7e13",
             "input_file": "al07_22.adif",
             "output_format": "Unknown",
-            "result": "3b76ec8fd5fa3d75b1ed903b712a8cad"
+            "result": "3b76ec8fd5fa3d75b1ed903b712a8cad",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08_96",
@@ -3257,7 +3663,8 @@
             "source_checksum": "42aa5cb5789129d90b3dca32b0d72f51",
             "input_file": "al08_96.adif",
             "output_format": "Unknown",
-            "result": "4677b93aa04c55103ebd1dce77c6f4c8"
+            "result": "4677b93aa04c55103ebd1dce77c6f4c8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am05_88",
@@ -3265,7 +3672,8 @@
             "source_checksum": "0f558fd21f4ee90728acfe660a5b2397",
             "input_file": "am05_88.adif",
             "output_format": "Unknown",
-            "result": "ae07362973a109e13ad7aa7a01fe2eef"
+            "result": "ae07362973a109e13ad7aa7a01fe2eef",
+            "profile": "AAC Main"
         },
         {
             "name": "am06_44",
@@ -3273,7 +3681,8 @@
             "source_checksum": "bc279de3c3e7962bdf47b64216f33900",
             "input_file": "am06_44.adif",
             "output_format": "Unknown",
-            "result": "c0bbfd973867fec9ed598abd1656761e"
+            "result": "c0bbfd973867fec9ed598abd1656761e",
+            "profile": "AAC Main"
         },
         {
             "name": "al04_32",
@@ -3281,7 +3690,8 @@
             "source_checksum": "bbf8a03e5af24d57f5e25b477b53dedd",
             "input_file": "al04_32.adif",
             "output_format": "Unknown",
-            "result": "b0376ccd5985561b7aedae959f37e7a4"
+            "result": "b0376ccd5985561b7aedae959f37e7a4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00_16",
@@ -3289,7 +3699,8 @@
             "source_checksum": "6d08399b1d0e756c8753377588655ded",
             "input_file": "al00_16.adif",
             "output_format": "Unknown",
-            "result": "5c6c8350621b3ba4c744712746c66213"
+            "result": "5c6c8350621b3ba4c744712746c66213",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al15_32",
@@ -3297,7 +3708,8 @@
             "source_checksum": "debe0a23d360e1fac5bfdb8d1236fdb4",
             "input_file": "al15_32.adif",
             "output_format": "Unknown",
-            "result": "dc3e02306732c899a66242006e85a6b8"
+            "result": "dc3e02306732c899a66242006e85a6b8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al10_16",
@@ -3305,7 +3717,8 @@
             "source_checksum": "b307946276a3d53b3fe86ea355f929ef",
             "input_file": "al10_16.adif",
             "output_format": "Unknown",
-            "result": "663f9042b68ace25fd7f7c9bba2b72f8"
+            "result": "663f9042b68ace25fd7f7c9bba2b72f8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as08_88",
@@ -3313,7 +3726,8 @@
             "source_checksum": "13cc1d46ee8f62e833cd70e6c70f99b2",
             "input_file": "as08_88.adif",
             "output_format": "Unknown",
-            "result": "617034d7418dbaf0d71811fb915d8a53"
+            "result": "617034d7418dbaf0d71811fb915d8a53",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as12_22",
@@ -3321,7 +3735,8 @@
             "source_checksum": "c3250d9d3fce32c0860179faff2286fe",
             "input_file": "as12_22.adif",
             "output_format": "Unknown",
-            "result": "793bdf4e548eec828ae840f15c7c8417"
+            "result": "793bdf4e548eec828ae840f15c7c8417",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as15_48",
@@ -3329,7 +3744,8 @@
             "source_checksum": "e6633a82dad2115fcc4edf7c2dce6b2b",
             "input_file": "as15_48.adif",
             "output_format": "Unknown",
-            "result": "c9a81a0fa18615801cdc39e5b163f671"
+            "result": "c9a81a0fa18615801cdc39e5b163f671",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as07_12",
@@ -3337,7 +3753,8 @@
             "source_checksum": "4200d52bd81aec5bb78f9c6177b9a6df",
             "input_file": "as07_12.adif",
             "output_format": "Unknown",
-            "result": "b166a694a0cf6373bea354e056d5910b"
+            "result": "b166a694a0cf6373bea354e056d5910b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am06_12",
@@ -3345,7 +3762,8 @@
             "source_checksum": "5e54a0d219e31d7a264311f12ad56644",
             "input_file": "am06_12.adif",
             "output_format": "Unknown",
-            "result": "4f57d72e18b9c3417387a09e27beb851"
+            "result": "4f57d72e18b9c3417387a09e27beb851",
+            "profile": "AAC Main"
         },
         {
             "name": "al16_64",
@@ -3353,7 +3771,8 @@
             "source_checksum": "374a6cdbd9f4703f2a874d51bc50f22d",
             "input_file": "al16_64.adif",
             "output_format": "Unknown",
-            "result": "0428ad19c2ec717d2e7d4a8bddaa10c3"
+            "result": "0428ad19c2ec717d2e7d4a8bddaa10c3",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14_48",
@@ -3361,7 +3780,8 @@
             "source_checksum": "dacda0d5da41fca70432eadca1f1a046",
             "input_file": "al14_48.adif",
             "output_format": "Unknown",
-            "result": "7b4fb2dd812dd2ecdd449e30e0034086"
+            "result": "7b4fb2dd812dd2ecdd449e30e0034086",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as01_32",
@@ -3369,7 +3789,8 @@
             "source_checksum": "b8c0032bd3cb8bef265f95c592fa2d2d",
             "input_file": "as01_32.adif",
             "output_format": "Unknown",
-            "result": "1c0e61a364a51f8e59d34d3f11caba1d"
+            "result": "1c0e61a364a51f8e59d34d3f11caba1d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al17_48",
@@ -3377,7 +3798,8 @@
             "source_checksum": "d0fb2b78eda4d4398afb7b451fc40dee",
             "input_file": "al17_48.adif",
             "output_format": "Unknown",
-            "result": "639ae11166bd1ce3bd23b4d5337008c8"
+            "result": "639ae11166bd1ce3bd23b4d5337008c8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16_12",
@@ -3385,7 +3807,8 @@
             "source_checksum": "bc274f6fa29242b60b233f4068379f63",
             "input_file": "al16_12.adif",
             "output_format": "Unknown",
-            "result": "740c6812e891a78b7780e52da56ac901"
+            "result": "740c6812e891a78b7780e52da56ac901",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03_96",
@@ -3393,7 +3816,8 @@
             "source_checksum": "466721f602d77300514338721341eb4e",
             "input_file": "al03_96.adif",
             "output_format": "Unknown",
-            "result": "c07660b161c8bf333f7703d39cd7829c"
+            "result": "c07660b161c8bf333f7703d39cd7829c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06_44",
@@ -3401,7 +3825,8 @@
             "source_checksum": "df9cd02d50eeebb38a6e983576614d93",
             "input_file": "al06_44.adif",
             "output_format": "Unknown",
-            "result": "c908646e2162876f19d0cdf958ddc156"
+            "result": "c908646e2162876f19d0cdf958ddc156",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am05_48",
@@ -3409,7 +3834,8 @@
             "source_checksum": "a536f7ee51b1d842d61cc65f5cabddcd",
             "input_file": "am05_48.adif",
             "output_format": "Unknown",
-            "result": "566d54b65ae740b80676ab9adb7feb9f"
+            "result": "566d54b65ae740b80676ab9adb7feb9f",
+            "profile": "AAC Main"
         },
         {
             "name": "as05_08",
@@ -3417,7 +3843,8 @@
             "source_checksum": "3046e117791ce58c8abadaf1aa0fc782",
             "input_file": "as05_08.adif",
             "output_format": "Unknown",
-            "result": "8cdd94e0953cc708e54a22c5ea799cd1"
+            "result": "8cdd94e0953cc708e54a22c5ea799cd1",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am04_11",
@@ -3425,7 +3852,8 @@
             "source_checksum": "a142562a01bd209c256a124888f1e10a",
             "input_file": "am04_11.adif",
             "output_format": "Unknown",
-            "result": "71ef16be1fc6d6ff5bb2907959ba6f56"
+            "result": "71ef16be1fc6d6ff5bb2907959ba6f56",
+            "profile": "AAC Main"
         },
         {
             "name": "am01_22",
@@ -3433,7 +3861,8 @@
             "source_checksum": "441bf198af41e64289480052dba0b3f2",
             "input_file": "am01_22.adif",
             "output_format": "Unknown",
-            "result": "7d384f1aebb4f9f6d919d534f72abf2e"
+            "result": "7d384f1aebb4f9f6d919d534f72abf2e",
+            "profile": "AAC Main"
         },
         {
             "name": "al10_88",
@@ -3441,7 +3870,8 @@
             "source_checksum": "0223eb0cbbc71b4fa3971d3aebd5812c",
             "input_file": "al10_88.adif",
             "output_format": "Unknown",
-            "result": "966b120a081761189dc6a11d8f1a7ddd"
+            "result": "966b120a081761189dc6a11d8f1a7ddd",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16_44",
@@ -3449,7 +3879,8 @@
             "source_checksum": "cb8d19c224ccd5bdfe845c44dfd2017a",
             "input_file": "al16_44.adif",
             "output_format": "Unknown",
-            "result": "4943294add67e3168b0686e549f1f707"
+            "result": "4943294add67e3168b0686e549f1f707",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as04_16",
@@ -3457,7 +3888,8 @@
             "source_checksum": "57cd8d2d166fc51219d6cd518422015e",
             "input_file": "as04_16.adif",
             "output_format": "Unknown",
-            "result": "2aa8ede9facecfd47e2da49c7e0b0bf1"
+            "result": "2aa8ede9facecfd47e2da49c7e0b0bf1",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as15_44",
@@ -3465,7 +3897,8 @@
             "source_checksum": "19eeabe4e2d7c8515389fcb43cd147e2",
             "input_file": "as15_44.adif",
             "output_format": "Unknown",
-            "result": "14888c909d35b55e76edfb2696f5c0d9"
+            "result": "14888c909d35b55e76edfb2696f5c0d9",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am03_96",
@@ -3473,7 +3906,8 @@
             "source_checksum": "e763471440d7436147483ab399b8f3bc",
             "input_file": "am03_96.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "",
+            "profile": "AAC Main"
         },
         {
             "name": "am00_11",
@@ -3481,7 +3915,8 @@
             "source_checksum": "2af028a7d8538d424b1b2e27e83683b7",
             "input_file": "am00_11.adif",
             "output_format": "Unknown",
-            "result": "bbb2a347eb79692e8162d364b3e2e851"
+            "result": "bbb2a347eb79692e8162d364b3e2e851",
+            "profile": "AAC Main"
         },
         {
             "name": "am07_08",
@@ -3489,7 +3924,8 @@
             "source_checksum": "da8f616c1ff96b93de7cfcf01350fe38",
             "input_file": "am07_08.adif",
             "output_format": "Unknown",
-            "result": "1eaa7584eda43146cd197cf43ee31336"
+            "result": "1eaa7584eda43146cd197cf43ee31336",
+            "profile": "AAC Main"
         },
         {
             "name": "as08_96",
@@ -3497,7 +3933,8 @@
             "source_checksum": "29867556ab2da11e31af5fe3ca374a4c",
             "input_file": "as08_96.adif",
             "output_format": "Unknown",
-            "result": "a5c6e4e4e267f3cf786c7ab76acbe9fa"
+            "result": "a5c6e4e4e267f3cf786c7ab76acbe9fa",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al02_12",
@@ -3505,7 +3942,8 @@
             "source_checksum": "a5fca3fd74b927fcd767b4ee2e064083",
             "input_file": "al02_12.adif",
             "output_format": "Unknown",
-            "result": "fba7a9108012d70f844bbfe73f862d15"
+            "result": "fba7a9108012d70f844bbfe73f862d15",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am04_22",
@@ -3513,7 +3951,8 @@
             "source_checksum": "203b22bb326c936ddb9b18314f9a64b2",
             "input_file": "am04_22.adif",
             "output_format": "Unknown",
-            "result": "3c613c9af057696d31579ec816f1dffa"
+            "result": "3c613c9af057696d31579ec816f1dffa",
+            "profile": "AAC Main"
         },
         {
             "name": "am05_32",
@@ -3521,7 +3960,8 @@
             "source_checksum": "7629c8af0f38a4f3382d8fe9e887d9b7",
             "input_file": "am05_32.adif",
             "output_format": "Unknown",
-            "result": "a19172db2537dcd34cfe08298bce7028"
+            "result": "a19172db2537dcd34cfe08298bce7028",
+            "profile": "AAC Main"
         },
         {
             "name": "am03_24",
@@ -3529,7 +3969,8 @@
             "source_checksum": "63b50f1a63b1180c9d998970d1b53e7f",
             "input_file": "am03_24.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "",
+            "profile": "AAC Main"
         },
         {
             "name": "as11_48",
@@ -3537,7 +3978,8 @@
             "source_checksum": "1e5d8d0b02b24ef69ef7fe569d8d7e6a",
             "input_file": "as11_48.adif",
             "output_format": "Unknown",
-            "result": "e780e91547c3144c6e472e92ed2210d7"
+            "result": "e780e91547c3144c6e472e92ed2210d7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as11_64",
@@ -3545,7 +3987,8 @@
             "source_checksum": "a791a84645d4bda22a2f825a2ce17b18",
             "input_file": "as11_64.adif",
             "output_format": "Unknown",
-            "result": "8fa7c4d7b94faff9117bd4d12c349e1b"
+            "result": "8fa7c4d7b94faff9117bd4d12c349e1b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am02_22",
@@ -3553,7 +3996,8 @@
             "source_checksum": "e7dc757057fbfbb9c198f08f4d5a3387",
             "input_file": "am02_22.adif",
             "output_format": "Unknown",
-            "result": "e1e025741b3432606b8ff69965b7f3d0"
+            "result": "e1e025741b3432606b8ff69965b7f3d0",
+            "profile": "AAC Main"
         },
         {
             "name": "as14_22",
@@ -3561,7 +4005,8 @@
             "source_checksum": "5d0280e294b34fdb4cd911fd7a46ac1d",
             "input_file": "as14_22.adif",
             "output_format": "Unknown",
-            "result": "02856cceb12e9637bb98fc210daf193b"
+            "result": "02856cceb12e9637bb98fc210daf193b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am00_48",
@@ -3569,7 +4014,8 @@
             "source_checksum": "3ace5dbd49daa0f5180e8c72348d80fc",
             "input_file": "am00_48.adif",
             "output_format": "Unknown",
-            "result": "8b30d5a5a799d5f59f3cd6ab973dbed9"
+            "result": "8b30d5a5a799d5f59f3cd6ab973dbed9",
+            "profile": "AAC Main"
         },
         {
             "name": "as10_96",
@@ -3577,7 +4023,8 @@
             "source_checksum": "44968383cc09da8aa4c1abcb65bcfcb2",
             "input_file": "as10_96.adif",
             "output_format": "Unknown",
-            "result": "72487940e6b21e1a5acfe6d5ddd57978"
+            "result": "72487940e6b21e1a5acfe6d5ddd57978",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al16_48",
@@ -3585,7 +4032,8 @@
             "source_checksum": "4a004a6ee14301b136cb05fafa7cdeb0",
             "input_file": "al16_48.adif",
             "output_format": "Unknown",
-            "result": "70f8ed0d2b593456e6e47df002fba53e"
+            "result": "70f8ed0d2b593456e6e47df002fba53e",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07_12",
@@ -3593,7 +4041,8 @@
             "source_checksum": "cd2f7b2a14d13941544b2ce4749bea49",
             "input_file": "al07_12.adif",
             "output_format": "Unknown",
-            "result": "d4de30fb19a0873a2357523a21a7c11f"
+            "result": "d4de30fb19a0873a2357523a21a7c11f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am03_08",
@@ -3601,7 +4050,8 @@
             "source_checksum": "a5ce55db814238f0cbdc8f76beb68a4d",
             "input_file": "am03_08.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "",
+            "profile": "AAC Main"
         },
         {
             "name": "as08_12",
@@ -3609,7 +4059,8 @@
             "source_checksum": "a0da765f6199724795c1913f74acfaa5",
             "input_file": "as08_12.adif",
             "output_format": "Unknown",
-            "result": "3501043be855b4329c14b0245fe8d603"
+            "result": "3501043be855b4329c14b0245fe8d603",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am04_88",
@@ -3617,7 +4068,8 @@
             "source_checksum": "bbec3d56a852642ac36f362e671c60cc",
             "input_file": "am04_88.adif",
             "output_format": "Unknown",
-            "result": "c08d877e3c11ac5d6897487fc64809bb"
+            "result": "c08d877e3c11ac5d6897487fc64809bb",
+            "profile": "AAC Main"
         },
         {
             "name": "as17_48",
@@ -3625,7 +4077,8 @@
             "source_checksum": "37e2757da8c5a7c085720c99183390d2",
             "input_file": "as17_48.adif",
             "output_format": "Unknown",
-            "result": "ebd19ef16b3576a8bad95c819c42aa47"
+            "result": "ebd19ef16b3576a8bad95c819c42aa47",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as13_12",
@@ -3633,7 +4086,8 @@
             "source_checksum": "e26bcb640a891776237d6a883756b598",
             "input_file": "as13_12.adif",
             "output_format": "Unknown",
-            "result": "971a2bff11d06bc3c578efda34aefa4b"
+            "result": "971a2bff11d06bc3c578efda34aefa4b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as08_22",
@@ -3641,7 +4095,8 @@
             "source_checksum": "d512b5f71db1be199548f7f7376f0d50",
             "input_file": "as08_22.adif",
             "output_format": "Unknown",
-            "result": "db921bd902654720933f799741bb35b2"
+            "result": "db921bd902654720933f799741bb35b2",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06_22",
@@ -3649,7 +4104,8 @@
             "source_checksum": "d71c22ad771c94afd2b6d4f2c6ed6b15",
             "input_file": "al06_22.adif",
             "output_format": "Unknown",
-            "result": "fd272f2518856dfd459c84cf9e7edc93"
+            "result": "fd272f2518856dfd459c84cf9e7edc93",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as06_11",
@@ -3657,7 +4113,8 @@
             "source_checksum": "3fcf9102aaf0952bb4e7c50c8bab1bd8",
             "input_file": "as06_11.adif",
             "output_format": "Unknown",
-            "result": "64d28b9d388a06953a33cc5b556f41ab"
+            "result": "64d28b9d388a06953a33cc5b556f41ab",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am06_22",
@@ -3665,7 +4122,8 @@
             "source_checksum": "dce4c4c15e1dd16a0f672069ed0f530f",
             "input_file": "am06_22.adif",
             "output_format": "Unknown",
-            "result": "660e495bf6ef3dbd6e4d1c0b7b62a73a"
+            "result": "660e495bf6ef3dbd6e4d1c0b7b62a73a",
+            "profile": "AAC Main"
         },
         {
             "name": "as01_08",
@@ -3673,7 +4131,8 @@
             "source_checksum": "212b8322471e7bc9e6b2ad14beeb8761",
             "input_file": "as01_08.adif",
             "output_format": "Unknown",
-            "result": "0b43057f093305a27b52f168adaaf255"
+            "result": "0b43057f093305a27b52f168adaaf255",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am04_24",
@@ -3681,7 +4140,8 @@
             "source_checksum": "b2aa87427e18b45f2f31fc49743c61c1",
             "input_file": "am04_24.adif",
             "output_format": "Unknown",
-            "result": "b1f7a855024212ea1278a995b014dc21"
+            "result": "b1f7a855024212ea1278a995b014dc21",
+            "profile": "AAC Main"
         },
         {
             "name": "am06_96",
@@ -3689,7 +4149,8 @@
             "source_checksum": "7191ad8979bc199124040cbf02aa0378",
             "input_file": "am06_96.adif",
             "output_format": "Unknown",
-            "result": "0663053dde8e099d32d4f2acde451e2c"
+            "result": "0663053dde8e099d32d4f2acde451e2c",
+            "profile": "AAC Main"
         },
         {
             "name": "al11_64",
@@ -3697,7 +4158,8 @@
             "source_checksum": "ff8f5f5225cbc9c95f1149c956b1e2c0",
             "input_file": "al11_64.adif",
             "output_format": "Unknown",
-            "result": "6d76d82bff1109a27323d1b70f609a04"
+            "result": "6d76d82bff1109a27323d1b70f609a04",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_24",
@@ -3705,7 +4167,8 @@
             "source_checksum": "3a22102baf5d6da1f30ae4ed249b40a1",
             "input_file": "al04_24.adif",
             "output_format": "Unknown",
-            "result": "9bfbda2644d94dca52dd3b7b5b6a49b6"
+            "result": "9bfbda2644d94dca52dd3b7b5b6a49b6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as14_32",
@@ -3713,7 +4176,8 @@
             "source_checksum": "5bd0381e5698ded6435918777cd75118",
             "input_file": "as14_32.adif",
             "output_format": "Unknown",
-            "result": "b4b3c045e136191c6d42df8fc352d3cf"
+            "result": "b4b3c045e136191c6d42df8fc352d3cf",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al10_24",
@@ -3721,7 +4185,8 @@
             "source_checksum": "e127b47545b9dcc8b6e9bcdc9b1de84d",
             "input_file": "al10_24.adif",
             "output_format": "Unknown",
-            "result": "58449a346b4090b8602eaedf03739fe3"
+            "result": "58449a346b4090b8602eaedf03739fe3",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as01_12",
@@ -3729,7 +4194,8 @@
             "source_checksum": "60d77c353f7fce8c053909939cf9f891",
             "input_file": "as01_12.adif",
             "output_format": "Unknown",
-            "result": "d83c4c702798b93f6e57812c4064ab1f"
+            "result": "d83c4c702798b93f6e57812c4064ab1f",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al00_22",
@@ -3737,7 +4203,8 @@
             "source_checksum": "8cc14dc053495aeee852d83e1bf2a81b",
             "input_file": "al00_22.adif",
             "output_format": "Unknown",
-            "result": "fc7d20249eb3f883c9244e88986eebb9"
+            "result": "fc7d20249eb3f883c9244e88986eebb9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_44",
@@ -3745,7 +4212,8 @@
             "source_checksum": "d5436682dc95dfe02f76c902ce6d7910",
             "input_file": "am00_44.adif",
             "output_format": "Unknown",
-            "result": "cbeb791f1771f1d0adcfff9a29fe4223"
+            "result": "cbeb791f1771f1d0adcfff9a29fe4223",
+            "profile": "AAC Main"
         },
         {
             "name": "as16_11",
@@ -3753,7 +4221,8 @@
             "source_checksum": "8862531c4e255ee2d9d87832e1722d19",
             "input_file": "as16_11.adif",
             "output_format": "Unknown",
-            "result": "66be4d61aa2181af657c5da70f141a96"
+            "result": "66be4d61aa2181af657c5da70f141a96",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al15_48",
@@ -3761,7 +4230,8 @@
             "source_checksum": "9c72e4694edfd3d7eb9554720f601acd",
             "input_file": "al15_48.adif",
             "output_format": "Unknown",
-            "result": "01a27d489878dbaf7a76b480a80f5abb"
+            "result": "01a27d489878dbaf7a76b480a80f5abb",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17_11",
@@ -3769,7 +4239,8 @@
             "source_checksum": "347c553b4258235e908d2f709e9df8eb",
             "input_file": "al17_11.adif",
             "output_format": "Unknown",
-            "result": "77d09b536b5c5cc251faa21e5aecb413"
+            "result": "77d09b536b5c5cc251faa21e5aecb413",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05_22",
@@ -3777,7 +4248,8 @@
             "source_checksum": "b08ba27954f42f9acc402d97f05ff1be",
             "input_file": "al05_22.adif",
             "output_format": "Unknown",
-            "result": "c297fd5aba3dbe1b55f41757e0ad518d"
+            "result": "c297fd5aba3dbe1b55f41757e0ad518d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06_11",
@@ -3785,7 +4257,8 @@
             "source_checksum": "166de66883ba6dc9ef1e1c393b6025cd",
             "input_file": "al06_11.adif",
             "output_format": "Unknown",
-            "result": "b1d3abe29c049fae6f83b218f7bc0677"
+            "result": "b1d3abe29c049fae6f83b218f7bc0677",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08_44",
@@ -3793,7 +4266,8 @@
             "source_checksum": "32879a6c083e9604cc58fd5e82de0993",
             "input_file": "al08_44.adif",
             "output_format": "Unknown",
-            "result": "ac48dbb44e76757732c7060fce50b773"
+            "result": "ac48dbb44e76757732c7060fce50b773",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am02_48",
@@ -3801,7 +4275,8 @@
             "source_checksum": "743db775068807269bb9725720adc606",
             "input_file": "am02_48.adif",
             "output_format": "Unknown",
-            "result": "41045aa7d349d9fe233869793d48f322"
+            "result": "41045aa7d349d9fe233869793d48f322",
+            "profile": "AAC Main"
         },
         {
             "name": "al03_11",
@@ -3809,7 +4284,8 @@
             "source_checksum": "5ff540a63aa030a2ed30b95330482e2b",
             "input_file": "al03_11.adif",
             "output_format": "Unknown",
-            "result": "cb5054b764e9019be9d0fcbfe3776835"
+            "result": "cb5054b764e9019be9d0fcbfe3776835",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as15_16",
@@ -3817,7 +4293,8 @@
             "source_checksum": "bfd30e9d134a16407b218e3224ef23c0",
             "input_file": "as15_16.adif",
             "output_format": "Unknown",
-            "result": "a4c66f7b5287477f02e2e46482b93fd2"
+            "result": "a4c66f7b5287477f02e2e46482b93fd2",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al11_48",
@@ -3825,7 +4302,8 @@
             "source_checksum": "3d295436e8f68c2ec55a5c20f3f8ae3b",
             "input_file": "al11_48.adif",
             "output_format": "Unknown",
-            "result": "a84e4a8cf3d4e8a5531c94fb8a08f8f8"
+            "result": "a84e4a8cf3d4e8a5531c94fb8a08f8f8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as09_11",
@@ -3833,7 +4311,8 @@
             "source_checksum": "1b8581d0b15b6f7f5cd716569ad2ab09",
             "input_file": "as09_11.adif",
             "output_format": "Unknown",
-            "result": "f1e414104151e770be3a8de90fae8b7e"
+            "result": "f1e414104151e770be3a8de90fae8b7e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al02_08",
@@ -3841,7 +4320,8 @@
             "source_checksum": "788c20b0fcdfc57dc15e0a09a47eb1d0",
             "input_file": "al02_08.adif",
             "output_format": "Unknown",
-            "result": "48e6870f8ccdcaefacd80036e6971aa4"
+            "result": "48e6870f8ccdcaefacd80036e6971aa4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as00_24",
@@ -3849,7 +4329,8 @@
             "source_checksum": "7a5a1e3981b096dc97c0bf51830e85e8",
             "input_file": "as00_24.adif",
             "output_format": "Unknown",
-            "result": "f55b20bf2eaaca20b8e12dfe76eb0d7d"
+            "result": "f55b20bf2eaaca20b8e12dfe76eb0d7d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as12_96",
@@ -3857,7 +4338,8 @@
             "source_checksum": "8e88b481ca1d46edc579fc4ecc28c695",
             "input_file": "as12_96.adif",
             "output_format": "Unknown",
-            "result": "84cfdbb1547092e3e15d28b2e9b274d5"
+            "result": "84cfdbb1547092e3e15d28b2e9b274d5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am02_96",
@@ -3865,7 +4347,8 @@
             "source_checksum": "166bc87d9c433afa1c0b01a184469e5b",
             "input_file": "am02_96.adif",
             "output_format": "Unknown",
-            "result": "000afc3c95e38a98e52cfd70568967ab"
+            "result": "000afc3c95e38a98e52cfd70568967ab",
+            "profile": "AAC Main"
         },
         {
             "name": "as09_48",
@@ -3873,7 +4356,8 @@
             "source_checksum": "1ec6c1375d18ccbc7c6a052491047ec2",
             "input_file": "as09_48.adif",
             "output_format": "Unknown",
-            "result": "27d560f65a1e11a757ad189a1f8bde77"
+            "result": "27d560f65a1e11a757ad189a1f8bde77",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am06_16",
@@ -3881,7 +4365,8 @@
             "source_checksum": "bdd2aa77cc5c82b1923c7d7fff1f887d",
             "input_file": "am06_16.adif",
             "output_format": "Unknown",
-            "result": "f8c39576e0e2d17d1d5f14726bb1cafb"
+            "result": "f8c39576e0e2d17d1d5f14726bb1cafb",
+            "profile": "AAC Main"
         },
         {
             "name": "as00_12",
@@ -3889,7 +4374,8 @@
             "source_checksum": "3a5927af46366d62cbda59089436a074",
             "input_file": "as00_12.adif",
             "output_format": "Unknown",
-            "result": "30ef66aa6a39b0b5d3a77aea1061928b"
+            "result": "30ef66aa6a39b0b5d3a77aea1061928b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as10_48",
@@ -3897,7 +4383,8 @@
             "source_checksum": "c9b6bb61e02ee79b14df737d1fe125d5",
             "input_file": "as10_48.adif",
             "output_format": "Unknown",
-            "result": "b66a6582c6c636102251dd3b020e22e2"
+            "result": "b66a6582c6c636102251dd3b020e22e2",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am01_32",
@@ -3905,7 +4392,8 @@
             "source_checksum": "be0d7cc4444f4950758da784ff278f90",
             "input_file": "am01_32.adif",
             "output_format": "Unknown",
-            "result": "1bcf994fb90b2f3eb5f15420a869f823"
+            "result": "1bcf994fb90b2f3eb5f15420a869f823",
+            "profile": "AAC Main"
         },
         {
             "name": "as12_44",
@@ -3913,7 +4401,8 @@
             "source_checksum": "913b6c922079246975e308661f2f76ac",
             "input_file": "as12_44.adif",
             "output_format": "Unknown",
-            "result": "8dfea67806acf9b1fdb52efe7134dd04"
+            "result": "8dfea67806acf9b1fdb52efe7134dd04",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am03_48",
@@ -3921,7 +4410,8 @@
             "source_checksum": "c69c313fbcd2e960d85ea6ff4b7daebb",
             "input_file": "am03_48.adif",
             "output_format": "Unknown",
-            "result": ""
+            "result": "",
+            "profile": "AAC Main"
         },
         {
             "name": "al11_44",
@@ -3929,7 +4419,8 @@
             "source_checksum": "f4bc933bdaee8fa9808dc69c2f7c967d",
             "input_file": "al11_44.adif",
             "output_format": "Unknown",
-            "result": "a84e4a8cf3d4e8a5531c94fb8a08f8f8"
+            "result": "a84e4a8cf3d4e8a5531c94fb8a08f8f8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as04_88",
@@ -3937,7 +4428,8 @@
             "source_checksum": "0507769e27d2e01595df2a87dfa32eaa",
             "input_file": "as04_88.adif",
             "output_format": "Unknown",
-            "result": "a2a2fc6b38a3190b8dde068cddfed7fe"
+            "result": "a2a2fc6b38a3190b8dde068cddfed7fe",
+            "profile": "AAC Scalable Sampling Rate"
         }
     ]
 }

--- a/test_suites/aac/MPEG2_AAC-ADTS.json
+++ b/test_suites/aac/MPEG2_AAC-ADTS.json
@@ -9,7 +9,8 @@
             "source_checksum": "27929bfbce9d06fb61274cb013d04e9a",
             "input_file": "al12_48.adts",
             "output_format": "fltp",
-            "result": "d4497dd09304c27484a4461b2f568b60"
+            "result": "d4497dd09304c27484a4461b2f568b60",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as20_24",
@@ -17,7 +18,8 @@
             "source_checksum": "711515116cd73b67d1f76862edc9cb10",
             "input_file": "as20_24.adts",
             "output_format": "fltp",
-            "result": "d5e46ba493f520194429846c1b377589"
+            "result": "d5e46ba493f520194429846c1b377589",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al09_11",
@@ -25,7 +27,8 @@
             "source_checksum": "d9c69bdd4677c4998591272e6de378e7",
             "input_file": "al09_11.adts",
             "output_format": "fltp",
-            "result": "ada779fe594fdcab99af4fc47e23559f"
+            "result": "ada779fe594fdcab99af4fc47e23559f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as21_44",
@@ -33,7 +36,8 @@
             "source_checksum": "8318287c05fcdde7031de892a154dc7a",
             "input_file": "as21_44.adts",
             "output_format": "fltp",
-            "result": "d862ac356292d4b0822cdf6aa76b9c16"
+            "result": "d862ac356292d4b0822cdf6aa76b9c16",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as19_44",
@@ -41,7 +45,8 @@
             "source_checksum": "5622d850cdae2178bf8cca590fdfa011",
             "input_file": "as19_44.adts",
             "output_format": "fltp",
-            "result": "06180286f29acf2b250cc6e29bd3a0a3"
+            "result": "06180286f29acf2b250cc6e29bd3a0a3",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al09_08",
@@ -49,7 +54,8 @@
             "source_checksum": "2843464c7d9b40adac27c075ef100705",
             "input_file": "al09_08.adts",
             "output_format": "fltp",
-            "result": "385198f06cb664a13c535ff49c04b88c"
+            "result": "385198f06cb664a13c535ff49c04b88c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as19_24",
@@ -57,7 +63,8 @@
             "source_checksum": "d95b1df14e768ae90fecebab57219b58",
             "input_file": "as19_24.adts",
             "output_format": "fltp",
-            "result": "d622aee91247ec1273194aa6de5c9745"
+            "result": "d622aee91247ec1273194aa6de5c9745",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as19_32",
@@ -65,7 +72,8 @@
             "source_checksum": "9e4044870f052175df24acdd6d04cd39",
             "input_file": "as19_32.adts",
             "output_format": "fltp",
-            "result": "eb269af031d50a8b3bed859d6bd25a4a"
+            "result": "eb269af031d50a8b3bed859d6bd25a4a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as20_96",
@@ -73,7 +81,8 @@
             "source_checksum": "0ffe6dc8a1a8817bc9f4f95bb0a272cf",
             "input_file": "as20_96.adts",
             "output_format": "fltp",
-            "result": "6f8594ae06969889a84608bf6ffd5e63"
+            "result": "6f8594ae06969889a84608bf6ffd5e63",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as19_88",
@@ -81,7 +90,8 @@
             "source_checksum": "5843d8d610d372283455b48f74cbe0d3",
             "input_file": "as19_88.adts",
             "output_format": "fltp",
-            "result": "71511bbda2ff1142753fb067b8248d99"
+            "result": "71511bbda2ff1142753fb067b8248d99",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as21_11",
@@ -89,7 +99,8 @@
             "source_checksum": "09b1c407c41e2370417abb5dedffce9c",
             "input_file": "as21_11.adts",
             "output_format": "fltp",
-            "result": "cdfca8758bec798142cf6d5337aa5f5b"
+            "result": "cdfca8758bec798142cf6d5337aa5f5b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as18_24",
@@ -97,7 +108,8 @@
             "source_checksum": "192ab015b67c34d36d22aa0675ca5560",
             "input_file": "as18_24.adts",
             "output_format": "fltp",
-            "result": "e683ef621ad09675f21632b06f89b894"
+            "result": "e683ef621ad09675f21632b06f89b894",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as19_64",
@@ -105,7 +117,8 @@
             "source_checksum": "e45128742ebd2432e82c007f18a631b9",
             "input_file": "as19_64.adts",
             "output_format": "fltp",
-            "result": "a5b63ad2134366d0b149854439dd87be"
+            "result": "a5b63ad2134366d0b149854439dd87be",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as20_88",
@@ -113,7 +126,8 @@
             "source_checksum": "d9a81756fa3880d19821de84ca37dd9a",
             "input_file": "as20_88.adts",
             "output_format": "fltp",
-            "result": "babc22cc098d8e7d797fbaa41e6663e4"
+            "result": "babc22cc098d8e7d797fbaa41e6663e4",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as20_08",
@@ -121,7 +135,8 @@
             "source_checksum": "ad7d08193b166cf1c46ff84a3f3ebb7d",
             "input_file": "as20_08.adts",
             "output_format": "fltp",
-            "result": "88514de302080fc199c2c5426fbbb256"
+            "result": "88514de302080fc199c2c5426fbbb256",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as21_64",
@@ -129,7 +144,8 @@
             "source_checksum": "6c595906c5e563a765ed97c825719cc6",
             "input_file": "as21_64.adts",
             "output_format": "fltp",
-            "result": "ad991bc9a517fb82965911570146a624"
+            "result": "ad991bc9a517fb82965911570146a624",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as21_24",
@@ -137,7 +153,8 @@
             "source_checksum": "7d54f1ca0dea1a42491252e61e0b0ade",
             "input_file": "as21_24.adts",
             "output_format": "fltp",
-            "result": "d619feee354716ce44a7c2966b9ab000"
+            "result": "d619feee354716ce44a7c2966b9ab000",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as21_16",
@@ -145,7 +162,8 @@
             "source_checksum": "29c98dae5c26f6739fa449607dc6adf9",
             "input_file": "as21_16.adts",
             "output_format": "fltp",
-            "result": "b44abf44783aebd3abc2478522c5889c"
+            "result": "b44abf44783aebd3abc2478522c5889c",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as18_88",
@@ -153,7 +171,8 @@
             "source_checksum": "c565798d39dbbc3a0c3dcb07d7210df8",
             "input_file": "as18_88.adts",
             "output_format": "fltp",
-            "result": "201a8ee48bfa77a78679dd26646382ac"
+            "result": "201a8ee48bfa77a78679dd26646382ac",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as18_11",
@@ -161,7 +180,8 @@
             "source_checksum": "f5ffb91d23d125853afcb8297d925404",
             "input_file": "as18_11.adts",
             "output_format": "fltp",
-            "result": "c6ce39ac9f3a19c727c9f1a6df0a3b24"
+            "result": "c6ce39ac9f3a19c727c9f1a6df0a3b24",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as20_48",
@@ -169,7 +189,8 @@
             "source_checksum": "569bb98829b5a308c3bb9c7afc83cdc6",
             "input_file": "as20_48.adts",
             "output_format": "fltp",
-            "result": "fa1e9486032f1dd20d3a4c5d760553d2"
+            "result": "fa1e9486032f1dd20d3a4c5d760553d2",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as21_22",
@@ -177,7 +198,8 @@
             "source_checksum": "316b53896aff83108f32d2db8aa39fcf",
             "input_file": "as21_22.adts",
             "output_format": "fltp",
-            "result": "04d847223c86171e00fe677929ee3186"
+            "result": "04d847223c86171e00fe677929ee3186",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as20_22",
@@ -185,7 +207,8 @@
             "source_checksum": "3cefa90c24155f261826bebb95065fe0",
             "input_file": "as20_22.adts",
             "output_format": "fltp",
-            "result": "0238c48dee49b5c46d17c87889ad9d7d"
+            "result": "0238c48dee49b5c46d17c87889ad9d7d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as21_08",
@@ -193,7 +216,8 @@
             "source_checksum": "a8ba0949a1e983cb076dafa6726082d4",
             "input_file": "as21_08.adts",
             "output_format": "fltp",
-            "result": "04c3c5d0994244b9a0abb57f0a20a211"
+            "result": "04c3c5d0994244b9a0abb57f0a20a211",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as20_44",
@@ -201,7 +225,8 @@
             "source_checksum": "c6c903ccd30accc90b44dbe556bf3701",
             "input_file": "as20_44.adts",
             "output_format": "fltp",
-            "result": "279af7b736395078a76289d9983e149d"
+            "result": "279af7b736395078a76289d9983e149d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as20_11",
@@ -209,7 +234,8 @@
             "source_checksum": "6d3260070f0e55a02e41272edce11d23",
             "input_file": "as20_11.adts",
             "output_format": "fltp",
-            "result": "c3f2298751f0b3c9b2d50ff8b4fd9d4e"
+            "result": "c3f2298751f0b3c9b2d50ff8b4fd9d4e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as19_48",
@@ -217,7 +243,8 @@
             "source_checksum": "a7a3032f2d9abb74ba53c59f8edaefec",
             "input_file": "as19_48.adts",
             "output_format": "fltp",
-            "result": "ba89239240bc73639dfb558223bc6fc2"
+            "result": "ba89239240bc73639dfb558223bc6fc2",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as19_08",
@@ -225,7 +252,8 @@
             "source_checksum": "035f0a74173468a7940e901da1599d55",
             "input_file": "as19_08.adts",
             "output_format": "fltp",
-            "result": "bce7bf321502962190947a6b504801e7"
+            "result": "bce7bf321502962190947a6b504801e7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as19_16",
@@ -233,7 +261,8 @@
             "source_checksum": "4a7dda41b06c18a35b9f9d7dbad42bc7",
             "input_file": "as19_16.adts",
             "output_format": "fltp",
-            "result": "17af6ae5dbd337a059710648c9ff996d"
+            "result": "17af6ae5dbd337a059710648c9ff996d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al09_64",
@@ -241,7 +270,8 @@
             "source_checksum": "154b9a2a184284d5f27aa9109324578a",
             "input_file": "al09_64.adts",
             "output_format": "fltp",
-            "result": "5f92fd7fada10e5dbd08b9587f19e8e1"
+            "result": "5f92fd7fada10e5dbd08b9587f19e8e1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al09_24",
@@ -249,7 +279,8 @@
             "source_checksum": "3e5a52c0c73cc9bb46d98d4c28378374",
             "input_file": "al09_24.adts",
             "output_format": "fltp",
-            "result": "b7c13b112a6dde20f831f325bb694aa6"
+            "result": "b7c13b112a6dde20f831f325bb694aa6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al09_44",
@@ -257,7 +288,8 @@
             "source_checksum": "8d67429688392ceaf915ae92dc0eb14e",
             "input_file": "al09_44.adts",
             "output_format": "fltp",
-            "result": "f94ac68ef4dc6c9bce35a7fd51000ac6"
+            "result": "f94ac68ef4dc6c9bce35a7fd51000ac6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al13_48",
@@ -265,7 +297,8 @@
             "source_checksum": "92e966b0c730d9dcde6373636d869534",
             "input_file": "al13_48.adts",
             "output_format": "fltp",
-            "result": "dbbebf84893807b7180eb7c9cc36099a"
+            "result": "dbbebf84893807b7180eb7c9cc36099a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as19_96",
@@ -273,7 +306,8 @@
             "source_checksum": "78ecb299d42f2aa4aa07d15240013e78",
             "input_file": "as19_96.adts",
             "output_format": "fltp",
-            "result": "0f7b79ceebf35154b63adf2d3ddd4ca5"
+            "result": "0f7b79ceebf35154b63adf2d3ddd4ca5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as20_12",
@@ -281,7 +315,8 @@
             "source_checksum": "f694118f7ff688c2915d6fe4060bef33",
             "input_file": "as20_12.adts",
             "output_format": "fltp",
-            "result": "15e83d3892a9532d46c4be01cd78cbe8"
+            "result": "15e83d3892a9532d46c4be01cd78cbe8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as20_64",
@@ -289,7 +324,8 @@
             "source_checksum": "da230df29e16888934ef7a64ca544243",
             "input_file": "as20_64.adts",
             "output_format": "fltp",
-            "result": "a49b9fdaac7c3bc18d7ea3254fc994b7"
+            "result": "a49b9fdaac7c3bc18d7ea3254fc994b7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as21_48",
@@ -297,7 +333,8 @@
             "source_checksum": "1c98f957869644bbc3f1095d0ee90ec4",
             "input_file": "as21_48.adts",
             "output_format": "fltp",
-            "result": "d9c561723a11e490b82c34f8405c9e79"
+            "result": "d9c561723a11e490b82c34f8405c9e79",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as18_32",
@@ -305,7 +342,8 @@
             "source_checksum": "e12fc78483b5c2a5bf4cab5aca1cd921",
             "input_file": "as18_32.adts",
             "output_format": "fltp",
-            "result": "9cc0ae49da101bd127a800aad247abf3"
+            "result": "9cc0ae49da101bd127a800aad247abf3",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al09_32",
@@ -313,7 +351,8 @@
             "source_checksum": "56e57d9b3c98efaf74c2e75e46b94707",
             "input_file": "al09_32.adts",
             "output_format": "fltp",
-            "result": "30d1b4ea7670a46a5bd7d19491e753c3"
+            "result": "30d1b4ea7670a46a5bd7d19491e753c3",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as18_16",
@@ -321,7 +360,8 @@
             "source_checksum": "a5bb06ebb5238ebd2539f481515aec11",
             "input_file": "as18_16.adts",
             "output_format": "fltp",
-            "result": "6a12f289a1f5a4f51b5b32364cb9dd01"
+            "result": "6a12f289a1f5a4f51b5b32364cb9dd01",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as18_48",
@@ -329,7 +369,8 @@
             "source_checksum": "e5fd7fb3db6bea960171e155ffcd81f2",
             "input_file": "as18_48.adts",
             "output_format": "fltp",
-            "result": "cd4d8fa4ce36a8b2d727f31b9d467f3b"
+            "result": "cd4d8fa4ce36a8b2d727f31b9d467f3b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as18_44",
@@ -337,7 +378,8 @@
             "source_checksum": "b4b616b26ab554ed57ea7014de845cc0",
             "input_file": "as18_44.adts",
             "output_format": "fltp",
-            "result": "81ea5c9925e1537495ac8698793d761d"
+            "result": "81ea5c9925e1537495ac8698793d761d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as21_96",
@@ -345,7 +387,8 @@
             "source_checksum": "5f31709d01b272dd9434e5800dd948dd",
             "input_file": "as21_96.adts",
             "output_format": "fltp",
-            "result": "0ec45e077a46af9ed983f847701abb0e"
+            "result": "0ec45e077a46af9ed983f847701abb0e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al09_22",
@@ -353,7 +396,8 @@
             "source_checksum": "683f11281b7830def34ee1f778c7130b",
             "input_file": "al09_22.adts",
             "output_format": "fltp",
-            "result": "42cd6fddbc3e3425c350ee38a01a20c8"
+            "result": "42cd6fddbc3e3425c350ee38a01a20c8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as19_12",
@@ -361,7 +405,8 @@
             "source_checksum": "1e22b357bef8f7a32fb5a0655a03cc65",
             "input_file": "as19_12.adts",
             "output_format": "fltp",
-            "result": "33d07752b3f3d2beb45a705754be6584"
+            "result": "33d07752b3f3d2beb45a705754be6584",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al09_16",
@@ -369,7 +414,8 @@
             "source_checksum": "8c91b5fc725fdba3c44c8f2390f89381",
             "input_file": "al09_16.adts",
             "output_format": "fltp",
-            "result": "fbc7c9af31c8cdb561f92cb61aaff61c"
+            "result": "fbc7c9af31c8cdb561f92cb61aaff61c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as18_64",
@@ -377,7 +423,8 @@
             "source_checksum": "8b9d9f7969f20284dcb670c51b425d93",
             "input_file": "as18_64.adts",
             "output_format": "fltp",
-            "result": "de4eada5809199644d621d62c4d2b306"
+            "result": "de4eada5809199644d621d62c4d2b306",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as19_11",
@@ -385,7 +432,8 @@
             "source_checksum": "f6415137c41dd5ce5572659abbd61333",
             "input_file": "as19_11.adts",
             "output_format": "fltp",
-            "result": "5dda30abdc4fa3399c8fa1a7c602bca8"
+            "result": "5dda30abdc4fa3399c8fa1a7c602bca8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al09_12",
@@ -393,7 +441,8 @@
             "source_checksum": "cd8ae7d9c7a06f1af755a33683594a98",
             "input_file": "al09_12.adts",
             "output_format": "fltp",
-            "result": "51b5beac5200b2794a7c7e9286314632"
+            "result": "51b5beac5200b2794a7c7e9286314632",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as20_16",
@@ -401,7 +450,8 @@
             "source_checksum": "a8ec01e8aa200ed65dbae8459b438df6",
             "input_file": "as20_16.adts",
             "output_format": "fltp",
-            "result": "84a7aa3b4b6cd9fc132916c32b7141f1"
+            "result": "84a7aa3b4b6cd9fc132916c32b7141f1",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al09_88",
@@ -409,7 +459,8 @@
             "source_checksum": "a4d5e526f7c0fc8fb048aad54e4d71c2",
             "input_file": "al09_88.adts",
             "output_format": "fltp",
-            "result": "ad8bb96b3ac329ba4b290233f22401f8"
+            "result": "ad8bb96b3ac329ba4b290233f22401f8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as18_08",
@@ -417,7 +468,8 @@
             "source_checksum": "a64588993a1bb52acfedb21df39e9b78",
             "input_file": "as18_08.adts",
             "output_format": "fltp",
-            "result": "1f6f96bd1d3b052e95286c93ebd24160"
+            "result": "1f6f96bd1d3b052e95286c93ebd24160",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as18_12",
@@ -425,7 +477,8 @@
             "source_checksum": "b745ffe579e4832c214c6de012485f1f",
             "input_file": "as18_12.adts",
             "output_format": "fltp",
-            "result": "6c33d452b9f9e9c11be869296a706c60"
+            "result": "6c33d452b9f9e9c11be869296a706c60",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as18_22",
@@ -433,7 +486,8 @@
             "source_checksum": "5369c26e819fa6ea569007ad629ac0ec",
             "input_file": "as18_22.adts",
             "output_format": "fltp",
-            "result": "7bdf3d0d5f144e49024717fd9a8a269b"
+            "result": "7bdf3d0d5f144e49024717fd9a8a269b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al09_48",
@@ -441,7 +495,8 @@
             "source_checksum": "5be05f18cfcf9340c9967a0d0007e4ad",
             "input_file": "al09_48.adts",
             "output_format": "fltp",
-            "result": "a4af5705b86bec13462ea6483c27802a"
+            "result": "a4af5705b86bec13462ea6483c27802a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al09_96",
@@ -449,7 +504,8 @@
             "source_checksum": "5ccaa6962dbbe8a7988990834b588b61",
             "input_file": "al09_96.adts",
             "output_format": "fltp",
-            "result": "74b3d242c6ac44779826115cfc15c46d"
+            "result": "74b3d242c6ac44779826115cfc15c46d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as18_96",
@@ -457,7 +513,8 @@
             "source_checksum": "5fca7fa515d86d5910147cc909bfc9fb",
             "input_file": "as18_96.adts",
             "output_format": "fltp",
-            "result": "24f35893403e126343fa56bdb3c6f9d7"
+            "result": "24f35893403e126343fa56bdb3c6f9d7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as21_12",
@@ -465,7 +522,8 @@
             "source_checksum": "939556a3ce7d04dc581db45317147d08",
             "input_file": "as21_12.adts",
             "output_format": "fltp",
-            "result": "db64f9c3f19a8136737977be740bfdff"
+            "result": "db64f9c3f19a8136737977be740bfdff",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as21_32",
@@ -473,7 +531,8 @@
             "source_checksum": "af841a1ebdefb2a40cd819c174fc1be6",
             "input_file": "as21_32.adts",
             "output_format": "fltp",
-            "result": "e3c9a074b3d1d32d8c38d6bc3bd25492"
+            "result": "e3c9a074b3d1d32d8c38d6bc3bd25492",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as19_22",
@@ -481,7 +540,8 @@
             "source_checksum": "21a24c98f9c0c871422050e31ff5a27a",
             "input_file": "as19_22.adts",
             "output_format": "fltp",
-            "result": "e4152a4e3bce0c8ce8665a1615f9e8f5"
+            "result": "e4152a4e3bce0c8ce8665a1615f9e8f5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as21_88",
@@ -489,7 +549,8 @@
             "source_checksum": "d1675729e2333effc6fcc50ab0b5e94b",
             "input_file": "as21_88.adts",
             "output_format": "fltp",
-            "result": "54c1a5c135243bf076dfcaef2672cfb5"
+            "result": "54c1a5c135243bf076dfcaef2672cfb5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as20_32",
@@ -497,7 +558,8 @@
             "source_checksum": "f9de9178603479f2575db585cc944622",
             "input_file": "as20_32.adts",
             "output_format": "fltp",
-            "result": "33fef2e3a0d96972297b51ff0662abd4"
+            "result": "33fef2e3a0d96972297b51ff0662abd4",
+            "profile": "AAC Scalable Sampling Rate"
         }
     ]
 }

--- a/test_suites/aac/MPEG4_AAC-ADIF.json
+++ b/test_suites/aac/MPEG4_AAC-ADIF.json
@@ -9,7 +9,8 @@
             "source_checksum": "3681801c90588ef83398b67f36b60d1b",
             "input_file": "al18_22.adif",
             "output_format": "Unknown",
-            "result": "9c650228dea2c563560dcf3fbc31bff1"
+            "result": "9c650228dea2c563560dcf3fbc31bff1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "ap01_48",
@@ -17,7 +18,8 @@
             "source_checksum": "895521190aba64eaabfc7a1dfa4a5849",
             "input_file": "ap01_48.adif",
             "output_format": "Unknown",
-            "result": "cb8a260c08236e342d2122496ae126d9"
+            "result": "cb8a260c08236e342d2122496ae126d9",
+            "profile": "AAC Long Term Prediction"
         },
         {
             "name": "al18_96",
@@ -25,7 +27,8 @@
             "source_checksum": "56ead998d01a5eab736fd969a70aba93",
             "input_file": "al18_96.adif",
             "output_format": "Unknown",
-            "result": "02b0f333d4caa37379a8ab513dbc4dbf"
+            "result": "02b0f333d4caa37379a8ab513dbc4dbf",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "ap04_48",
@@ -33,7 +36,8 @@
             "source_checksum": "05027b12053bd06a0a62de4cc9cd45e6",
             "input_file": "ap04_48.adif",
             "output_format": "Unknown",
-            "result": "6e1767241de43646691c21587ccbab9f"
+            "result": "6e1767241de43646691c21587ccbab9f",
+            "profile": "AAC Long Term Prediction"
         },
         {
             "name": "al18_08",
@@ -41,7 +45,8 @@
             "source_checksum": "41348311f534009080c69a26ec1f1855",
             "input_file": "al18_08.adif",
             "output_format": "Unknown",
-            "result": "b2927751ae7a97613a9d9d0d2748eca7"
+            "result": "b2927751ae7a97613a9d9d0d2748eca7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18_64",
@@ -49,7 +54,8 @@
             "source_checksum": "86ce9461e663a1fb130268d04810f6f9",
             "input_file": "al18_64.adif",
             "output_format": "Unknown",
-            "result": "756d27e1b1bead05839758072cea9690"
+            "result": "756d27e1b1bead05839758072cea9690",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "ap02_48",
@@ -57,7 +63,8 @@
             "source_checksum": "ac186216e1d85c0962cd0b9ee068c8c7",
             "input_file": "ap02_48.adif",
             "output_format": "Unknown",
-            "result": "57f4964f065c75fa825bf7c795ae621f"
+            "result": "57f4964f065c75fa825bf7c795ae621f",
+            "profile": "AAC Long Term Prediction"
         },
         {
             "name": "al18_32",
@@ -65,7 +72,8 @@
             "source_checksum": "f6d92ad51c73c1c6a00a7c3956fe43aa",
             "input_file": "al18_32.adif",
             "output_format": "Unknown",
-            "result": "26c2430033002a138568d17ca3317ade"
+            "result": "26c2430033002a138568d17ca3317ade",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "ap05_48",
@@ -73,7 +81,8 @@
             "source_checksum": "f96cb4c929e1de8ef35d98791aed273e",
             "input_file": "ap05_48.adif",
             "output_format": "Unknown",
-            "result": "e5f3db7043119313eb29f6f670989ecd"
+            "result": "e5f3db7043119313eb29f6f670989ecd",
+            "profile": "AAC Long Term Prediction"
         }
     ]
 }

--- a/test_suites/aac/MPEG4_AAC-ADTS.json
+++ b/test_suites/aac/MPEG4_AAC-ADTS.json
@@ -9,7 +9,8 @@
             "source_checksum": "fbfbcc287abaa61bb1d4e6209dc7b351",
             "input_file": "al18_32.adts",
             "output_format": "fltp",
-            "result": ""
+            "result": "",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18_22",
@@ -17,7 +18,8 @@
             "source_checksum": "9bd1df720da86de0f12a5e13cd9bac3f",
             "input_file": "al18_22.adts",
             "output_format": "fltp",
-            "result": ""
+            "result": "",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "ap04_48",
@@ -25,7 +27,8 @@
             "source_checksum": "07092bd549a107aab9546b4a7e0ececa",
             "input_file": "ap04_48.adts",
             "output_format": "fltp",
-            "result": ""
+            "result": "",
+            "profile": "AAC Long Term Prediction"
         },
         {
             "name": "al18_64",
@@ -33,7 +36,8 @@
             "source_checksum": "908ef86a5c5b546f2707e7abf6a4fcbf",
             "input_file": "al18_64.adts",
             "output_format": "fltp",
-            "result": ""
+            "result": "",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "ap02_48",
@@ -41,7 +45,8 @@
             "source_checksum": "f918c11808e687e6dc5a64154d0685b3",
             "input_file": "ap02_48.adts",
             "output_format": "fltp",
-            "result": ""
+            "result": "",
+            "profile": "AAC Long Term Prediction"
         },
         {
             "name": "al18_08",
@@ -49,7 +54,8 @@
             "source_checksum": "354eeece733c86fc4f22b63c2a6e0dbc",
             "input_file": "al18_08.adts",
             "output_format": "fltp",
-            "result": ""
+            "result": "",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "ap01_48",
@@ -57,7 +63,8 @@
             "source_checksum": "fb59fdf49e4c6ca1b7a766ce2112e36f",
             "input_file": "ap01_48.adts",
             "output_format": "fltp",
-            "result": ""
+            "result": "",
+            "profile": "AAC Long Term Prediction"
         },
         {
             "name": "al18_96",
@@ -65,7 +72,8 @@
             "source_checksum": "3a2cc79299fb52481170cced3441b5de",
             "input_file": "al18_96.adts",
             "output_format": "fltp",
-            "result": ""
+            "result": "",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "ap05_48",
@@ -73,7 +81,8 @@
             "source_checksum": "9470863a3df3daf3d4a47a8226933501",
             "input_file": "ap05_48.adts",
             "output_format": "fltp",
-            "result": ""
+            "result": "",
+            "profile": "AAC Long Term Prediction"
         }
     ]
 }

--- a/test_suites/aac/MPEG4_AAC-MP4-ER.json
+++ b/test_suites/aac/MPEG4_AAC-MP4-ER.json
@@ -9,7 +9,8 @@
             "source_checksum": "26bce18b93e6457bafd02f610cc5a4f4",
             "input_file": "er_al10_08_ep0.mp4",
             "output_format": "fltp",
-            "result": "c6fcd6821736a7db08b4b837bddc8d5a"
+            "result": "c6fcd6821736a7db08b4b837bddc8d5a",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_eld1002np_44_ep0",
@@ -17,7 +18,8 @@
             "source_checksum": "56c25a9ba7dbf2edaa1bd1f62fb7a4e5",
             "input_file": "er_eld1002np_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "5eb1bff509ee2190b5c8106e85394768"
+            "result": "5eb1bff509ee2190b5c8106e85394768",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1103_24_ep0",
@@ -25,7 +27,8 @@
             "source_checksum": "8b470529e23025663c48feae4b65b66e",
             "input_file": "er_ad1103_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "99644c341f0bb6f29e37a890f4be730b"
+            "result": "99644c341f0bb6f29e37a890f4be730b",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1000np_44_ep0",
@@ -33,7 +36,8 @@
             "source_checksum": "3a1e676b38d716ac0a040b37c0714dec",
             "input_file": "er_ad1000np_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "3979c2ea61844c0a04f0dbddb57eec92"
+            "result": "3979c2ea61844c0a04f0dbddb57eec92",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1103np_24_ep0",
@@ -41,7 +45,8 @@
             "source_checksum": "670a533c40dda4b3ec489e704f032424",
             "input_file": "er_ad1103np_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "6b7a5643f94d6b9eb0c0ab5de7018e8d"
+            "result": "6b7a5643f94d6b9eb0c0ab5de7018e8d",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_al21_24_ep0",
@@ -49,7 +54,8 @@
             "source_checksum": "83e08abad9e1c275b7a5f94d25a7f2ef",
             "input_file": "er_al21_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "f3cdf0859f2b86948193696e920746b3"
+            "result": "f3cdf0859f2b86948193696e920746b3",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_al10_48_ep0",
@@ -57,7 +63,8 @@
             "source_checksum": "ea64f49436f9bc1e2c085fb2259476b8",
             "input_file": "er_al10_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "aa8625ff1c435a24875da37565e160d1"
+            "result": "aa8625ff1c435a24875da37565e160d1",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_ad1009np_44_ep0",
@@ -65,7 +72,8 @@
             "source_checksum": "0db9fd4e9c5b17c53257ae101eb2c290",
             "input_file": "er_ad1009np_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "6e02795901f04ae627156df73b094cb2"
+            "result": "6e02795901f04ae627156df73b094cb2",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_al21_11_ep0",
@@ -73,7 +81,8 @@
             "source_checksum": "93cddf58785bcde8b4f21397b4089e07",
             "input_file": "er_al21_11_ep0.mp4",
             "output_format": "fltp",
-            "result": "e8b861c4c0c46a5352ccda59164b270d"
+            "result": "e8b861c4c0c46a5352ccda59164b270d",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_al10_64_ep0",
@@ -81,7 +90,8 @@
             "source_checksum": "b26d8ade01bd7a7e97b00de3bf4d0437",
             "input_file": "er_al10_64_ep0.mp4",
             "output_format": "fltp",
-            "result": "ec46c3606e01cf7dc52672ba02edb467"
+            "result": "ec46c3606e01cf7dc52672ba02edb467",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_ad1109np_22_ep0",
@@ -89,7 +99,8 @@
             "source_checksum": "eb4359696b3bb4cc7829c01b009a923d",
             "input_file": "er_ad1109np_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "0345d807c094d3d02f285ca5bd265bd9"
+            "result": "0345d807c094d3d02f285ca5bd265bd9",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1000np_32_ep0",
@@ -97,7 +108,8 @@
             "source_checksum": "bb2a11db5a4122ec0e367af485232784",
             "input_file": "er_ad1000np_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "d34f82efec1ebe1b5078c09e40fff4ce"
+            "result": "d34f82efec1ebe1b5078c09e40fff4ce",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1109np_44_ep0",
@@ -105,7 +117,8 @@
             "source_checksum": "33542e20d1323cf57a75a43d2a4ca765",
             "input_file": "er_ad1109np_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "ec2593eaf154abaa043f1a47489e1136"
+            "result": "ec2593eaf154abaa043f1a47489e1136",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld2100np_48_ep0",
@@ -113,7 +126,8 @@
             "source_checksum": "b0a5a5c01392ba233d2f7c1e3879b236",
             "input_file": "er_eld2100np_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "ab903797b9e36362337d2ab2bc450b53"
+            "result": "ab903797b9e36362337d2ab2bc450b53",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1102np_44_ep0",
@@ -121,7 +135,8 @@
             "source_checksum": "6688979b54230137d648a929d7291a17",
             "input_file": "er_ad1102np_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "438c091db872ebe33ffc82680cd389fa"
+            "result": "438c091db872ebe33ffc82680cd389fa",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld2100np_44_ep0",
@@ -129,7 +144,8 @@
             "source_checksum": "3a4400b0518bb27dab517da22890d797",
             "input_file": "er_eld2100np_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "1530aa87694937db16abf4e008c7d1bb"
+            "result": "1530aa87694937db16abf4e008c7d1bb",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "al16sf_08",
@@ -137,7 +153,8 @@
             "source_checksum": "26c365f74e2bdb5aef239e06a763417d",
             "input_file": "al16sf_08.mp4",
             "output_format": "fltp",
-            "result": "4aa885e17b05c45118ff7d377c67b9fe"
+            "result": "4aa885e17b05c45118ff7d377c67b9fe",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "er_eld1101np_22_ep0",
@@ -145,7 +162,8 @@
             "source_checksum": "9ff710fb9fc6bc3f3ab33224524a75f4",
             "input_file": "er_eld1101np_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "d76cbeb40e4b969ac5387410e3677352"
+            "result": "d76cbeb40e4b969ac5387410e3677352",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1000_48_ep0",
@@ -153,7 +171,8 @@
             "source_checksum": "6916186f575fcb043dff05add344cf00",
             "input_file": "er_ad1000_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "1e0380d3fcb5937d3638e75a6b1e7f1b"
+            "result": "1e0380d3fcb5937d3638e75a6b1e7f1b",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld2000np_44_ep0",
@@ -161,7 +180,8 @@
             "source_checksum": "362541312ff9076fee3883121259659f",
             "input_file": "er_eld2000np_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "f088e5604c253614fec57f1f4a6684f5"
+            "result": "f088e5604c253614fec57f1f4a6684f5",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_al21_08_ep0",
@@ -169,7 +189,8 @@
             "source_checksum": "ac942aa845d97da613b3b06a3a16585f",
             "input_file": "er_al21_08_ep0.mp4",
             "output_format": "fltp",
-            "result": "b66059b4e749edbc7046b8560d5f5967"
+            "result": "b66059b4e749edbc7046b8560d5f5967",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_ad1109_24_ep0",
@@ -177,7 +198,8 @@
             "source_checksum": "d1f9fed36b551ed31fbeca28a531d039",
             "input_file": "er_ad1109_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "212971666535971ede102e7764709d08"
+            "result": "212971666535971ede102e7764709d08",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1102_44_ep0",
@@ -185,7 +207,8 @@
             "source_checksum": "987ebb50884a34b8499a1cc361fa68cd",
             "input_file": "er_ad1102_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "332e6e892fba7f670d67eb3fc6df2d5b"
+            "result": "332e6e892fba7f670d67eb3fc6df2d5b",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1109np_24_ep0",
@@ -193,7 +216,8 @@
             "source_checksum": "df15f20067ed6da6b9030055724e15ba",
             "input_file": "er_ad1109np_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "3ad16d655502f87a6e5f29bb3e0750e1"
+            "result": "3ad16d655502f87a6e5f29bb3e0750e1",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld1101np_44_ep0",
@@ -201,7 +225,8 @@
             "source_checksum": "f81a9ef31b3fb4ba7cb1e4a49fd21194",
             "input_file": "er_eld1101np_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "72cfbf286c23f484f018b1e374848f8c"
+            "result": "72cfbf286c23f484f018b1e374848f8c",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1103np_32_ep0",
@@ -209,7 +234,8 @@
             "source_checksum": "70f96824580ade7379347c76110aa932",
             "input_file": "er_ad1103np_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "584090736b663c17757c7ff589e14cc0"
+            "result": "584090736b663c17757c7ff589e14cc0",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld2000np_48_ep0",
@@ -217,7 +243,8 @@
             "source_checksum": "d29d3e2c9d05cfb6d1d7c9ed08a83838",
             "input_file": "er_eld2000np_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "c5286ddc28643270fc52031a679a395c"
+            "result": "c5286ddc28643270fc52031a679a395c",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1000_32_ep0",
@@ -225,7 +252,8 @@
             "source_checksum": "557961d4ba6c5fbdf11564d1d97e85c9",
             "input_file": "er_ad1000_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "a3db51fd80898726e05a672006edbfda"
+            "result": "a3db51fd80898726e05a672006edbfda",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld2100np_32_ep0",
@@ -233,7 +261,8 @@
             "source_checksum": "0ba1be9b550e52ea133bb5d543266a79",
             "input_file": "er_eld2100np_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "827afb35bd8bd757c3ff2c901ed4308f"
+            "result": "827afb35bd8bd757c3ff2c901ed4308f",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_al10_12_ep0",
@@ -241,7 +270,8 @@
             "source_checksum": "78419c443d1cb73f22c2be3a628528c4",
             "input_file": "er_al10_12_ep0.mp4",
             "output_format": "fltp",
-            "result": "895e17a37ab1a076d430fe3d42f929d7"
+            "result": "895e17a37ab1a076d430fe3d42f929d7",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_ad1109_32_ep0",
@@ -249,7 +279,8 @@
             "source_checksum": "99680e8265ccb2081ede038d30bc4081",
             "input_file": "er_ad1109_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "2e048a5a89091cd43671ba8c2af77d11"
+            "result": "2e048a5a89091cd43671ba8c2af77d11",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1009np_24_ep0",
@@ -257,7 +288,8 @@
             "source_checksum": "cd5e9efab90b1e3986c0a0c3bc3f0fe8",
             "input_file": "er_ad1009np_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "26c6d2ebf383b816ae91f404e2068050"
+            "result": "26c6d2ebf383b816ae91f404e2068050",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1103_32_ep0",
@@ -265,7 +297,8 @@
             "source_checksum": "2abcbadbc3143d23e54e3fb6e3bf95d9",
             "input_file": "er_ad1103_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "8c115284c4d87ad1168e208220ca3fea"
+            "result": "8c115284c4d87ad1168e208220ca3fea",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld1001np_22_ep0",
@@ -273,7 +306,8 @@
             "source_checksum": "bd1c0f36300e1153adc36e363f8fd368",
             "input_file": "er_eld1001np_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "ff20c9a0553d8d13940c101386c9bd68"
+            "result": "ff20c9a0553d8d13940c101386c9bd68",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_eld1000np_48_ep0",
@@ -281,7 +315,8 @@
             "source_checksum": "b1ddc9429beb1807daa5e93b9629d29c",
             "input_file": "er_eld1000np_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "7f570fee53b99c5066adfc455cad9302"
+            "result": "7f570fee53b99c5066adfc455cad9302",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_eld2000np_22_ep0",
@@ -289,7 +324,8 @@
             "source_checksum": "270bb6c5a43ead1a36af14aca28cf02f",
             "input_file": "er_eld2000np_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "9f4ad9877bd1be77305d418cd69e1cac"
+            "result": "9f4ad9877bd1be77305d418cd69e1cac",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_al21_48_ep0",
@@ -297,7 +333,8 @@
             "source_checksum": "9b88cbc17d8c6b75f3cb2c08e4e50446",
             "input_file": "er_al21_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "7b8f976df4b91511da3c074150352b63"
+            "result": "7b8f976df4b91511da3c074150352b63",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_eld1100np_32_ep0",
@@ -305,7 +342,8 @@
             "source_checksum": "1852d9d9c8838e01881c09e7d6877e13",
             "input_file": "er_eld1100np_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "4b0f124ad0c9f40c839aa95b5a711d08"
+            "result": "4b0f124ad0c9f40c839aa95b5a711d08",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1103_48_ep0",
@@ -313,7 +351,8 @@
             "source_checksum": "1a3d68c67a268bbcd6094c3c21267aa1",
             "input_file": "er_ad1103_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "555bf3ade23e9c247b53f3c56c5e6fda"
+            "result": "555bf3ade23e9c247b53f3c56c5e6fda",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_al21_12_ep0",
@@ -321,7 +360,8 @@
             "source_checksum": "a75277e3bb21b8e71f64ed1c0b87d9a6",
             "input_file": "er_al21_12_ep0.mp4",
             "output_format": "fltp",
-            "result": "7b18d074100213ab294bac8f558cc3df"
+            "result": "7b18d074100213ab294bac8f558cc3df",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_al10_44_ep0",
@@ -329,7 +369,8 @@
             "source_checksum": "3c1ca2c0ca552073a7c8c43497128aed",
             "input_file": "er_al10_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "c67e324952cb9e34ce4baf5317b4631c"
+            "result": "c67e324952cb9e34ce4baf5317b4631c",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_ad1103_44_ep0",
@@ -337,7 +378,8 @@
             "source_checksum": "7f4604395275473d21888f02d90d85b0",
             "input_file": "er_ad1103_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "b57817e9685e880ecf53b8bbe43fc4c8"
+            "result": "b57817e9685e880ecf53b8bbe43fc4c8",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1009np_32_ep0",
@@ -345,7 +387,8 @@
             "source_checksum": "00b95f4c693f8ba63b6724e69dcfa846",
             "input_file": "er_ad1009np_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "16df4ae23bf506c475c4d3f8c0698fd4"
+            "result": "16df4ae23bf506c475c4d3f8c0698fd4",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld1102np_44_ep0",
@@ -353,7 +396,8 @@
             "source_checksum": "f40d31bdcdc7ab034f24ce09c9f58e07",
             "input_file": "er_eld1102np_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "64656964d2f42b1a4106154918d9fe7e"
+            "result": "64656964d2f42b1a4106154918d9fe7e",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1000_24_ep0",
@@ -361,7 +405,8 @@
             "source_checksum": "e7c1275f048213fda3056c613a6602e3",
             "input_file": "er_ad1000_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "adb2ad187c39ce276e21f4303bd6f765"
+            "result": "adb2ad187c39ce276e21f4303bd6f765",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld1100np_48_ep0",
@@ -369,7 +414,8 @@
             "source_checksum": "f8108cbb185cf3b31db640d1748fad79",
             "input_file": "er_eld1100np_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "b9160336693ae2ed73fb1099310c398c"
+            "result": "b9160336693ae2ed73fb1099310c398c",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1100np_44_ep0",
@@ -377,7 +423,8 @@
             "source_checksum": "d8948badebdba62c3fa5d3699ed58bc0",
             "input_file": "er_ad1100np_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "438c091db872ebe33ffc82680cd389fa"
+            "result": "438c091db872ebe33ffc82680cd389fa",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1103np_48_ep0",
@@ -385,7 +432,8 @@
             "source_checksum": "f24412755c3b9a8b09c07f529886c2df",
             "input_file": "er_ad1103np_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "687527ce33acf008c3aa4965479d8146"
+            "result": "687527ce33acf008c3aa4965479d8146",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld1101np_24_ep0",
@@ -393,7 +441,8 @@
             "source_checksum": "d7bb3f920a70bbedf32a1e3c8efac664",
             "input_file": "er_eld1101np_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "4c63888c442a903a7a35fe71097defe4"
+            "result": "4c63888c442a903a7a35fe71097defe4",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1103np_44_ep0",
@@ -401,7 +450,8 @@
             "source_checksum": "29f720614143f00a5e267db75cedab67",
             "input_file": "er_ad1103np_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "21acbae527ef6644b90bbd275dbce56b"
+            "result": "21acbae527ef6644b90bbd275dbce56b",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1102np_24_ep0",
@@ -409,7 +459,8 @@
             "source_checksum": "04eee28e92ea2c6528d79a76c2f9c187",
             "input_file": "er_ad1102np_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "a6e741ee834e77a758e77f8fd5e50a20"
+            "result": "a6e741ee834e77a758e77f8fd5e50a20",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_al10_32_ep0",
@@ -417,7 +468,8 @@
             "source_checksum": "134eced76316c312dd731e92e2997abc",
             "input_file": "er_al10_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "7a279aba076d4ca2b67bbc864d70970b"
+            "result": "7a279aba076d4ca2b67bbc864d70970b",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_ad1102np_22_ep0",
@@ -425,7 +477,8 @@
             "source_checksum": "85fd8e8724b5e426ff4a189fcd4775cb",
             "input_file": "er_ad1102np_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "ef839c2808b3abc6c64af9c928140eae"
+            "result": "ef839c2808b3abc6c64af9c928140eae",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld1100np_24_ep0",
@@ -433,7 +486,8 @@
             "source_checksum": "49c707647d21102ca48028de76becec2",
             "input_file": "er_eld1100np_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "cc6acd8d840ce8a1e3f5137a9760731b"
+            "result": "cc6acd8d840ce8a1e3f5137a9760731b",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_al10_22_ep0",
@@ -441,7 +495,8 @@
             "source_checksum": "a059de2f08acf98406b9ecb10af74fdd",
             "input_file": "er_al10_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "5ffce45fbae018d04ca1acbc93f20d98"
+            "result": "5ffce45fbae018d04ca1acbc93f20d98",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_ad1102_22_ep0",
@@ -449,7 +504,8 @@
             "source_checksum": "9f2c1f6dbc1720ff9f2ff90a6c76962a",
             "input_file": "er_ad1102_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "6f485ea042f14fd0d4f54016acd9ff42"
+            "result": "6f485ea042f14fd0d4f54016acd9ff42",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1103_22_ep0",
@@ -457,7 +513,8 @@
             "source_checksum": "f5573b545d9bc589e03381f31a15a76d",
             "input_file": "er_ad1103_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "9080966e286a6b9a96e9f56b85869d26"
+            "result": "9080966e286a6b9a96e9f56b85869d26",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_al10_24_ep0",
@@ -465,7 +522,8 @@
             "source_checksum": "aa8aa251ffd77d101a8b864c28dd5c99",
             "input_file": "er_al10_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "c1fb34796ce151eded306616ae5911d3"
+            "result": "c1fb34796ce151eded306616ae5911d3",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_ad1109np_48_ep0",
@@ -473,7 +531,8 @@
             "source_checksum": "9231517c1d5554841d291710be33ef5f",
             "input_file": "er_ad1109np_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "1d2105dc9f842d6f5871fc2636a716fe"
+            "result": "1d2105dc9f842d6f5871fc2636a716fe",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_al10_96_ep0",
@@ -481,7 +540,8 @@
             "source_checksum": "277c987e9f4ef1de38b973b28e387674",
             "input_file": "er_al10_96_ep0.mp4",
             "output_format": "fltp",
-            "result": "f527c6c7cb9cfa164098519920140f6c"
+            "result": "f527c6c7cb9cfa164098519920140f6c",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_ad1109_48_ep0",
@@ -489,7 +549,8 @@
             "source_checksum": "3810716c26aa101b8cbfffa271398dae",
             "input_file": "er_ad1109_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "0f2652a924c8eefe6ac4454d5d1644c5"
+            "result": "0f2652a924c8eefe6ac4454d5d1644c5",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1000_44_ep0",
@@ -497,7 +558,8 @@
             "source_checksum": "0b9f7fb6bcfa23fe47533793d1920155",
             "input_file": "er_ad1000_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "e9ef68dd8b0835aaa00644f986e74249"
+            "result": "e9ef68dd8b0835aaa00644f986e74249",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1103np_22_ep0",
@@ -505,7 +567,8 @@
             "source_checksum": "58f29e7132b7aadb7a95b6df93ad294d",
             "input_file": "er_ad1103np_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "c441f75a01d3a951fbd72394702ceb1b"
+            "result": "c441f75a01d3a951fbd72394702ceb1b",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld2100np_24_ep0",
@@ -513,7 +576,8 @@
             "source_checksum": "393dc6c5bb2080b1cb1dacd8a6947969",
             "input_file": "er_eld2100np_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "28db0e8995d4bbf0e03028cef0e4539f"
+            "result": "28db0e8995d4bbf0e03028cef0e4539f",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1009np_48_ep0",
@@ -521,7 +585,8 @@
             "source_checksum": "9ab09cd291073d8930061488bfee7e64",
             "input_file": "er_ad1009np_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "e7d94f0ab333991f551c165ab0fdfa5c"
+            "result": "e7d94f0ab333991f551c165ab0fdfa5c",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1109np_32_ep0",
@@ -529,7 +594,8 @@
             "source_checksum": "4836a604033b313898fea3fcbbf843f5",
             "input_file": "er_ad1109np_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "064cdb8ce0e1811f7ea815216e300c99"
+            "result": "064cdb8ce0e1811f7ea815216e300c99",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld1102np_22_ep0",
@@ -537,7 +603,8 @@
             "source_checksum": "08a77755bd5479a6b02a10f8b1b8fb6b",
             "input_file": "er_eld1102np_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "980a1c6e02b7c3d20d026c87ee1b3061"
+            "result": "980a1c6e02b7c3d20d026c87ee1b3061",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1102_48_ep0",
@@ -545,7 +612,8 @@
             "source_checksum": "a9f4c557eeadbd7e9d051b854141d04c",
             "input_file": "er_ad1102_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "8361ece97fdf8f1dd4977c1d86a11345"
+            "result": "8361ece97fdf8f1dd4977c1d86a11345",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld1102np_32_ep0",
@@ -553,7 +621,8 @@
             "source_checksum": "eeb11678bf04c63a25f937be84fca235",
             "input_file": "er_eld1102np_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "7f6693fe4738cf8c70d86872a1d6ef50"
+            "result": "7f6693fe4738cf8c70d86872a1d6ef50",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1000np_48_ep0",
@@ -561,7 +630,8 @@
             "source_checksum": "37f99e3230375016f305ff559be53862",
             "input_file": "er_ad1000np_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "86deb3c0874a0b22b4a563bd1c378510"
+            "result": "86deb3c0874a0b22b4a563bd1c378510",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "al07sf_08",
@@ -569,7 +639,8 @@
             "source_checksum": "affa134e126228b86538668d9a469ece",
             "input_file": "al07sf_08.mp4",
             "output_format": "fltp",
-            "result": "4595249efe95fdfe23775f4361d35802"
+            "result": "4595249efe95fdfe23775f4361d35802",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "er_eld1102np_24_ep0",
@@ -577,7 +648,8 @@
             "source_checksum": "2c3809437807ac57dc7cf5f1fbb3b768",
             "input_file": "er_eld1102np_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "8d090e996f0482b65a73ecb09f6d098c"
+            "result": "8d090e996f0482b65a73ecb09f6d098c",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_eld1002np_22_ep0",
@@ -585,7 +657,8 @@
             "source_checksum": "d558cfe29bfcd0fc67ecc51d3f7d2b1e",
             "input_file": "er_eld1002np_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "aa2fa4a4e7f209fc3365cc29277d4f63"
+            "result": "aa2fa4a4e7f209fc3365cc29277d4f63",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_al21_64_ep0",
@@ -593,7 +666,8 @@
             "source_checksum": "5e8aec3c8343b2f3292d1321ed9b6171",
             "input_file": "er_al21_64_ep0.mp4",
             "output_format": "fltp",
-            "result": "cc2fbf3ea34be5fa845b035e6bd86a42"
+            "result": "cc2fbf3ea34be5fa845b035e6bd86a42",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_eld1100np_44_ep0",
@@ -601,7 +675,8 @@
             "source_checksum": "6a00489d914334bb340faeb21ce0ca00",
             "input_file": "er_eld1100np_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "0ef341648df98e43a1eebd8d34f0ed2d"
+            "result": "0ef341648df98e43a1eebd8d34f0ed2d",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1109_44_ep0",
@@ -609,7 +684,8 @@
             "source_checksum": "3f9de602e7072083a42da719ee29a1e9",
             "input_file": "er_ad1109_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "0f2652a924c8eefe6ac4454d5d1644c5"
+            "result": "0f2652a924c8eefe6ac4454d5d1644c5",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld1102np_48_ep0",
@@ -617,7 +693,8 @@
             "source_checksum": "b3ed0ac9e400c0daa04a7a9e689b405c",
             "input_file": "er_eld1102np_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "7867b99a6e2ea4f6d56b0fb9c1c22a72"
+            "result": "7867b99a6e2ea4f6d56b0fb9c1c22a72",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_eld1001np_48_ep0",
@@ -625,7 +702,8 @@
             "source_checksum": "3c3fb465914729c1ac698cac8a5e0b14",
             "input_file": "er_eld1001np_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "f22aadd4033a0071c065f59034c231ad"
+            "result": "f22aadd4033a0071c065f59034c231ad",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1000_22_ep0",
@@ -633,7 +711,8 @@
             "source_checksum": "be35f725aea4661a26e90e371c99cf86",
             "input_file": "er_ad1000_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "3d62533ebd4d8b12dbf964b8fcef87d5"
+            "result": "3d62533ebd4d8b12dbf964b8fcef87d5",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld1000np_24_ep0",
@@ -641,7 +720,8 @@
             "source_checksum": "017173db6979bb2d9894a5ee7b29af6e",
             "input_file": "er_eld1000np_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "829a4ce3a1865d8a965679defdcc7829"
+            "result": "829a4ce3a1865d8a965679defdcc7829",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_eld1101np_48_ep0",
@@ -649,7 +729,8 @@
             "source_checksum": "bb0db8c18babc2127dcf23325c138c52",
             "input_file": "er_eld1101np_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "24291e994b13fd1fa9351b1a1877c0a5"
+            "result": "24291e994b13fd1fa9351b1a1877c0a5",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_eld2000np_32_ep0",
@@ -657,7 +738,8 @@
             "source_checksum": "0003233dce8db074c0241d731fc302a5",
             "input_file": "er_eld2000np_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "6eaa86e98082caf563bff51ef25d8bcc"
+            "result": "6eaa86e98082caf563bff51ef25d8bcc",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_al21_16_ep0",
@@ -665,7 +747,8 @@
             "source_checksum": "3d5c816c9a34cf057dd575112ef6a2f4",
             "input_file": "er_al21_16_ep0.mp4",
             "output_format": "fltp",
-            "result": "49e6a36bdc0a570cc26874a4c9f6235f"
+            "result": "49e6a36bdc0a570cc26874a4c9f6235f",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_ad1100np_24_ep0",
@@ -673,7 +756,8 @@
             "source_checksum": "5490d765586367e654fc1d9184c093c0",
             "input_file": "er_ad1100np_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "a6e741ee834e77a758e77f8fd5e50a20"
+            "result": "a6e741ee834e77a758e77f8fd5e50a20",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1102_32_ep0",
@@ -681,7 +765,8 @@
             "source_checksum": "0ef1d4b154ba64f497d351b111ab51ca",
             "input_file": "er_ad1102_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "1958643d40f63e7d4a9bf8c4dc26584c"
+            "result": "1958643d40f63e7d4a9bf8c4dc26584c",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1102_24_ep0",
@@ -689,7 +774,8 @@
             "source_checksum": "3fe5ffea36b9fd880094a8a6f1d1a041",
             "input_file": "er_ad1102_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "458014fd9bc03487072703d6bea0c13e"
+            "result": "458014fd9bc03487072703d6bea0c13e",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld1001np_32_ep0",
@@ -697,7 +783,8 @@
             "source_checksum": "06d214ebddbf836a898ded9e050cbc49",
             "input_file": "er_eld1001np_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "2148e4918631fa293176c59e921026b9"
+            "result": "2148e4918631fa293176c59e921026b9",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_eld1002np_32_ep0",
@@ -705,7 +792,8 @@
             "source_checksum": "8652d266e57dd7c62aad4c9c2d8a0d5a",
             "input_file": "er_eld1002np_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "79d699eeba6752ae3b29679fdc7616e2"
+            "result": "79d699eeba6752ae3b29679fdc7616e2",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_eld1100np_22_ep0",
@@ -713,7 +801,8 @@
             "source_checksum": "305917a2a2ed2da901a327a724f404f1",
             "input_file": "er_eld1100np_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "7e8a2f7a4c35fea1bade7a776ea6def4"
+            "result": "7e8a2f7a4c35fea1bade7a776ea6def4",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1102np_48_ep0",
@@ -721,7 +810,8 @@
             "source_checksum": "c4920c19829bcf5431d76174f2d55989",
             "input_file": "er_ad1102np_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "c06fd90bd71c193456f1a61b643cd845"
+            "result": "c06fd90bd71c193456f1a61b643cd845",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1100np_48_ep0",
@@ -729,7 +819,8 @@
             "source_checksum": "4f5ffc824bae3bd3974d29eedd76653c",
             "input_file": "er_ad1100np_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "c06fd90bd71c193456f1a61b643cd845"
+            "result": "c06fd90bd71c193456f1a61b643cd845",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "al14sf_08",
@@ -737,7 +828,8 @@
             "source_checksum": "86744bb97ec398469fb9dc0c5c537cd7",
             "input_file": "al14sf_08.mp4",
             "output_format": "fltp",
-            "result": "de273e46aafc0190a9f1b0cff657b8fb"
+            "result": "de273e46aafc0190a9f1b0cff657b8fb",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "er_ad1109_22_ep0",
@@ -745,7 +837,8 @@
             "source_checksum": "c49c0652ff473928cdfc84e98fd226c5",
             "input_file": "er_ad1109_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "212971666535971ede102e7764709d08"
+            "result": "212971666535971ede102e7764709d08",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_al10_16_ep0",
@@ -753,7 +846,8 @@
             "source_checksum": "8329f3520bb380d3d615088ac17e0346",
             "input_file": "er_al10_16_ep0.mp4",
             "output_format": "fltp",
-            "result": "425322db8d5e51e323c5f0b93d2831d0"
+            "result": "425322db8d5e51e323c5f0b93d2831d0",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_eld1001np_44_ep0",
@@ -761,7 +855,8 @@
             "source_checksum": "a2ee90ccb4c66a2b8d0353992eb3e291",
             "input_file": "er_eld1001np_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "66f39b4b40417497e8c23b174a0116b7"
+            "result": "66f39b4b40417497e8c23b174a0116b7",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1102np_32_ep0",
@@ -769,7 +864,8 @@
             "source_checksum": "ba7d4eaa25f4bc5b05a10bcab5c501a2",
             "input_file": "er_ad1102np_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "7c664d8171c01d151d78ef0ddafc5ace"
+            "result": "7c664d8171c01d151d78ef0ddafc5ace",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld1000np_32_ep0",
@@ -777,7 +873,8 @@
             "source_checksum": "9a1dfe23cab5f47c5d29500ea0c2495c",
             "input_file": "er_eld1000np_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "d536049b5dadf6cf7927eed3024ea03e"
+            "result": "d536049b5dadf6cf7927eed3024ea03e",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_al10_11_ep0",
@@ -785,7 +882,8 @@
             "source_checksum": "8c969714e872af07fc374f5dca07bef9",
             "input_file": "er_al10_11_ep0.mp4",
             "output_format": "fltp",
-            "result": "6c9983825c8d30d7211ae1d929201f08"
+            "result": "6c9983825c8d30d7211ae1d929201f08",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_ad1009np_22_ep0",
@@ -793,7 +891,8 @@
             "source_checksum": "a9495a8b4b85a7d15b0567123089cbdf",
             "input_file": "er_ad1009np_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "e8badb9eae31bbc8c47c07718c4ed666"
+            "result": "e8badb9eae31bbc8c47c07718c4ed666",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld1000np_44_ep0",
@@ -801,7 +900,8 @@
             "source_checksum": "2127f4f7467d675409fe679ec9f491a7",
             "input_file": "er_eld1000np_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "743a1a9945049c9b117356caed22de92"
+            "result": "743a1a9945049c9b117356caed22de92",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_al10_88_ep0",
@@ -809,7 +909,8 @@
             "source_checksum": "62da442ed736926d88f7af378a9c922c",
             "input_file": "er_al10_88_ep0.mp4",
             "output_format": "fltp",
-            "result": "4f6b2fbfd9006d2647473dfdf7039e07"
+            "result": "4f6b2fbfd9006d2647473dfdf7039e07",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_ad1000np_22_ep0",
@@ -817,7 +918,8 @@
             "source_checksum": "525f1126aadb37b89204150171242d8c",
             "input_file": "er_ad1000np_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "3b83525a94148681891a52fe3920d7c5"
+            "result": "3b83525a94148681891a52fe3920d7c5",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_al21_32_ep0",
@@ -825,7 +927,8 @@
             "source_checksum": "e984cddfafd7abf9a80fbcbee5489915",
             "input_file": "er_al21_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "8a0ba2d9a6aff5ef5aa942124a8bb972"
+            "result": "8a0ba2d9a6aff5ef5aa942124a8bb972",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_ad1000np_24_ep0",
@@ -833,7 +936,8 @@
             "source_checksum": "adcb13b40d0a4686a235380ff09cdccf",
             "input_file": "er_ad1000np_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "4ba0027dee940081bb9c3d23a73cd796"
+            "result": "4ba0027dee940081bb9c3d23a73cd796",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_ad1100np_32_ep0",
@@ -841,7 +945,8 @@
             "source_checksum": "afa31e4a93936aa60be7b06fd2e29356",
             "input_file": "er_ad1100np_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "7c664d8171c01d151d78ef0ddafc5ace"
+            "result": "7c664d8171c01d151d78ef0ddafc5ace",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_eld1002np_24_ep0",
@@ -849,7 +954,8 @@
             "source_checksum": "c693ad02acaca5c457b6ea90f430bf3c",
             "input_file": "er_eld1002np_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "f7b8b97a8745310e0efb0933a571024d"
+            "result": "f7b8b97a8745310e0efb0933a571024d",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_al21_22_ep0",
@@ -857,7 +963,8 @@
             "source_checksum": "f32d5d02377bec66dfc4de4c95781f19",
             "input_file": "er_al21_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "3aa7c59975e95fd3e4b9afb1d232db86"
+            "result": "3aa7c59975e95fd3e4b9afb1d232db86",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_al21_44_ep0",
@@ -865,7 +972,8 @@
             "source_checksum": "6623ca641a3fd61f8dc34a6513908c20",
             "input_file": "er_al21_44_ep0.mp4",
             "output_format": "fltp",
-            "result": "3ccac063da9949f0d2f89a6939a29dc2"
+            "result": "3ccac063da9949f0d2f89a6939a29dc2",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_eld1002np_48_ep0",
@@ -873,7 +981,8 @@
             "source_checksum": "f60324013b319f697a61d156d513f0f4",
             "input_file": "er_eld1002np_48_ep0.mp4",
             "output_format": "fltp",
-            "result": "1e45873a30075411a1f350222b12e4be"
+            "result": "1e45873a30075411a1f350222b12e4be",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_ad1100np_22_ep0",
@@ -881,7 +990,8 @@
             "source_checksum": "ed8e08dcc785bf654cb369d838e71d2a",
             "input_file": "er_ad1100np_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "ef839c2808b3abc6c64af9c928140eae"
+            "result": "ef839c2808b3abc6c64af9c928140eae",
+            "profile": "Error Resilient AAC Low Delay"
         },
         {
             "name": "er_al21_88_ep0",
@@ -889,7 +999,8 @@
             "source_checksum": "ac96fbdf43f9935ee0e0500b9aac32de",
             "input_file": "er_al21_88_ep0.mp4",
             "output_format": "fltp",
-            "result": "e935ef2c0365c29a5785b30aeb3da002"
+            "result": "e935ef2c0365c29a5785b30aeb3da002",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_eld1001np_24_ep0",
@@ -897,7 +1008,8 @@
             "source_checksum": "9997147edfadfc1fbe119d77eb57d292",
             "input_file": "er_eld1001np_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "a347b6407dc32dcd005e7c8e3497e0ad"
+            "result": "a347b6407dc32dcd005e7c8e3497e0ad",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_eld2100np_22_ep0",
@@ -905,7 +1017,8 @@
             "source_checksum": "04b92fbc3efe9db520ff1dd7cc862a5e",
             "input_file": "er_eld2100np_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "6d0b509c0363bc0c4ab66bff5b629351"
+            "result": "6d0b509c0363bc0c4ab66bff5b629351",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_eld2000np_24_ep0",
@@ -913,7 +1026,8 @@
             "source_checksum": "8719cec076eb9d08d455c1d68e2135f4",
             "input_file": "er_eld2000np_24_ep0.mp4",
             "output_format": "fltp",
-            "result": "20210ce9452e691f88ce33ebf8b36ccd"
+            "result": "20210ce9452e691f88ce33ebf8b36ccd",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_eld1101np_32_ep0",
@@ -921,7 +1035,8 @@
             "source_checksum": "ddbff36d1c9534c76d28ef5f4f5c9e7e",
             "input_file": "er_eld1101np_32_ep0.mp4",
             "output_format": "fltp",
-            "result": "9e328c2e13b8b1fec8e10f2da3a9601f"
+            "result": "9e328c2e13b8b1fec8e10f2da3a9601f",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         },
         {
             "name": "er_al21_96_ep0",
@@ -929,7 +1044,8 @@
             "source_checksum": "b029d8cd0902a45ba704a2b7c65ec84c",
             "input_file": "er_al21_96_ep0.mp4",
             "output_format": "fltp",
-            "result": "da710ab7351c9500ece8eff60f18accd"
+            "result": "da710ab7351c9500ece8eff60f18accd",
+            "profile": "Error Resilient AAC Low Complexity"
         },
         {
             "name": "er_eld1000np_22_ep0",
@@ -937,7 +1053,8 @@
             "source_checksum": "2686571b1052156f59b97620c3982001",
             "input_file": "er_eld1000np_22_ep0.mp4",
             "output_format": "fltp",
-            "result": "0fea1969edf11269e25ce45d63719b31"
+            "result": "0fea1969edf11269e25ce45d63719b31",
+            "profile": "Error Resilient AAC Enhanced Low Delay"
         }
     ]
 }

--- a/test_suites/aac/MPEG4_AAC-MP4.json
+++ b/test_suites/aac/MPEG4_AAC-MP4.json
@@ -9,7 +9,8 @@
             "source_checksum": "5c24a9d1cb7f4fa0b2411cd5c06d9b51",
             "input_file": "al03_88.mp4",
             "output_format": "fltp",
-            "result": "582225859b9df6f9bb2a25c7ec843fdd"
+            "result": "582225859b9df6f9bb2a25c7ec843fdd",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as12_12",
@@ -17,7 +18,8 @@
             "source_checksum": "f8dc0532392017182c88750416530bbf",
             "input_file": "as12_12.mp4",
             "output_format": "fltp",
-            "result": "bda16028a6bf0f84d2466e3689bf73bb"
+            "result": "bda16028a6bf0f84d2466e3689bf73bb",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as11_08",
@@ -25,7 +27,8 @@
             "source_checksum": "6d94215f3f93a2c902ec0a530c125593",
             "input_file": "as11_08.mp4",
             "output_format": "fltp",
-            "result": "c956ff0d8d65f1157da8db8704a1aa0f"
+            "result": "c956ff0d8d65f1157da8db8704a1aa0f",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06sf_11",
@@ -33,7 +36,8 @@
             "source_checksum": "5c70070e209964f0ad617ff3159bb5f3",
             "input_file": "al06sf_11.mp4",
             "output_format": "fltp",
-            "result": "7a87c14fd11bbc3b60aa9e4f33c197f1"
+            "result": "7a87c14fd11bbc3b60aa9e4f33c197f1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as16_64",
@@ -41,7 +45,8 @@
             "source_checksum": "18655d2b66c3d82e437cf4ba53c8b846",
             "input_file": "as16_64.mp4",
             "output_format": "fltp",
-            "result": "ec355f7a5f6a6728ddb7b9076940d870"
+            "result": "ec355f7a5f6a6728ddb7b9076940d870",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al16_88",
@@ -49,7 +54,8 @@
             "source_checksum": "2c17bccc6fcc14b8e69d5ef9c6f6499d",
             "input_file": "al16_88.mp4",
             "output_format": "fltp",
-            "result": "97cd06e5939f630e7f5a510dd5e7a813"
+            "result": "97cd06e5939f630e7f5a510dd5e7a813",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as01_22",
@@ -57,7 +63,8 @@
             "source_checksum": "1f85ae3b9c31d6c5f2a62b11cc22373d",
             "input_file": "as01_22.mp4",
             "output_format": "fltp",
-            "result": "575bde090656bf44b9b7d1031cc7b4ac"
+            "result": "575bde090656bf44b9b7d1031cc7b4ac",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03sf_22",
@@ -65,7 +72,8 @@
             "source_checksum": "996de7cf2d6d4eb8d9f61d1e07a3796a",
             "input_file": "al03sf_22.mp4",
             "output_format": "fltp",
-            "result": "6819ba04cee182d2aa3247ed93b9923d"
+            "result": "6819ba04cee182d2aa3247ed93b9923d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as09_44",
@@ -73,7 +81,8 @@
             "source_checksum": "0a59789e5c925ab85c481c068c029fde",
             "input_file": "as09_44.mp4",
             "output_format": "fltp",
-            "result": "1c94b07c439b666ba0a70cac1f6738fc"
+            "result": "1c94b07c439b666ba0a70cac1f6738fc",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al01_96",
@@ -81,7 +90,8 @@
             "source_checksum": "7d68c09d9a5305a5dd800df0c25257a2",
             "input_file": "al01_96.mp4",
             "output_format": "fltp",
-            "result": "4677b93aa04c55103ebd1dce77c6f4c8"
+            "result": "4677b93aa04c55103ebd1dce77c6f4c8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_cm_48_4",
@@ -89,7 +99,8 @@
             "source_checksum": "2637f4a3be1eabb6096d06c7efdeb952",
             "input_file": "al_sbr_cm_48_4.mp4",
             "output_format": "fltp",
-            "result": "07acadee4407b998e5418e8c8648a39a"
+            "result": "07acadee4407b998e5418e8c8648a39a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am06_22",
@@ -97,7 +108,8 @@
             "source_checksum": "7c9e3959cf77ef945a1f21bce9f969b4",
             "input_file": "am06_22.mp4",
             "output_format": "fltp",
-            "result": "cbeb3dc961c8192dc2e2a1e7ec06e942"
+            "result": "cbeb3dc961c8192dc2e2a1e7ec06e942",
+            "profile": "AAC Main"
         },
         {
             "name": "al_sbr_sr_64_2_fsaac32",
@@ -105,7 +117,8 @@
             "source_checksum": "9115b198863286afcc2a519de49d8e59",
             "input_file": "al_sbr_sr_64_2_fsaac32.mp4",
             "output_format": "fltp",
-            "result": "c82a0f963cc008fcc223c77f6d6ffa7e"
+            "result": "c82a0f963cc008fcc223c77f6d6ffa7e",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_e_44_2",
@@ -113,7 +126,8 @@
             "source_checksum": "9886fc350bc0f53bddfb92283fde5eb3",
             "input_file": "al_sbr_e_44_2.mp4",
             "output_format": "fltp",
-            "result": "1d7ab0c44433d56d9c0f513445ed16ab"
+            "result": "1d7ab0c44433d56d9c0f513445ed16ab",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_ps_03_new",
@@ -121,7 +135,8 @@
             "source_checksum": "458b52cac1a86d7f7f4b65833d920d97",
             "input_file": "al_sbr_ps_03_new.mp4",
             "output_format": "fltp",
-            "result": "bce3ff8a9b5f74de69f9bd70ba79ec17"
+            "result": "bce3ff8a9b5f74de69f9bd70ba79ec17",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_64",
@@ -129,7 +144,8 @@
             "source_checksum": "32380747173d25cb74d186c1b5ef0633",
             "input_file": "am00_64.mp4",
             "output_format": "fltp",
-            "result": "3fb7576e4821be816a5a20f373fe8779"
+            "result": "3fb7576e4821be816a5a20f373fe8779",
+            "profile": "AAC Main"
         },
         {
             "name": "al960_sbr_e_48_1",
@@ -137,7 +153,8 @@
             "source_checksum": "391085d91c33a9763aab5639ec31a2ad",
             "input_file": "al960_sbr_e_48_1.mp4",
             "output_format": "fltp",
-            "result": "3948da9fb84070805d5fce2486b26540"
+            "result": "3948da9fb84070805d5fce2486b26540",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03sf_24",
@@ -145,7 +162,8 @@
             "source_checksum": "11af69a60e0960eb09d48c9e183d7b72",
             "input_file": "al03sf_24.mp4",
             "output_format": "fltp",
-            "result": "b1b73118761159fff81b5c7af18892c7"
+            "result": "b1b73118761159fff81b5c7af18892c7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as11_12",
@@ -153,7 +171,8 @@
             "source_checksum": "5a0216dce0d82663ebe4246fda4d0ce9",
             "input_file": "as11_12.mp4",
             "output_format": "fltp",
-            "result": "3ce237e2c0b6e10f47d7c50c8938148b"
+            "result": "3ce237e2c0b6e10f47d7c50c8938148b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08_64",
@@ -161,7 +180,8 @@
             "source_checksum": "473c8c3d8318eb0eb943328f50ce11f1",
             "input_file": "al08_64.mp4",
             "output_format": "fltp",
-            "result": "5d0a32000b5332c5b1d7fb698016c61b"
+            "result": "5d0a32000b5332c5b1d7fb698016c61b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_i_48_2",
@@ -169,7 +189,8 @@
             "source_checksum": "8b14d022c0fa21a461635df357483a20",
             "input_file": "al_sbr_i_48_2.mp4",
             "output_format": "fltp",
-            "result": "050fc9d7bb1da63426a356dd660f53f7"
+            "result": "050fc9d7bb1da63426a356dd660f53f7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as14_08",
@@ -177,7 +198,8 @@
             "source_checksum": "d5d8cd2a47398bfadf1d92a8743b0972",
             "input_file": "as14_08.mp4",
             "output_format": "fltp",
-            "result": "7115b7fdfd6e1078b9d52c112558d8a5"
+            "result": "7115b7fdfd6e1078b9d52c112558d8a5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am04_22",
@@ -185,7 +207,8 @@
             "source_checksum": "c67e3e45c1d39e5919a8a88ea7947bc9",
             "input_file": "am04_22.mp4",
             "output_format": "fltp",
-            "result": "3c613c9af057696d31579ec816f1dffa"
+            "result": "3c613c9af057696d31579ec816f1dffa",
+            "profile": "AAC Main"
         },
         {
             "name": "al05_11",
@@ -193,7 +216,8 @@
             "source_checksum": "0ac97958a2d7a800f2117fc8af05a6f4",
             "input_file": "al05_11.mp4",
             "output_format": "fltp",
-            "result": "915e57e4e3865a3ea6a0d4e89f81ba45"
+            "result": "915e57e4e3865a3ea6a0d4e89f81ba45",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as08_12",
@@ -201,7 +225,8 @@
             "source_checksum": "24b8fd58f1ea8fbc3d4a45c02625e156",
             "input_file": "as08_12.mp4",
             "output_format": "fltp",
-            "result": "3501043be855b4329c14b0245fe8d603"
+            "result": "3501043be855b4329c14b0245fe8d603",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al960_sbr_e_44_1",
@@ -209,7 +234,8 @@
             "source_checksum": "ea9693be866a5d3aacf7a49440790ab9",
             "input_file": "al960_sbr_e_44_1.mp4",
             "output_format": "fltp",
-            "result": "ee05787eb7fc2a3373b1bcf9139d886a"
+            "result": "ee05787eb7fc2a3373b1bcf9139d886a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as12_08",
@@ -217,7 +243,8 @@
             "source_checksum": "718c467d92b8175fb7ddd60f0ab78a54",
             "input_file": "as12_08.mp4",
             "output_format": "fltp",
-            "result": "ada25d771c467cdc3112323b11cb9251"
+            "result": "ada25d771c467cdc3112323b11cb9251",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al17_48",
@@ -225,7 +252,8 @@
             "source_checksum": "9c4a1121e14fb1284ebf6c1285d6248a",
             "input_file": "al17_48.mp4",
             "output_format": "fltp",
-            "result": "639ae11166bd1ce3bd23b4d5337008c8"
+            "result": "639ae11166bd1ce3bd23b4d5337008c8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_ps_01",
@@ -233,7 +261,8 @@
             "source_checksum": "e4463cec5ba8f4fe5359652cf1104042",
             "input_file": "al_sbr_ps_01.mp4",
             "output_format": "fltp",
-            "result": "4550561b5ebfc5a9a1b1db3fb3bf400a"
+            "result": "4550561b5ebfc5a9a1b1db3fb3bf400a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08_22",
@@ -241,7 +270,8 @@
             "source_checksum": "83c7b8d778982275eea5c565288f746b",
             "input_file": "al08_22.mp4",
             "output_format": "fltp",
-            "result": "dec77b61bcff3f2d211248abcb521963"
+            "result": "dec77b61bcff3f2d211248abcb521963",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00sf_16",
@@ -249,7 +279,8 @@
             "source_checksum": "b75f00fd53c0247c98cfd7a4ccb447ce",
             "input_file": "al00sf_16.mp4",
             "output_format": "fltp",
-            "result": "5c6c8350621b3ba4c744712746c66213"
+            "result": "5c6c8350621b3ba4c744712746c66213",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am02_88",
@@ -257,7 +288,8 @@
             "source_checksum": "08e182012990786f8ecac90ba19ef363",
             "input_file": "am02_88.mp4",
             "output_format": "fltp",
-            "result": "4fe01b15aaf82e7121652ffffb489d36"
+            "result": "4fe01b15aaf82e7121652ffffb489d36",
+            "profile": "AAC Main"
         },
         {
             "name": "al05sf_08",
@@ -265,7 +297,8 @@
             "source_checksum": "a471bf730fa5d94b58ff871704669d1f",
             "input_file": "al05sf_08.mp4",
             "output_format": "fltp",
-            "result": "0af6ed73f0e59937b0ffff6da27a9bc8"
+            "result": "0af6ed73f0e59937b0ffff6da27a9bc8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18sf_48",
@@ -273,7 +306,8 @@
             "source_checksum": "3d5bc6a94832f7e7ff2a99b68138af50",
             "input_file": "al18sf_48.mp4",
             "output_format": "fltp",
-            "result": "13b25122d84f8f04af614e23eb6550a1"
+            "result": "13b25122d84f8f04af614e23eb6550a1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_e_48_2",
@@ -281,7 +315,8 @@
             "source_checksum": "011abaed897ded65d76ea30a6f24ac71",
             "input_file": "al960_sbr_e_48_2.mp4",
             "output_format": "fltp",
-            "result": "87eb5968e4fdda8e261b0e44680f6260"
+            "result": "87eb5968e4fdda8e261b0e44680f6260",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00sf_12",
@@ -289,7 +324,8 @@
             "source_checksum": "2d0336993c21b4904ecd818653770530",
             "input_file": "al00sf_12.mp4",
             "output_format": "fltp",
-            "result": "1003860d480d488f2093171008643ca2"
+            "result": "1003860d480d488f2093171008643ca2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am07_11",
@@ -297,7 +333,8 @@
             "source_checksum": "daa1f905cd87d897edc102cc3aa0d8c2",
             "input_file": "am07_11.mp4",
             "output_format": "fltp",
-            "result": "b37abfdcf7c03ef388b7ae195b40e34c"
+            "result": "b37abfdcf7c03ef388b7ae195b40e34c",
+            "profile": "AAC Main"
         },
         {
             "name": "as07_11",
@@ -305,7 +342,8 @@
             "source_checksum": "9f6741379bbf1a6ba8542756373134b7",
             "input_file": "as07_11.mp4",
             "output_format": "fltp",
-            "result": "e88a0c08a34fdcce2f9f917b871240e0"
+            "result": "e88a0c08a34fdcce2f9f917b871240e0",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al00sf_32",
@@ -313,7 +351,8 @@
             "source_checksum": "c9ae61b1285bd0ff8bdfcd14ccf7a505",
             "input_file": "al00sf_32.mp4",
             "output_format": "fltp",
-            "result": "9379f05a63dbbf78e458e88f8b36a4bc"
+            "result": "9379f05a63dbbf78e458e88f8b36a4bc",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_sr_96_2_fsaac48",
@@ -321,7 +360,8 @@
             "source_checksum": "ad0134224eb11bcc595728df4fb995c0",
             "input_file": "al_sbr_sr_96_2_fsaac48.mp4",
             "output_format": "fltp",
-            "result": "5b54d731273ba8aa55fd9d4948179165"
+            "result": "5b54d731273ba8aa55fd9d4948179165",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_96",
@@ -329,7 +369,8 @@
             "source_checksum": "b732ecc2fb827e72afc864c68097c9e3",
             "input_file": "am00_96.mp4",
             "output_format": "fltp",
-            "result": "60095c11878cfbedd806518168312f3d"
+            "result": "60095c11878cfbedd806518168312f3d",
+            "profile": "AAC Main"
         },
         {
             "name": "as15_12",
@@ -337,7 +378,8 @@
             "source_checksum": "0e7ca1f469207e13046a1eaba1eb11ca",
             "input_file": "as15_12.mp4",
             "output_format": "fltp",
-            "result": "7b6e6b62e77f601ed9fd73435a318738"
+            "result": "7b6e6b62e77f601ed9fd73435a318738",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as01_44",
@@ -345,7 +387,8 @@
             "source_checksum": "90da8c0a62dce383be5ce87c2fde0f10",
             "input_file": "as01_44.mp4",
             "output_format": "fltp",
-            "result": "341a1c0cbe9cfb820c5b8ac6ffba3504"
+            "result": "341a1c0cbe9cfb820c5b8ac6ffba3504",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_gh_48_2",
@@ -353,7 +396,8 @@
             "source_checksum": "4b8464f28c43206ac6321ec5d80545ed",
             "input_file": "al_sbr_gh_48_2.mp4",
             "output_format": "fltp",
-            "result": "bfb144c98dd0f7627aa35dd72da7a698"
+            "result": "bfb144c98dd0f7627aa35dd72da7a698",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am01_88",
@@ -361,7 +405,8 @@
             "source_checksum": "3c8b3e9956f9bfe7446db37c0c70f775",
             "input_file": "am01_88.mp4",
             "output_format": "fltp",
-            "result": "aa3b7e61c9327bd386bbddf54519a571"
+            "result": "aa3b7e61c9327bd386bbddf54519a571",
+            "profile": "AAC Main"
         },
         {
             "name": "al07sf_16",
@@ -369,7 +414,8 @@
             "source_checksum": "ebf2b8c870e7f2cca74d962fde8d3b81",
             "input_file": "al07sf_16.mp4",
             "output_format": "fltp",
-            "result": "5bec3c86d8e071439aec19ab9a237488"
+            "result": "5bec3c86d8e071439aec19ab9a237488",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as00_22",
@@ -377,7 +423,8 @@
             "source_checksum": "b958c7ba1d8dcc38cb387adc171843d4",
             "input_file": "as00_22.mp4",
             "output_format": "fltp",
-            "result": "a4a12aa95046d129e976ce367ca751a7"
+            "result": "a4a12aa95046d129e976ce367ca751a7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_ps_02",
@@ -385,7 +432,8 @@
             "source_checksum": "77cec67e9a554b4803bc4edd7e47fc48",
             "input_file": "al_sbr_ps_02.mp4",
             "output_format": "fltp",
-            "result": "ea9769c002c80ca8fce59e93d37ab79f"
+            "result": "ea9769c002c80ca8fce59e93d37ab79f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al19sf_32",
@@ -393,7 +441,8 @@
             "source_checksum": "4076980291be70769f3bbd2327973b54",
             "input_file": "al19sf_32.mp4",
             "output_format": "fltp",
-            "result": "5557f7070528f4d5aeb1a69655d934e9"
+            "result": "5557f7070528f4d5aeb1a69655d934e9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_s_32_2",
@@ -401,7 +450,8 @@
             "source_checksum": "fe41d27d07aa77abd4f30e168a74e03e",
             "input_file": "al960_sbr_s_32_2.mp4",
             "output_format": "fltp",
-            "result": "f72dde76b64e9172d9a989de5cc19a0c"
+            "result": "f72dde76b64e9172d9a989de5cc19a0c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_24",
@@ -409,7 +459,8 @@
             "source_checksum": "bc9b5c8ae549d28294d1575d359278fe",
             "input_file": "am00_24.mp4",
             "output_format": "fltp",
-            "result": "d91800bc70282ef0bfca4c96812e03fe"
+            "result": "d91800bc70282ef0bfca4c96812e03fe",
+            "profile": "AAC Main"
         },
         {
             "name": "al08sf_16",
@@ -417,7 +468,8 @@
             "source_checksum": "299e88abf6cefd830d70fa750d777b11",
             "input_file": "al08sf_16.mp4",
             "output_format": "fltp",
-            "result": "bb5f7e58db2f7940c656fa704596ed5e"
+            "result": "bb5f7e58db2f7940c656fa704596ed5e",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_gh_48_1",
@@ -425,7 +477,8 @@
             "source_checksum": "7976f5b42ef81fb987760a46a38dde4d",
             "input_file": "al_sbr_gh_48_1.mp4",
             "output_format": "fltp",
-            "result": "f351b343a6a033ecfa3ab319818d53ee"
+            "result": "f351b343a6a033ecfa3ab319818d53ee",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01sf_12",
@@ -433,7 +486,8 @@
             "source_checksum": "c8e40e16c0e07645e0d464f7008ffbdc",
             "input_file": "al01sf_12.mp4",
             "output_format": "fltp",
-            "result": "1bf3c602a298c1b7b2f65080c83d4b49"
+            "result": "1bf3c602a298c1b7b2f65080c83d4b49",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_sig_24_2_fsaac24_sig1",
@@ -441,7 +495,8 @@
             "source_checksum": "f3dc920c33288d0fec32812a9d72f986",
             "input_file": "al_sbr_sig_24_2_fsaac24_sig1.mp4",
             "output_format": "fltp",
-            "result": "a14a5cd3ba671a570afe3c18921031e0"
+            "result": "a14a5cd3ba671a570afe3c18921031e0",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_ps_01_new",
@@ -449,7 +504,8 @@
             "source_checksum": "37181ac31bbb8a9f1af7d19416aa205d",
             "input_file": "al_sbr_ps_01_new.mp4",
             "output_format": "fltp",
-            "result": "4550561b5ebfc5a9a1b1db3fb3bf400a"
+            "result": "4550561b5ebfc5a9a1b1db3fb3bf400a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am01_96",
@@ -457,7 +513,8 @@
             "source_checksum": "7f63405058532c0fbc2d8e77e0260fc7",
             "input_file": "am01_96.mp4",
             "output_format": "fltp",
-            "result": "12ea7bf04bce95c5c3ae286b17f6907e"
+            "result": "12ea7bf04bce95c5c3ae286b17f6907e",
+            "profile": "AAC Main"
         },
         {
             "name": "al18_96",
@@ -465,7 +522,8 @@
             "source_checksum": "0fd2a1046276a648535025a5a2cfb118",
             "input_file": "al18_96.mp4",
             "output_format": "fltp",
-            "result": "02b0f333d4caa37379a8ab513dbc4dbf"
+            "result": "02b0f333d4caa37379a8ab513dbc4dbf",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07_08",
@@ -473,7 +531,8 @@
             "source_checksum": "ccb765da1d3a895d1c08b865b6a9ea61",
             "input_file": "al07_08.mp4",
             "output_format": "fltp",
-            "result": "2d7e3fd7be8d36787f4ab6c9606f9c3b"
+            "result": "2d7e3fd7be8d36787f4ab6c9606f9c3b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_ps_06",
@@ -481,7 +540,8 @@
             "source_checksum": "726dd94f7c29da1dc11314c837c37400",
             "input_file": "al_sbr_ps_06.mp4",
             "output_format": "fltp",
-            "result": "f181b26d3fa66a999216967f4d86861c"
+            "result": "f181b26d3fa66a999216967f4d86861c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am06_32",
@@ -489,7 +549,8 @@
             "source_checksum": "6e378ef43c14c3953903e0f9f3880bc8",
             "input_file": "am06_32.mp4",
             "output_format": "fltp",
-            "result": "30421207207921fc241e27f2a83dae6d"
+            "result": "30421207207921fc241e27f2a83dae6d",
+            "profile": "AAC Main"
         },
         {
             "name": "al18_64",
@@ -497,7 +558,8 @@
             "source_checksum": "ec57a5ac44c2d51c5f8f54e4dd719fb9",
             "input_file": "al18_64.mp4",
             "output_format": "fltp",
-            "result": "756d27e1b1bead05839758072cea9690"
+            "result": "756d27e1b1bead05839758072cea9690",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04sf_12",
@@ -505,7 +567,8 @@
             "source_checksum": "4355c9899f455001a6cfa3c37c6203a7",
             "input_file": "al04sf_12.mp4",
             "output_format": "fltp",
-            "result": "4320324e32f3eb59a745643911e04e99"
+            "result": "4320324e32f3eb59a745643911e04e99",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am05_48",
@@ -513,7 +576,8 @@
             "source_checksum": "12d05acb689987524a0bdcaad40b90af",
             "input_file": "am05_48.mp4",
             "output_format": "fltp",
-            "result": "b541fde93e8560268968c31f97e99670"
+            "result": "b541fde93e8560268968c31f97e99670",
+            "profile": "AAC Main"
         },
         {
             "name": "al06_12",
@@ -521,7 +585,8 @@
             "source_checksum": "466d81b8c01c4e6d0242298e946e0cbd",
             "input_file": "al06_12.mp4",
             "output_format": "fltp",
-            "result": "5fe712f1dde528f6fcb243abd257774e"
+            "result": "5fe712f1dde528f6fcb243abd257774e",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01sf_48",
@@ -529,7 +594,8 @@
             "source_checksum": "5609bd8c37c9c6eaaefad81b3b9fb74f",
             "input_file": "al01sf_48.mp4",
             "output_format": "fltp",
-            "result": "300f8cc27d8b5abfe5720b69f398bad2"
+            "result": "300f8cc27d8b5abfe5720b69f398bad2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as00_88",
@@ -537,7 +603,8 @@
             "source_checksum": "db39187bafa701fc511de788910db76c",
             "input_file": "as00_88.mp4",
             "output_format": "fltp",
-            "result": "9fad6dc2afb3e4dfe2c48736dc612302"
+            "result": "9fad6dc2afb3e4dfe2c48736dc612302",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al02sf_44",
@@ -545,7 +612,8 @@
             "source_checksum": "0b911fd176602896f567b5e7af08121a",
             "input_file": "al02sf_44.mp4",
             "output_format": "fltp",
-            "result": "976f11accce8764adff7f6fe13c1d204"
+            "result": "976f11accce8764adff7f6fe13c1d204",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00sf_24",
@@ -553,7 +621,8 @@
             "source_checksum": "5c91b7ce3b799a7a13f7559fcfd51987",
             "input_file": "al00sf_24.mp4",
             "output_format": "fltp",
-            "result": "3440a3a7649138c087f6b6136314d19d"
+            "result": "3440a3a7649138c087f6b6136314d19d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_sr_16_2_fsaac08",
@@ -561,7 +630,8 @@
             "source_checksum": "2eaa3228c98825d869acacf218cf4b8c",
             "input_file": "al_sbr_sr_16_2_fsaac08.mp4",
             "output_format": "fltp",
-            "result": "7beb050c34bd5312ba76cb951dafe717"
+            "result": "7beb050c34bd5312ba76cb951dafe717",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00_96",
@@ -569,7 +639,8 @@
             "source_checksum": "d07af8a92b07ea72a47ca09fc642b730",
             "input_file": "al00_96.mp4",
             "output_format": "fltp",
-            "result": "7dc7b3c9f121b6afe05020dcd7316f45"
+            "result": "7dc7b3c9f121b6afe05020dcd7316f45",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as04_11",
@@ -577,7 +648,8 @@
             "source_checksum": "7aad49efbfc1ab6385a9e7863771a151",
             "input_file": "as04_11.mp4",
             "output_format": "fltp",
-            "result": "9b1e1cb3d539ac3c605175a667cc426a"
+            "result": "9b1e1cb3d539ac3c605175a667cc426a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as14_24",
@@ -585,7 +657,8 @@
             "source_checksum": "35f0954709379de980c7b627ced23f1b",
             "input_file": "as14_24.mp4",
             "output_format": "fltp",
-            "result": "0966159214c51e6107b936474ad8690b"
+            "result": "0966159214c51e6107b936474ad8690b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as16_32",
@@ -593,7 +666,8 @@
             "source_checksum": "4a98d802ec8bf5e8bb8ace0ddc0c4108",
             "input_file": "as16_32.mp4",
             "output_format": "fltp",
-            "result": "726a358b4e88b5ccd816a3ae976473d0"
+            "result": "726a358b4e88b5ccd816a3ae976473d0",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al17sf_08",
@@ -601,7 +675,8 @@
             "source_checksum": "5d1813aa237c103faa16fea33402f9f2",
             "input_file": "al17sf_08.mp4",
             "output_format": "fltp",
-            "result": "9ce0c79e5a3b97ba1cd7f9051b9cb813"
+            "result": "9ce0c79e5a3b97ba1cd7f9051b9cb813",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_s_44_2",
@@ -609,7 +684,8 @@
             "source_checksum": "d218fe798aa43d3be523fa11e97ffc7e",
             "input_file": "al960_sbr_s_44_2.mp4",
             "output_format": "fltp",
-            "result": "d59428f4b83f3d37883e119934a9b0c2"
+            "result": "d59428f4b83f3d37883e119934a9b0c2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_11",
@@ -617,7 +693,8 @@
             "source_checksum": "f6ac584c5cd93dbb4f8907b139b9c01c",
             "input_file": "am00_11.mp4",
             "output_format": "fltp",
-            "result": "bbb2a347eb79692e8162d364b3e2e851"
+            "result": "bbb2a347eb79692e8162d364b3e2e851",
+            "profile": "AAC Main"
         },
         {
             "name": "as12_44",
@@ -625,7 +702,8 @@
             "source_checksum": "c570b62fd54751d1353c2d28e9632615",
             "input_file": "as12_44.mp4",
             "output_format": "fltp",
-            "result": "8dfea67806acf9b1fdb52efe7134dd04"
+            "result": "8dfea67806acf9b1fdb52efe7134dd04",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al19_08",
@@ -633,7 +711,8 @@
             "source_checksum": "2cf0e90c3c554ca7b0071ebf989de289",
             "input_file": "al19_08.mp4",
             "output_format": "fltp",
-            "result": "64d301b16399d5ad296ec3dbd216ecde"
+            "result": "64d301b16399d5ad296ec3dbd216ecde",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as12_16",
@@ -641,7 +720,8 @@
             "source_checksum": "43cb47b7d553fa2b1657fc206c32ab5b",
             "input_file": "as12_16.mp4",
             "output_format": "fltp",
-            "result": "a987f1846c38136e503b386b0eb1bec8"
+            "result": "a987f1846c38136e503b386b0eb1bec8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08sf_08",
@@ -649,7 +729,8 @@
             "source_checksum": "2d4379bf236597884cc38721f663f95e",
             "input_file": "al08sf_08.mp4",
             "output_format": "fltp",
-            "result": "5e4137362e9be4a4f875f45ff642b08d"
+            "result": "5e4137362e9be4a4f875f45ff642b08d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08sf_64",
@@ -657,7 +738,8 @@
             "source_checksum": "558e8076307ddfe9ffe3f8928067affe",
             "input_file": "al08sf_64.mp4",
             "output_format": "fltp",
-            "result": "5d0a32000b5332c5b1d7fb698016c61b"
+            "result": "5d0a32000b5332c5b1d7fb698016c61b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08sf_48",
@@ -665,7 +747,8 @@
             "source_checksum": "fa9fe405f0ec0000f6ab6102dccda480",
             "input_file": "al08sf_48.mp4",
             "output_format": "fltp",
-            "result": "8f516b5865c47cca496bc37853843af9"
+            "result": "8f516b5865c47cca496bc37853843af9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am04_64",
@@ -673,7 +756,8 @@
             "source_checksum": "589335b559b1ec516f58bbe7b4211689",
             "input_file": "am04_64.mp4",
             "output_format": "fltp",
-            "result": "9526a9dca60fba036bb04ad28e8deacc"
+            "result": "9526a9dca60fba036bb04ad28e8deacc",
+            "profile": "AAC Main"
         },
         {
             "name": "al17_32",
@@ -681,7 +765,8 @@
             "source_checksum": "501df2b51f864b59a86772d0f4fd7bfe",
             "input_file": "al17_32.mp4",
             "output_format": "fltp",
-            "result": "fb0aaa3f83522df7406f67744aa5ac0f"
+            "result": "fb0aaa3f83522df7406f67744aa5ac0f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as10_11",
@@ -689,7 +774,8 @@
             "source_checksum": "48d565af62611dabad34157b83addd9d",
             "input_file": "as10_11.mp4",
             "output_format": "fltp",
-            "result": "48faf4c4165ff42a3ed86f7102e266f6"
+            "result": "48faf4c4165ff42a3ed86f7102e266f6",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as08_32",
@@ -697,7 +783,8 @@
             "source_checksum": "52516623e699d22ba27bf35f117a2955",
             "input_file": "as08_32.mp4",
             "output_format": "fltp",
-            "result": "11a3cfd97a1fdb82c0a2c46df65514b6"
+            "result": "11a3cfd97a1fdb82c0a2c46df65514b6",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am05_08",
@@ -705,7 +792,8 @@
             "source_checksum": "3d7664d878d25053898ed023a1e1cd44",
             "input_file": "am05_08.mp4",
             "output_format": "fltp",
-            "result": "d628c51559ed343102fe562669440db2"
+            "result": "d628c51559ed343102fe562669440db2",
+            "profile": "AAC Main"
         },
         {
             "name": "al08sf_11",
@@ -713,7 +801,8 @@
             "source_checksum": "98ab98f9fb6c52b2b26eb0a06df15703",
             "input_file": "al08sf_11.mp4",
             "output_format": "fltp",
-            "result": "d8c40ec2fdc54badf9adfff75031b79a"
+            "result": "d8c40ec2fdc54badf9adfff75031b79a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00_44",
@@ -721,7 +810,8 @@
             "source_checksum": "37d8c9845655a695ebfd33ce13881c63",
             "input_file": "al00_44.mp4",
             "output_format": "fltp",
-            "result": "31f0d7315b2d03acb22d7920f5814855"
+            "result": "31f0d7315b2d03acb22d7920f5814855",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00_22",
@@ -729,7 +819,8 @@
             "source_checksum": "8828741c4a624d98b22a097a030bfe36",
             "input_file": "al00_22.mp4",
             "output_format": "fltp",
-            "result": "fc7d20249eb3f883c9244e88986eebb9"
+            "result": "fc7d20249eb3f883c9244e88986eebb9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_i_44_2",
@@ -737,7 +828,8 @@
             "source_checksum": "79ee30f7730c566fd6ad031c8a527157",
             "input_file": "al960_sbr_i_44_2.mp4",
             "output_format": "fltp",
-            "result": "fb2137ded0d1cf852aa27708a4f89ad2"
+            "result": "fb2137ded0d1cf852aa27708a4f89ad2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17sf_88",
@@ -745,7 +837,8 @@
             "source_checksum": "913f808968f190b0e1d682fac6ca8373",
             "input_file": "al17sf_88.mp4",
             "output_format": "fltp",
-            "result": "ad70e0b02635cfcb30c928dc70b4ef05"
+            "result": "ad70e0b02635cfcb30c928dc70b4ef05",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06sf_08",
@@ -753,7 +846,8 @@
             "source_checksum": "80a185e97370b9341742cd39d6e4a5a3",
             "input_file": "al06sf_08.mp4",
             "output_format": "fltp",
-            "result": "45e04543ce989cb061362b84855d6107"
+            "result": "45e04543ce989cb061362b84855d6107",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17sf_64",
@@ -761,7 +855,8 @@
             "source_checksum": "d53a25e42afa25edd6d23f2df8df07ab",
             "input_file": "al17sf_64.mp4",
             "output_format": "fltp",
-            "result": "9c3bc834d40d27a441ab80ae72eda8c4"
+            "result": "9c3bc834d40d27a441ab80ae72eda8c4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_sr_44_2_fsaac44",
@@ -769,7 +864,8 @@
             "source_checksum": "d15294569be73d50019d11b8ca993483",
             "input_file": "al_sbr_sr_44_2_fsaac44.mp4",
             "output_format": "fltp",
-            "result": "d24799df18f44ecb65d70ecd04519369"
+            "result": "d24799df18f44ecb65d70ecd04519369",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am02_32",
@@ -777,7 +873,8 @@
             "source_checksum": "a416a16587b677eb9cc0028ef8c8f065",
             "input_file": "am02_32.mp4",
             "output_format": "fltp",
-            "result": "a88295fef84eb1c1d62083daec20c9b2"
+            "result": "a88295fef84eb1c1d62083daec20c9b2",
+            "profile": "AAC Main"
         },
         {
             "name": "as03_16",
@@ -785,7 +882,8 @@
             "source_checksum": "8e85ffafc74b18cdc52bce6479fe8956",
             "input_file": "as03_16.mp4",
             "output_format": "fltp",
-            "result": "0298779243f1f989e4aea5aa255f57ea"
+            "result": "0298779243f1f989e4aea5aa255f57ea",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as00_11",
@@ -793,7 +891,8 @@
             "source_checksum": "df362dbde146c0ab34e502ac493295a0",
             "input_file": "as00_11.mp4",
             "output_format": "fltp",
-            "result": "3629580db303963cdea8dc8d3ecc28e1"
+            "result": "3629580db303963cdea8dc8d3ecc28e1",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al02sf_64",
@@ -801,7 +900,8 @@
             "source_checksum": "7d867af8488df6c06bf66b6cdbedfd23",
             "input_file": "al02sf_64.mp4",
             "output_format": "fltp",
-            "result": "5a1b7aaee8c3e44254fb010268cdcabe"
+            "result": "5a1b7aaee8c3e44254fb010268cdcabe",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_gh_32_1",
@@ -809,7 +909,8 @@
             "source_checksum": "5a3db651c2e9ecf7330c00d6fd128875",
             "input_file": "al_sbr_gh_32_1.mp4",
             "output_format": "fltp",
-            "result": "b88528fca9d6158805c92529dc09c8f5"
+            "result": "b88528fca9d6158805c92529dc09c8f5",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as08_22",
@@ -817,7 +918,8 @@
             "source_checksum": "524caa40d96bc2a271100c89126e3031",
             "input_file": "as08_22.mp4",
             "output_format": "fltp",
-            "result": "db921bd902654720933f799741bb35b2"
+            "result": "db921bd902654720933f799741bb35b2",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al17sf_24",
@@ -825,7 +927,8 @@
             "source_checksum": "54f1fb1859aaa869502ab3da41009529",
             "input_file": "al17sf_24.mp4",
             "output_format": "fltp",
-            "result": "81e7f63e34e349fd6138172552c55936"
+            "result": "81e7f63e34e349fd6138172552c55936",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14sf_24",
@@ -833,7 +936,8 @@
             "source_checksum": "87d0b157410bc5b9fa0e02d114b56a97",
             "input_file": "al14sf_24.mp4",
             "output_format": "fltp",
-            "result": "744f7fd7aef4005110b26134c89938f6"
+            "result": "744f7fd7aef4005110b26134c89938f6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as17_88",
@@ -841,7 +945,8 @@
             "source_checksum": "890a6d08036caaed1b041ceda676f54f",
             "input_file": "as17_88.mp4",
             "output_format": "fltp",
-            "result": "3bf98e171d2dec7242e96170d718c2f7"
+            "result": "3bf98e171d2dec7242e96170d718c2f7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am02_96",
@@ -849,7 +954,8 @@
             "source_checksum": "c6d0fb7246519fe1d30994eb8fe6bdc9",
             "input_file": "am02_96.mp4",
             "output_format": "fltp",
-            "result": "000afc3c95e38a98e52cfd70568967ab"
+            "result": "000afc3c95e38a98e52cfd70568967ab",
+            "profile": "AAC Main"
         },
         {
             "name": "as05_44",
@@ -857,7 +963,8 @@
             "source_checksum": "7e82abc7219d4929e6441fc0466f4d30",
             "input_file": "as05_44.mp4",
             "output_format": "fltp",
-            "result": "6d52bc409273a725d7d0688d2be08421"
+            "result": "6d52bc409273a725d7d0688d2be08421",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as11_64",
@@ -865,7 +972,8 @@
             "source_checksum": "62fc978020e48c0a91a4feb80f822107",
             "input_file": "as11_64.mp4",
             "output_format": "fltp",
-            "result": "8fa7c4d7b94faff9117bd4d12c349e1b"
+            "result": "8fa7c4d7b94faff9117bd4d12c349e1b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06_22",
@@ -873,7 +981,8 @@
             "source_checksum": "e1738c83d846cf6acbc5438675e08841",
             "input_file": "al06_22.mp4",
             "output_format": "fltp",
-            "result": "f50bd18a7adc9a417550c3499a277d16"
+            "result": "f50bd18a7adc9a417550c3499a277d16",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as05_11",
@@ -881,7 +990,8 @@
             "source_checksum": "694187cef3068928087ba6fca91df129",
             "input_file": "as05_11.mp4",
             "output_format": "fltp",
-            "result": "4304c8ed55dac9a12a96e88528ce97b7"
+            "result": "4304c8ed55dac9a12a96e88528ce97b7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al04sf_16",
@@ -889,7 +999,8 @@
             "source_checksum": "3578372f1d94f8baf7872fc2e31a942b",
             "input_file": "al04sf_16.mp4",
             "output_format": "fltp",
-            "result": "e9a74efa429e0d6ca38b2c59bdf61652"
+            "result": "e9a74efa429e0d6ca38b2c59bdf61652",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am01_16",
@@ -897,7 +1008,8 @@
             "source_checksum": "62f2b0ee9e838030920f433b38e1f5a4",
             "input_file": "am01_16.mp4",
             "output_format": "fltp",
-            "result": "f49b1f4d1aa9471cf83b838eaac185a7"
+            "result": "f49b1f4d1aa9471cf83b838eaac185a7",
+            "profile": "AAC Main"
         },
         {
             "name": "al_sbr_sr_22_2_fsaac11",
@@ -905,7 +1017,8 @@
             "source_checksum": "8d0180558ac8297d7d869f4cf3049157",
             "input_file": "al_sbr_sr_22_2_fsaac11.mp4",
             "output_format": "fltp",
-            "result": "882fce818a3e0da1a93c5344383fbcdc"
+            "result": "882fce818a3e0da1a93c5344383fbcdc",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as02_22",
@@ -913,7 +1026,8 @@
             "source_checksum": "5a43f26bcb977c545443d8a6ccdbb82d",
             "input_file": "as02_22.mp4",
             "output_format": "fltp",
-            "result": "01451e220069c903d77ca277444480c5"
+            "result": "01451e220069c903d77ca277444480c5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al00sf_96",
@@ -921,7 +1035,8 @@
             "source_checksum": "83001d60e7f08d92107157021811d7a2",
             "input_file": "al00sf_96.mp4",
             "output_format": "fltp",
-            "result": "7dc7b3c9f121b6afe05020dcd7316f45"
+            "result": "7dc7b3c9f121b6afe05020dcd7316f45",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01sf_11",
@@ -929,7 +1044,8 @@
             "source_checksum": "a63bfe0ffefb576be2832688bbb0afa1",
             "input_file": "al01sf_11.mp4",
             "output_format": "fltp",
-            "result": "68ebaf2c433c13381e815db62a7c3385"
+            "result": "68ebaf2c433c13381e815db62a7c3385",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14sf_88",
@@ -937,7 +1053,8 @@
             "source_checksum": "9218e51f2272d72aadee80788fb074ca",
             "input_file": "al14sf_88.mp4",
             "output_format": "fltp",
-            "result": "93099bfdaf22a5847e010eef08f10537"
+            "result": "93099bfdaf22a5847e010eef08f10537",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as07_96",
@@ -945,7 +1062,8 @@
             "source_checksum": "c8ded0ce5fbc3de85465b57d3c9b2eb2",
             "input_file": "as07_96.mp4",
             "output_format": "fltp",
-            "result": "a0e96752daf6523ef7b97ee65781e4a6"
+            "result": "a0e96752daf6523ef7b97ee65781e4a6",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al960_sbr_ps_04",
@@ -953,7 +1071,8 @@
             "source_checksum": "dd14f7358c6d19e5c34a9b5ca56a9e42",
             "input_file": "al960_sbr_ps_04.mp4",
             "output_format": "fltp",
-            "result": "a346168a7ddbd92f8a578af0ae25c329"
+            "result": "a346168a7ddbd92f8a578af0ae25c329",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as03_44",
@@ -961,7 +1080,8 @@
             "source_checksum": "98372c12b3a36acda6f59bbb9b72e82b",
             "input_file": "as03_44.mp4",
             "output_format": "fltp",
-            "result": "b9d7b1fcf7a918ddf1cd51ef97314043"
+            "result": "b9d7b1fcf7a918ddf1cd51ef97314043",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am04_11",
@@ -969,7 +1089,8 @@
             "source_checksum": "0292a8763a76ca99e7dc1c3c010a836e",
             "input_file": "am04_11.mp4",
             "output_format": "fltp",
-            "result": "71ef16be1fc6d6ff5bb2907959ba6f56"
+            "result": "71ef16be1fc6d6ff5bb2907959ba6f56",
+            "profile": "AAC Main"
         },
         {
             "name": "ap03_48",
@@ -977,7 +1098,8 @@
             "source_checksum": "2f529ffc47bee9f79b28723f7434ad3f",
             "input_file": "ap03_48.mp4",
             "output_format": "fltp",
-            "result": "52d92adafcc39d43c81daf44c422d9cf"
+            "result": "52d92adafcc39d43c81daf44c422d9cf",
+            "profile": "AAC Long Term Prediction"
         },
         {
             "name": "as02_24",
@@ -985,7 +1107,8 @@
             "source_checksum": "0f6315a24c1184187b0cfad0aa431406",
             "input_file": "as02_24.mp4",
             "output_format": "fltp",
-            "result": "90ebe7c4b7924fd5bd0c8a26d904ac79"
+            "result": "90ebe7c4b7924fd5bd0c8a26d904ac79",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as14_88",
@@ -993,7 +1116,8 @@
             "source_checksum": "c8973d5357acff7fab3e641e41344f2e",
             "input_file": "as14_88.mp4",
             "output_format": "fltp",
-            "result": "9262d0f32739414588944b22fb614ae3"
+            "result": "9262d0f32739414588944b22fb614ae3",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al04sf_32",
@@ -1001,7 +1125,8 @@
             "source_checksum": "3ffe860f3421bcf9d3ebbc32f87f7628",
             "input_file": "al04sf_32.mp4",
             "output_format": "fltp",
-            "result": "ba7398cba6f48891b0d23e6acd8fce18"
+            "result": "ba7398cba6f48891b0d23e6acd8fce18",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am06_44",
@@ -1009,7 +1134,8 @@
             "source_checksum": "7de5db579169851d20a9fdb5e3c68eee",
             "input_file": "am06_44.mp4",
             "output_format": "fltp",
-            "result": "5a0665bb918d8d8781e27f32ef647d70"
+            "result": "5a0665bb918d8d8781e27f32ef647d70",
+            "profile": "AAC Main"
         },
         {
             "name": "am07_48",
@@ -1017,7 +1143,8 @@
             "source_checksum": "4c7bc5928b32516bf1bb97e0289b3ac4",
             "input_file": "am07_48.mp4",
             "output_format": "fltp",
-            "result": "2f30ea331a513cd7518ffee298d7ff30"
+            "result": "2f30ea331a513cd7518ffee298d7ff30",
+            "profile": "AAC Main"
         },
         {
             "name": "as04_44",
@@ -1025,7 +1152,8 @@
             "source_checksum": "f2d5c5f9932c454f459b044f5e65bbf6",
             "input_file": "as04_44.mp4",
             "output_format": "fltp",
-            "result": "ae6dbe2fb03f50ef1498e9b483c988c5"
+            "result": "ae6dbe2fb03f50ef1498e9b483c988c5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08_12",
@@ -1033,7 +1161,8 @@
             "source_checksum": "b46a4651cb2bd6aadaa9450e5f0634fa",
             "input_file": "al08_12.mp4",
             "output_format": "fltp",
-            "result": "a273a49706ea5efed833bcc4df2fd467"
+            "result": "a273a49706ea5efed833bcc4df2fd467",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_i_48_1",
@@ -1041,7 +1170,8 @@
             "source_checksum": "2407cf004623aa9053b8d6b0b66ef165",
             "input_file": "al960_sbr_i_48_1.mp4",
             "output_format": "fltp",
-            "result": "d376da587968f7bd0e0e052ec850494d"
+            "result": "d376da587968f7bd0e0e052ec850494d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as04_22",
@@ -1049,7 +1179,8 @@
             "source_checksum": "3c2cfa3a207e2a916815693ca88342bb",
             "input_file": "as04_22.mp4",
             "output_format": "fltp",
-            "result": "8df4dd9c6101bc3fc187683955fbc2b6"
+            "result": "8df4dd9c6101bc3fc187683955fbc2b6",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am05_44",
@@ -1057,7 +1188,8 @@
             "source_checksum": "0b114ddc101e17e17c1dc548f0313830",
             "input_file": "am05_44.mp4",
             "output_format": "fltp",
-            "result": "514459cbbdeca750a11a7c750a65e113"
+            "result": "514459cbbdeca750a11a7c750a65e113",
+            "profile": "AAC Main"
         },
         {
             "name": "al_sbr_e_32_2",
@@ -1065,7 +1197,8 @@
             "source_checksum": "9df84696290af9f66517c15a71933bc0",
             "input_file": "al_sbr_e_32_2.mp4",
             "output_format": "fltp",
-            "result": "4817b96acec45229cedbcd62cd82b134"
+            "result": "4817b96acec45229cedbcd62cd82b134",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_64",
@@ -1073,7 +1206,8 @@
             "source_checksum": "47a9d91a5b317743feb6075f193face9",
             "input_file": "al04_64.mp4",
             "output_format": "fltp",
-            "result": "334e1e916f28c240965ed8e8f3ce6b38"
+            "result": "334e1e916f28c240965ed8e8f3ce6b38",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02_44",
@@ -1081,7 +1215,8 @@
             "source_checksum": "2255f11ea10983761d629c9f56fb80e5",
             "input_file": "al02_44.mp4",
             "output_format": "fltp",
-            "result": "976f11accce8764adff7f6fe13c1d204"
+            "result": "976f11accce8764adff7f6fe13c1d204",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05_48",
@@ -1089,7 +1224,8 @@
             "source_checksum": "58978ab191e3bfe9ea610c5a31680b79",
             "input_file": "al05_48.mp4",
             "output_format": "fltp",
-            "result": "d72ef57b7bad160905b7d1650360c474"
+            "result": "d72ef57b7bad160905b7d1650360c474",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07sf_11",
@@ -1097,7 +1233,8 @@
             "source_checksum": "6e02eae5a629e9fe451a39bc6365a620",
             "input_file": "al07sf_11.mp4",
             "output_format": "fltp",
-            "result": "f901e5fd1267ecf66a6803278518d006"
+            "result": "f901e5fd1267ecf66a6803278518d006",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_sr_32_2_fsaac32",
@@ -1105,7 +1242,8 @@
             "source_checksum": "a334dda7d4e5bc7c22c0e89c445ebb08",
             "input_file": "al_sbr_sr_32_2_fsaac32.mp4",
             "output_format": "fltp",
-            "result": "43dbe8c371a7946673ece994ea8f6293"
+            "result": "43dbe8c371a7946673ece994ea8f6293",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03_64",
@@ -1113,7 +1251,8 @@
             "source_checksum": "29511894eeff964d41285708e3c1b303",
             "input_file": "al03_64.mp4",
             "output_format": "fltp",
-            "result": "352d2c45ae42514dde7d018bbcdd538c"
+            "result": "352d2c45ae42514dde7d018bbcdd538c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as03_12",
@@ -1121,7 +1260,8 @@
             "source_checksum": "c0fe5e48e5fb3e99a65c8fbfe1de6a87",
             "input_file": "as03_12.mp4",
             "output_format": "fltp",
-            "result": "abe28e655b5db49b04de9ea99b431e4e"
+            "result": "abe28e655b5db49b04de9ea99b431e4e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al18sf_12",
@@ -1129,7 +1269,8 @@
             "source_checksum": "5d54277997cc0e4781052d258440ca1a",
             "input_file": "al18sf_12.mp4",
             "output_format": "fltp",
-            "result": "621bfe9dc4c755520ae97b2f400c563a"
+            "result": "621bfe9dc4c755520ae97b2f400c563a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00sf_64",
@@ -1137,7 +1278,8 @@
             "source_checksum": "a5589e87e1942e37c4f160725c43ae8f",
             "input_file": "al00sf_64.mp4",
             "output_format": "fltp",
-            "result": "0acee3957588ecf625efa56540f02f6a"
+            "result": "0acee3957588ecf625efa56540f02f6a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am07_96",
@@ -1145,7 +1287,8 @@
             "source_checksum": "8b66be8e9b14913e6c82106648cd8ef4",
             "input_file": "am07_96.mp4",
             "output_format": "fltp",
-            "result": "819dbd950461c95ca2389b9d8a6d1376"
+            "result": "819dbd950461c95ca2389b9d8a6d1376",
+            "profile": "AAC Main"
         },
         {
             "name": "as05_48",
@@ -1153,7 +1296,8 @@
             "source_checksum": "cf5e7954e68f578b1147ed9f0b92c69a",
             "input_file": "as05_48.mp4",
             "output_format": "fltp",
-            "result": "92776cb4dcaa00660145739ac77f3c40"
+            "result": "92776cb4dcaa00660145739ac77f3c40",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as06_22",
@@ -1161,7 +1305,8 @@
             "source_checksum": "5358a27ce906c0855056121c37696e4c",
             "input_file": "as06_22.mp4",
             "output_format": "fltp",
-            "result": "3d1602d419ff72fd988407ac777dc09d"
+            "result": "3d1602d419ff72fd988407ac777dc09d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_sig_48_2_sig0",
@@ -1169,7 +1314,8 @@
             "source_checksum": "9142825e62a0eed0f10667414f55bb78",
             "input_file": "al_sbr_sig_48_2_sig0.mp4",
             "output_format": "fltp",
-            "result": "0067d37aa712b90303a9b60e9648ca9c"
+            "result": "0067d37aa712b90303a9b60e9648ca9c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01sf_24",
@@ -1177,7 +1323,8 @@
             "source_checksum": "faf2f5d95d0a7a078eb2392ed6eb8461",
             "input_file": "al01sf_24.mp4",
             "output_format": "fltp",
-            "result": "2a1f9b80e590bf4009bdcc7feab11a47"
+            "result": "2a1f9b80e590bf4009bdcc7feab11a47",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03sf_12",
@@ -1185,7 +1332,8 @@
             "source_checksum": "8d928dc856f094bdae93004834f7e9d8",
             "input_file": "al03sf_12.mp4",
             "output_format": "fltp",
-            "result": "97c9a4a96818ef0c03dc1c8797aa7279"
+            "result": "97c9a4a96818ef0c03dc1c8797aa7279",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as01_88",
@@ -1193,7 +1341,8 @@
             "source_checksum": "44b435794197dbed317abfc5d6732c01",
             "input_file": "as01_88.mp4",
             "output_format": "fltp",
-            "result": "537a0a3189c650bc1d9e06011f636b26"
+            "result": "537a0a3189c650bc1d9e06011f636b26",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as11_16",
@@ -1201,7 +1350,8 @@
             "source_checksum": "d6905c984ad9cf428d1fa1b91beb6b9a",
             "input_file": "as11_16.mp4",
             "output_format": "fltp",
-            "result": "d704c48a8c7a7aadbeb0ff2cd664b065"
+            "result": "d704c48a8c7a7aadbeb0ff2cd664b065",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al18sf_64",
@@ -1209,7 +1359,8 @@
             "source_checksum": "3d507dfee12cbebdb536126cc006d190",
             "input_file": "al18sf_64.mp4",
             "output_format": "fltp",
-            "result": "439121dd587cf47da2a3bdbd07d9eb8c"
+            "result": "439121dd587cf47da2a3bdbd07d9eb8c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as04_48",
@@ -1217,7 +1368,8 @@
             "source_checksum": "f8bbfe7254f7bc21c9a401cb00d6d976",
             "input_file": "as04_48.mp4",
             "output_format": "fltp",
-            "result": "7ccf38ad07dce3b25b59283013770709"
+            "result": "7ccf38ad07dce3b25b59283013770709",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al16_44",
@@ -1225,7 +1377,8 @@
             "source_checksum": "a0b3f0990a1a226627c77e17a7ee6f13",
             "input_file": "al16_44.mp4",
             "output_format": "fltp",
-            "result": "b364313bc224edfe5f40d49cbd14dc3a"
+            "result": "b364313bc224edfe5f40d49cbd14dc3a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am04_88",
@@ -1233,7 +1386,8 @@
             "source_checksum": "212caaf3e6dc1c05ec2ebcd90917731f",
             "input_file": "am04_88.mp4",
             "output_format": "fltp",
-            "result": "c08d877e3c11ac5d6897487fc64809bb"
+            "result": "c08d877e3c11ac5d6897487fc64809bb",
+            "profile": "AAC Main"
         },
         {
             "name": "as03_08",
@@ -1241,7 +1395,8 @@
             "source_checksum": "48fbfc39e049c059edc87ff8093a12f6",
             "input_file": "as03_08.mp4",
             "output_format": "fltp",
-            "result": "873c6825dee58dba747bb0d1713c9876"
+            "result": "873c6825dee58dba747bb0d1713c9876",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as07_32",
@@ -1249,7 +1404,8 @@
             "source_checksum": "77c9bc3fa04218035bba0fc2adbc6ba7",
             "input_file": "as07_32.mp4",
             "output_format": "fltp",
-            "result": "0915e1fbc77e87737d528a0c43051124"
+            "result": "0915e1fbc77e87737d528a0c43051124",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as07_48",
@@ -1257,7 +1413,8 @@
             "source_checksum": "55dcc19d653e0023879104eb131ae4d0",
             "input_file": "as07_48.mp4",
             "output_format": "fltp",
-            "result": "06baf14e1baa6f403761fb4aff978608"
+            "result": "06baf14e1baa6f403761fb4aff978608",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al07_16",
@@ -1265,7 +1422,8 @@
             "source_checksum": "47f105f37cd76d3daabd62f541b15448",
             "input_file": "al07_16.mp4",
             "output_format": "fltp",
-            "result": "5bec3c86d8e071439aec19ab9a237488"
+            "result": "5bec3c86d8e071439aec19ab9a237488",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18sf_44",
@@ -1273,7 +1431,8 @@
             "source_checksum": "87cdb14b6ab3c2710c47f7abdc702a67",
             "input_file": "al18sf_44.mp4",
             "output_format": "fltp",
-            "result": "13b25122d84f8f04af614e23eb6550a1"
+            "result": "13b25122d84f8f04af614e23eb6550a1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_ps_03",
@@ -1281,7 +1440,8 @@
             "source_checksum": "17f7d06f1c0dee51e7ca4a01d06b453b",
             "input_file": "al_sbr_ps_03.mp4",
             "output_format": "fltp",
-            "result": "bce3ff8a9b5f74de69f9bd70ba79ec17"
+            "result": "bce3ff8a9b5f74de69f9bd70ba79ec17",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01sf_44",
@@ -1289,7 +1449,8 @@
             "source_checksum": "ab42a1613202e1071e53fd45b253f801",
             "input_file": "al01sf_44.mp4",
             "output_format": "fltp",
-            "result": "0ac8f10d9023e838fd99b79fbd158eab"
+            "result": "0ac8f10d9023e838fd99b79fbd158eab",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as11_48",
@@ -1297,7 +1458,8 @@
             "source_checksum": "9ed2ba80fe4e102279641b10556db2bf",
             "input_file": "as11_48.mp4",
             "output_format": "fltp",
-            "result": "e780e91547c3144c6e472e92ed2210d7"
+            "result": "e780e91547c3144c6e472e92ed2210d7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al960_sbr_gh_48_2",
@@ -1305,7 +1467,8 @@
             "source_checksum": "a3efc5cae8ad8d0f8b2461b4ea3c1907",
             "input_file": "al960_sbr_gh_48_2.mp4",
             "output_format": "fltp",
-            "result": "60f5a91b514b584cca0602b42d477c0d"
+            "result": "60f5a91b514b584cca0602b42d477c0d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as10_12",
@@ -1313,7 +1476,8 @@
             "source_checksum": "fdd7aaea16de73c9fb0106dd70e09865",
             "input_file": "as10_12.mp4",
             "output_format": "fltp",
-            "result": "f057d8a0ad40f59015672c8d713d44ee"
+            "result": "f057d8a0ad40f59015672c8d713d44ee",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "ap02_48",
@@ -1321,7 +1485,8 @@
             "source_checksum": "6f81c8d70dc36136f5ffa040d789ecc5",
             "input_file": "ap02_48.mp4",
             "output_format": "fltp",
-            "result": "57f4964f065c75fa825bf7c795ae621f"
+            "result": "57f4964f065c75fa825bf7c795ae621f",
+            "profile": "AAC Long Term Prediction"
         },
         {
             "name": "as17_08",
@@ -1329,7 +1494,8 @@
             "source_checksum": "f4ad708c59b2deb052d7d50d75721f81",
             "input_file": "as17_08.mp4",
             "output_format": "fltp",
-            "result": "43e5ba87c26f08d32b8b89469c9a3d7e"
+            "result": "43e5ba87c26f08d32b8b89469c9a3d7e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as14_22",
@@ -1337,7 +1503,8 @@
             "source_checksum": "9aad8d04dcb95667d9bb925837e6f539",
             "input_file": "as14_22.mp4",
             "output_format": "fltp",
-            "result": "11cff3010666624d2685b395d6071660"
+            "result": "11cff3010666624d2685b395d6071660",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as17_96",
@@ -1345,7 +1512,8 @@
             "source_checksum": "beaa15ce5385414a9c95c7484c3399b7",
             "input_file": "as17_96.mp4",
             "output_format": "fltp",
-            "result": "e5b7d4506a2a7e476c5e173afcf19226"
+            "result": "e5b7d4506a2a7e476c5e173afcf19226",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as15_22",
@@ -1353,7 +1521,8 @@
             "source_checksum": "51a7227c4db22f51f65d746403d53e81",
             "input_file": "as15_22.mp4",
             "output_format": "fltp",
-            "result": "e88c4c3d31939140f940c179a1bf8244"
+            "result": "e88c4c3d31939140f940c179a1bf8244",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as13_48",
@@ -1361,7 +1530,8 @@
             "source_checksum": "1e204c40c21993c04f2f1155c3631f52",
             "input_file": "as13_48.mp4",
             "output_format": "fltp",
-            "result": "38dbd84743ca49a00c9e69128f4a238b"
+            "result": "38dbd84743ca49a00c9e69128f4a238b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08sf_88",
@@ -1369,7 +1539,8 @@
             "source_checksum": "4025ea18b25f3637cb6fce32ce2029d7",
             "input_file": "al08sf_88.mp4",
             "output_format": "fltp",
-            "result": "fc18f917a53ab031889a5eb3215fcf1e"
+            "result": "fc18f917a53ab031889a5eb3215fcf1e",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02_64",
@@ -1377,7 +1548,8 @@
             "source_checksum": "4828dbe28aa7e2158ccf937e5d6fb0b2",
             "input_file": "al02_64.mp4",
             "output_format": "fltp",
-            "result": "5a1b7aaee8c3e44254fb010268cdcabe"
+            "result": "5a1b7aaee8c3e44254fb010268cdcabe",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_i_32_2",
@@ -1385,7 +1557,8 @@
             "source_checksum": "e9df5182742a1549d2a3bb90fe78616e",
             "input_file": "al960_sbr_i_32_2.mp4",
             "output_format": "fltp",
-            "result": "a44949df5ae980e79b68026c0e32d81b"
+            "result": "a44949df5ae980e79b68026c0e32d81b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_i_44_1",
@@ -1393,7 +1566,8 @@
             "source_checksum": "d953b1f6f63c0c53810351e3db16c25b",
             "input_file": "al960_sbr_i_44_1.mp4",
             "output_format": "fltp",
-            "result": "03a08c58ed607a86a7f6cf5926b9e30b"
+            "result": "03a08c58ed607a86a7f6cf5926b9e30b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as03_22",
@@ -1401,7 +1575,8 @@
             "source_checksum": "c56014afc0e75c1cae52b29144f7b0be",
             "input_file": "as03_22.mp4",
             "output_format": "fltp",
-            "result": "60873fde0040eae4680267487c338185"
+            "result": "60873fde0040eae4680267487c338185",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am07_24",
@@ -1409,7 +1584,8 @@
             "source_checksum": "1a731057a5ca36f3505c3c38eb2a4e91",
             "input_file": "am07_24.mp4",
             "output_format": "fltp",
-            "result": "34a614580de7ea3e545321475d46ccb2"
+            "result": "34a614580de7ea3e545321475d46ccb2",
+            "profile": "AAC Main"
         },
         {
             "name": "am02_22",
@@ -1417,7 +1593,8 @@
             "source_checksum": "d09bbf40ca8cb81370929979552fd492",
             "input_file": "am02_22.mp4",
             "output_format": "fltp",
-            "result": "e1e025741b3432606b8ff69965b7f3d0"
+            "result": "e1e025741b3432606b8ff69965b7f3d0",
+            "profile": "AAC Main"
         },
         {
             "name": "as17_44",
@@ -1425,7 +1602,8 @@
             "source_checksum": "60a2c3f590ac837460139e21a0fb7d11",
             "input_file": "as17_44.mp4",
             "output_format": "fltp",
-            "result": "6cb48e019e3819c3b29af695278d478f"
+            "result": "6cb48e019e3819c3b29af695278d478f",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06sf_48",
@@ -1433,7 +1611,8 @@
             "source_checksum": "a5fbb400a14de59fd5662c2523020da3",
             "input_file": "al06sf_48.mp4",
             "output_format": "fltp",
-            "result": "553e7c1cbaa5998e084475fa4b92fc6b"
+            "result": "553e7c1cbaa5998e084475fa4b92fc6b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as16_96",
@@ -1441,7 +1620,8 @@
             "source_checksum": "f84425e0f778c9f7fe620df8c2eea3f5",
             "input_file": "as16_96.mp4",
             "output_format": "fltp",
-            "result": "d78c16d1ef51d12466ffc32e805c7432"
+            "result": "d78c16d1ef51d12466ffc32e805c7432",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al07sf_32",
@@ -1449,7 +1629,8 @@
             "source_checksum": "3af0b50bf84d67dd4bb2a471700024be",
             "input_file": "al07sf_32.mp4",
             "output_format": "fltp",
-            "result": "ff2b32c235da8fb26eb0cd6ab7c55cda"
+            "result": "ff2b32c235da8fb26eb0cd6ab7c55cda",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07sf_88",
@@ -1457,7 +1638,8 @@
             "source_checksum": "ad5e2b8dc87815d82513ddd8d4e78c1f",
             "input_file": "al07sf_88.mp4",
             "output_format": "fltp",
-            "result": "2f1b3c8c6bb9fbb97febd375d9657f4b"
+            "result": "2f1b3c8c6bb9fbb97febd375d9657f4b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_gh_44_1",
@@ -1465,7 +1647,8 @@
             "source_checksum": "7ca30d2c1ff1e6e814de56f46665655f",
             "input_file": "al_sbr_gh_44_1.mp4",
             "output_format": "fltp",
-            "result": "36333990f7d48886936840cfb1f8d30d"
+            "result": "36333990f7d48886936840cfb1f8d30d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_16",
@@ -1473,7 +1656,8 @@
             "source_checksum": "9de47e5621d10f07f646c7c78b564f7e",
             "input_file": "al04_16.mp4",
             "output_format": "fltp",
-            "result": "e9a74efa429e0d6ca38b2c59bdf61652"
+            "result": "e9a74efa429e0d6ca38b2c59bdf61652",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02sf_12",
@@ -1481,7 +1665,8 @@
             "source_checksum": "a6f4ab8ef71c014738c571d335beff7e",
             "input_file": "al02sf_12.mp4",
             "output_format": "fltp",
-            "result": "fba7a9108012d70f844bbfe73f862d15"
+            "result": "fba7a9108012d70f844bbfe73f862d15",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as12_96",
@@ -1489,7 +1674,8 @@
             "source_checksum": "59c606e0446eb4bceb6429b46bc4f24d",
             "input_file": "as12_96.mp4",
             "output_format": "fltp",
-            "result": "84cfdbb1547092e3e15d28b2e9b274d5"
+            "result": "84cfdbb1547092e3e15d28b2e9b274d5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as01_11",
@@ -1497,7 +1683,8 @@
             "source_checksum": "216237a2de5448719388f1e18a61d666",
             "input_file": "as01_11.mp4",
             "output_format": "fltp",
-            "result": "bcdc702495729e0034fbb65cfea176ec"
+            "result": "bcdc702495729e0034fbb65cfea176ec",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as04_64",
@@ -1505,7 +1692,8 @@
             "source_checksum": "e2badf6bce9b7a7d708f12251e33cf55",
             "input_file": "as04_64.mp4",
             "output_format": "fltp",
-            "result": "e8ba5e37c694b3669d197c8ba5f980a1"
+            "result": "e8ba5e37c694b3669d197c8ba5f980a1",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as10_96",
@@ -1513,7 +1701,8 @@
             "source_checksum": "f091d78b1d24f8c5da1e9d0551365e60",
             "input_file": "as10_96.mp4",
             "output_format": "fltp",
-            "result": "72487940e6b21e1a5acfe6d5ddd57978"
+            "result": "72487940e6b21e1a5acfe6d5ddd57978",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as11_24",
@@ -1521,7 +1710,8 @@
             "source_checksum": "ceb2a5c94e7d5afd78829582e1787a2e",
             "input_file": "as11_24.mp4",
             "output_format": "fltp",
-            "result": "e293ad22f9eb770a524d17288b774880"
+            "result": "e293ad22f9eb770a524d17288b774880",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as16_12",
@@ -1529,7 +1719,8 @@
             "source_checksum": "c347605f97839f80ae074c58d733d8ab",
             "input_file": "as16_12.mp4",
             "output_format": "fltp",
-            "result": "cebcae8df24d92b22b9bf630fdcccdbe"
+            "result": "cebcae8df24d92b22b9bf630fdcccdbe",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al960_sbr_ps_06",
@@ -1537,7 +1728,8 @@
             "source_checksum": "f076af1002cdc256cec184f11d4d94ef",
             "input_file": "al960_sbr_ps_06.mp4",
             "output_format": "fltp",
-            "result": "7bdd332c1684d9f69b7d5b721033b5dd"
+            "result": "7bdd332c1684d9f69b7d5b721033b5dd",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06sf_44",
@@ -1545,7 +1737,8 @@
             "source_checksum": "e459a84a907d4a61b8ff2c1d9a3f199b",
             "input_file": "al06sf_44.mp4",
             "output_format": "fltp",
-            "result": "1a44da7dc44a968dd889bd4a8ce861f2"
+            "result": "1a44da7dc44a968dd889bd4a8ce861f2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_ps_02",
@@ -1553,7 +1746,8 @@
             "source_checksum": "fe3cae0219cde4b80f6fc238918ca510",
             "input_file": "al960_sbr_ps_02.mp4",
             "output_format": "fltp",
-            "result": "ea6bf8d45d2a642567dae7ceb3ba4761"
+            "result": "ea6bf8d45d2a642567dae7ceb3ba4761",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as15_48",
@@ -1561,7 +1755,8 @@
             "source_checksum": "8ad283b87e3703aa28815e24719a7ddd",
             "input_file": "as15_48.mp4",
             "output_format": "fltp",
-            "result": "38bc14e0a71144769d57b6fd72367f90"
+            "result": "38bc14e0a71144769d57b6fd72367f90",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_i_32_2",
@@ -1569,7 +1764,8 @@
             "source_checksum": "43508f1a6f7b172234459d09b00452be",
             "input_file": "al_sbr_i_32_2.mp4",
             "output_format": "fltp",
-            "result": "7fe2361d70f0ff64a26e0825be5c6754"
+            "result": "7fe2361d70f0ff64a26e0825be5c6754",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14sf_11",
@@ -1577,7 +1773,8 @@
             "source_checksum": "d9237a9270d1b7eab8f9f1ce936bf08d",
             "input_file": "al14sf_11.mp4",
             "output_format": "fltp",
-            "result": "e0f68df4182839866feb36ec0dfa23a2"
+            "result": "e0f68df4182839866feb36ec0dfa23a2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_ps_03",
@@ -1585,7 +1782,8 @@
             "source_checksum": "0d9d4060708ceafbf5c022a1191e526e",
             "input_file": "al960_sbr_ps_03.mp4",
             "output_format": "fltp",
-            "result": "cefb07bc527c214dd69bbf7c537c453a"
+            "result": "cefb07bc527c214dd69bbf7c537c453a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02sf_32",
@@ -1593,7 +1791,8 @@
             "source_checksum": "84f981fffbbbb1076ea162d85677f512",
             "input_file": "al02sf_32.mp4",
             "output_format": "fltp",
-            "result": "05a8592e1a8de09f7b806367f8123938"
+            "result": "05a8592e1a8de09f7b806367f8123938",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05sf_48",
@@ -1601,7 +1800,8 @@
             "source_checksum": "71ca0c099a14a2dd3f39f15078e04fa0",
             "input_file": "al05sf_48.mp4",
             "output_format": "fltp",
-            "result": "d72ef57b7bad160905b7d1650360c474"
+            "result": "d72ef57b7bad160905b7d1650360c474",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14sf_96",
@@ -1609,7 +1809,8 @@
             "source_checksum": "231ad1ff911ac3e658dd2cd5bfa5937a",
             "input_file": "al14sf_96.mp4",
             "output_format": "fltp",
-            "result": "ab6c0c02ab8224bc5f126264ee403a42"
+            "result": "ab6c0c02ab8224bc5f126264ee403a42",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as08_08",
@@ -1617,7 +1818,8 @@
             "source_checksum": "1b60749f9e9b77ec08a72793327dbb0a",
             "input_file": "as08_08.mp4",
             "output_format": "fltp",
-            "result": "e62bcd4999610e37ee6b257bc01542d9"
+            "result": "e62bcd4999610e37ee6b257bc01542d9",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_sr_22_2_fsaac22",
@@ -1625,7 +1827,8 @@
             "source_checksum": "58626cd7db1e0fe382eb80ea561777e3",
             "input_file": "al_sbr_sr_22_2_fsaac22.mp4",
             "output_format": "fltp",
-            "result": "5738ef7272e4a43c16da334afb3391b0"
+            "result": "5738ef7272e4a43c16da334afb3391b0",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17sf_22",
@@ -1633,7 +1836,8 @@
             "source_checksum": "922be0d507d444d6e3d8e2c53bce4813",
             "input_file": "al17sf_22.mp4",
             "output_format": "fltp",
-            "result": "282a105e716a8a6280f5fd9c162dbbce"
+            "result": "282a105e716a8a6280f5fd9c162dbbce",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18sf_88",
@@ -1641,7 +1845,8 @@
             "source_checksum": "f231c117317b7460fa234da621e1b6a4",
             "input_file": "al18sf_88.mp4",
             "output_format": "fltp",
-            "result": "2def4518f557639d7940b9056891daf8"
+            "result": "2def4518f557639d7940b9056891daf8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al19_88",
@@ -1649,7 +1854,8 @@
             "source_checksum": "48f777931ebc1f4e2381e46c6938823d",
             "input_file": "al19_88.mp4",
             "output_format": "fltp",
-            "result": "c063c9667651a1ee43c6d6a539d6f1b6"
+            "result": "c063c9667651a1ee43c6d6a539d6f1b6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as13_32",
@@ -1657,7 +1863,8 @@
             "source_checksum": "5d2a80b9c30c62e4be10270e54a7d4ba",
             "input_file": "as13_32.mp4",
             "output_format": "fltp",
-            "result": "117f87d7df6ab0c614f19209ba1bf04e"
+            "result": "117f87d7df6ab0c614f19209ba1bf04e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al14_48",
@@ -1665,7 +1872,8 @@
             "source_checksum": "ad1a02e299f886c63eb6f9d02b5d6b14",
             "input_file": "al14_48.mp4",
             "output_format": "fltp",
-            "result": "7b4fb2dd812dd2ecdd449e30e0034086"
+            "result": "7b4fb2dd812dd2ecdd449e30e0034086",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as13_44",
@@ -1673,7 +1881,8 @@
             "source_checksum": "901841ef112ddf61f8152977a8d078ec",
             "input_file": "as13_44.mp4",
             "output_format": "fltp",
-            "result": "3a771bc954be2ffed4dd6217ab0cdc6b"
+            "result": "3a771bc954be2ffed4dd6217ab0cdc6b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as04_88",
@@ -1681,7 +1890,8 @@
             "source_checksum": "6370ec402dfca0b3021415838a42ac68",
             "input_file": "as04_88.mp4",
             "output_format": "fltp",
-            "result": "a2a2fc6b38a3190b8dde068cddfed7fe"
+            "result": "a2a2fc6b38a3190b8dde068cddfed7fe",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03sf_16",
@@ -1689,7 +1899,8 @@
             "source_checksum": "f8898617a8d9a61df9dea4f905991b20",
             "input_file": "al03sf_16.mp4",
             "output_format": "fltp",
-            "result": "98b5f0df41b303b02037224f09cf45ea"
+            "result": "98b5f0df41b303b02037224f09cf45ea",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01_32",
@@ -1697,7 +1908,8 @@
             "source_checksum": "3df26533c8c3f84e15d21bcfa42bdc1d",
             "input_file": "al01_32.mp4",
             "output_format": "fltp",
-            "result": "11be4fd08e53a9ee75abaca22469f6dd"
+            "result": "11be4fd08e53a9ee75abaca22469f6dd",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04sf_48",
@@ -1705,7 +1917,8 @@
             "source_checksum": "f39dfafa67d444d1ad0b66d1a2377a73",
             "input_file": "al04sf_48.mp4",
             "output_format": "fltp",
-            "result": "1f04cda750065aad2633d369241e9aed"
+            "result": "1f04cda750065aad2633d369241e9aed",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03_32",
@@ -1713,7 +1926,8 @@
             "source_checksum": "3db1421eb2390b6898c6f5b81a8d1fc6",
             "input_file": "al03_32.mp4",
             "output_format": "fltp",
-            "result": "5262e32342bfac7cfbad37a17fbdaba2"
+            "result": "5262e32342bfac7cfbad37a17fbdaba2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as08_64",
@@ -1721,7 +1935,8 @@
             "source_checksum": "419530e6661771e85dbd65f48feca692",
             "input_file": "as08_64.mp4",
             "output_format": "fltp",
-            "result": "967475be69d08b82e6b150b78a86f44d"
+            "result": "967475be69d08b82e6b150b78a86f44d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as16_24",
@@ -1729,7 +1944,8 @@
             "source_checksum": "fc555018c4c4b3a4fbfc08a07a9cfb0b",
             "input_file": "as16_24.mp4",
             "output_format": "fltp",
-            "result": "8e8e826631fde7c58683f6bf668f5343"
+            "result": "8e8e826631fde7c58683f6bf668f5343",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as15_08",
@@ -1737,7 +1953,8 @@
             "source_checksum": "700efb283282fee2ddaf30afe308e1ac",
             "input_file": "as15_08.mp4",
             "output_format": "fltp",
-            "result": "8f9b805a20a67eb5b2b7e05323f412ec"
+            "result": "8f9b805a20a67eb5b2b7e05323f412ec",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am07_16",
@@ -1745,7 +1962,8 @@
             "source_checksum": "bec7d8dec5395a4fbf99e31972eff33a",
             "input_file": "am07_16.mp4",
             "output_format": "fltp",
-            "result": "42c320c8ab67efeebaeb25cc98c06a3d"
+            "result": "42c320c8ab67efeebaeb25cc98c06a3d",
+            "profile": "AAC Main"
         },
         {
             "name": "al17_12",
@@ -1753,7 +1971,8 @@
             "source_checksum": "5f4c5f52ac777c3ea169b232fbc03e90",
             "input_file": "al17_12.mp4",
             "output_format": "fltp",
-            "result": "bca856a6877d9a5324d8a1cf5cf8864c"
+            "result": "bca856a6877d9a5324d8a1cf5cf8864c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_i_32_1",
@@ -1761,7 +1980,8 @@
             "source_checksum": "9ce169c73423826af7031d55846e68f8",
             "input_file": "al_sbr_i_32_1.mp4",
             "output_format": "fltp",
-            "result": "c66cc8e8978bb3d26b3622ee0f85320b"
+            "result": "c66cc8e8978bb3d26b3622ee0f85320b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_e_32_2",
@@ -1769,7 +1989,8 @@
             "source_checksum": "a7fbbd07a83e4ef7b4311d0963f73d9b",
             "input_file": "al960_sbr_e_32_2.mp4",
             "output_format": "fltp",
-            "result": "7783c420ff8afec5790da91d22172601"
+            "result": "7783c420ff8afec5790da91d22172601",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_32",
@@ -1777,7 +1998,8 @@
             "source_checksum": "fd6c42148a56fe48da847f1d157cec9e",
             "input_file": "al04_32.mp4",
             "output_format": "fltp",
-            "result": "b0376ccd5985561b7aedae959f37e7a4"
+            "result": "b0376ccd5985561b7aedae959f37e7a4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al19_44",
@@ -1785,7 +2007,8 @@
             "source_checksum": "fd9794262e20c0ef1a17cdc185186b8b",
             "input_file": "al19_44.mp4",
             "output_format": "fltp",
-            "result": "5557f7070528f4d5aeb1a69655d934e9"
+            "result": "5557f7070528f4d5aeb1a69655d934e9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16sf_16",
@@ -1793,7 +2016,8 @@
             "source_checksum": "056fc1f4343adfecc4c5e2ba23b16704",
             "input_file": "al16sf_16.mp4",
             "output_format": "fltp",
-            "result": "0bc72c62df843828b386be714b0fb5fe"
+            "result": "0bc72c62df843828b386be714b0fb5fe",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as09_32",
@@ -1801,7 +2025,8 @@
             "source_checksum": "8d9a05e24a1930034ff159d84001b66a",
             "input_file": "as09_32.mp4",
             "output_format": "fltp",
-            "result": "c30c42a679a63bb4764920eb82e34101"
+            "result": "c30c42a679a63bb4764920eb82e34101",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al18_16",
@@ -1809,7 +2034,8 @@
             "source_checksum": "a7795a3423fd9dc95dcb70472fe4e0e6",
             "input_file": "al18_16.mp4",
             "output_format": "fltp",
-            "result": "721af0545b93204b6ddf4372cf5e10c5"
+            "result": "721af0545b93204b6ddf4372cf5e10c5",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_e_32_1",
@@ -1817,7 +2043,8 @@
             "source_checksum": "d1eae85954c8e1be74a4f40267bb8ac3",
             "input_file": "al960_sbr_e_32_1.mp4",
             "output_format": "fltp",
-            "result": "98aab2c6d012d9a12a76c671e26a920f"
+            "result": "98aab2c6d012d9a12a76c671e26a920f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "ap05_48",
@@ -1825,7 +2052,8 @@
             "source_checksum": "7b6dceb9f1338f857d9fcd0b7111da77",
             "input_file": "ap05_48.mp4",
             "output_format": "fltp",
-            "result": "e5f3db7043119313eb29f6f670989ecd"
+            "result": "e5f3db7043119313eb29f6f670989ecd",
+            "profile": "AAC Long Term Prediction"
         },
         {
             "name": "al_sbr_s_32_2",
@@ -1833,7 +2061,8 @@
             "source_checksum": "34d5e61f00d116d816d407828d0237c6",
             "input_file": "al_sbr_s_32_2.mp4",
             "output_format": "fltp",
-            "result": "c3020ed472f98b73208e474476a93b23"
+            "result": "c3020ed472f98b73208e474476a93b23",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am06_96",
@@ -1841,7 +2070,8 @@
             "source_checksum": "8478cc37fb28b4c91c2d0a0d0b07d30a",
             "input_file": "am06_96.mp4",
             "output_format": "fltp",
-            "result": "69fe0c79bc9f8ac63f94d54ceae9aa4e"
+            "result": "69fe0c79bc9f8ac63f94d54ceae9aa4e",
+            "profile": "AAC Main"
         },
         {
             "name": "al14_16",
@@ -1849,7 +2079,8 @@
             "source_checksum": "04abbb1eea01fc50610b77115eba1f5d",
             "input_file": "al14_16.mp4",
             "output_format": "fltp",
-            "result": "adcf17383ea63c860aca7c047bb4acd5"
+            "result": "adcf17383ea63c860aca7c047bb4acd5",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18sf_96",
@@ -1857,7 +2088,8 @@
             "source_checksum": "a40f5bf8e61dc757d4c43ecff5112087",
             "input_file": "al18sf_96.mp4",
             "output_format": "fltp",
-            "result": "2def4518f557639d7940b9056891daf8"
+            "result": "2def4518f557639d7940b9056891daf8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_48",
@@ -1865,7 +2097,8 @@
             "source_checksum": "703405d4b1847f95ad30103298a9aa69",
             "input_file": "am00_48.mp4",
             "output_format": "fltp",
-            "result": "8b30d5a5a799d5f59f3cd6ab973dbed9"
+            "result": "8b30d5a5a799d5f59f3cd6ab973dbed9",
+            "profile": "AAC Main"
         },
         {
             "name": "as03_48",
@@ -1873,7 +2106,8 @@
             "source_checksum": "8a9159c4cd8e76edd279785790f3a9b7",
             "input_file": "as03_48.mp4",
             "output_format": "fltp",
-            "result": "340d9fe3dc66b3a18d59d62df1d71954"
+            "result": "340d9fe3dc66b3a18d59d62df1d71954",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as13_64",
@@ -1881,7 +2115,8 @@
             "source_checksum": "9703ffb3589a1997f9f55e0a9afab8c8",
             "input_file": "as13_64.mp4",
             "output_format": "fltp",
-            "result": "50a018fa269ac0679e6548db4389ed84"
+            "result": "50a018fa269ac0679e6548db4389ed84",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as12_32",
@@ -1889,7 +2124,8 @@
             "source_checksum": "50304093bf0cbaf74c48cec0e5189775",
             "input_file": "as12_32.mp4",
             "output_format": "fltp",
-            "result": "473779bf860222b0f5ba126f140ae89f"
+            "result": "473779bf860222b0f5ba126f140ae89f",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as01_96",
@@ -1897,7 +2133,8 @@
             "source_checksum": "9b427347dca14e73f3aeb6160989c6ba",
             "input_file": "as01_96.mp4",
             "output_format": "fltp",
-            "result": "27786e9b7d83abafd8c0bff805d429b9"
+            "result": "27786e9b7d83abafd8c0bff805d429b9",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as02_32",
@@ -1905,7 +2142,8 @@
             "source_checksum": "1e7216a926d6ea3fc3bf98c21c32eae2",
             "input_file": "as02_32.mp4",
             "output_format": "fltp",
-            "result": "f3ee637a48cf6737058daef20576406c"
+            "result": "f3ee637a48cf6737058daef20576406c",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al19_22",
@@ -1913,7 +2151,8 @@
             "source_checksum": "874ebaf2588fb3c5ec49c0973c7fed33",
             "input_file": "al19_22.mp4",
             "output_format": "fltp",
-            "result": "3c5ac88b6143205c814736a3030c8dd9"
+            "result": "3c5ac88b6143205c814736a3030c8dd9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am04_32",
@@ -1921,7 +2160,8 @@
             "source_checksum": "1530ce1a7232b041686ab9a3d2fb42e6",
             "input_file": "am04_32.mp4",
             "output_format": "fltp",
-            "result": "ec52fee00142a4c1c7777d5ed7348ac6"
+            "result": "ec52fee00142a4c1c7777d5ed7348ac6",
+            "profile": "AAC Main"
         },
         {
             "name": "al17sf_11",
@@ -1929,7 +2169,8 @@
             "source_checksum": "8842aee4256f1741612ce1f78ba6f96c",
             "input_file": "al17sf_11.mp4",
             "output_format": "fltp",
-            "result": "77d09b536b5c5cc251faa21e5aecb413"
+            "result": "77d09b536b5c5cc251faa21e5aecb413",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03sf_32",
@@ -1937,7 +2178,8 @@
             "source_checksum": "cf3052d1a5e90f77033f82b3880ec40f",
             "input_file": "al03sf_32.mp4",
             "output_format": "fltp",
-            "result": "e82b1fc1d47d004bbb3be7e0feb1f969"
+            "result": "e82b1fc1d47d004bbb3be7e0feb1f969",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06sf_16",
@@ -1945,7 +2187,8 @@
             "source_checksum": "f5841793fec2f26332fd5396ad3dd38c",
             "input_file": "al06sf_16.mp4",
             "output_format": "fltp",
-            "result": "729917620326455911d3e057ee5b1951"
+            "result": "729917620326455911d3e057ee5b1951",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as01_64",
@@ -1953,7 +2196,8 @@
             "source_checksum": "168b907c8dbd7f6618c771a951fbf72f",
             "input_file": "as01_64.mp4",
             "output_format": "fltp",
-            "result": "a94e930b4474e51dffb012d46af338d5"
+            "result": "a94e930b4474e51dffb012d46af338d5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al18_44",
@@ -1961,7 +2205,8 @@
             "source_checksum": "09925e18e04262319694a14d62946e1a",
             "input_file": "al18_44.mp4",
             "output_format": "fltp",
-            "result": "13b25122d84f8f04af614e23eb6550a1"
+            "result": "13b25122d84f8f04af614e23eb6550a1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as03_24",
@@ -1969,7 +2214,8 @@
             "source_checksum": "acd4a595d5dde588a08c690b0f3e905f",
             "input_file": "as03_24.mp4",
             "output_format": "fltp",
-            "result": "7824e57e3964d56457224f67a9383e7b"
+            "result": "7824e57e3964d56457224f67a9383e7b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06sf_12",
@@ -1977,7 +2223,8 @@
             "source_checksum": "538495025b07b5b2092f2edbb6c1fc02",
             "input_file": "al06sf_12.mp4",
             "output_format": "fltp",
-            "result": "5fe712f1dde528f6fcb243abd257774e"
+            "result": "5fe712f1dde528f6fcb243abd257774e",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04sf_08",
@@ -1985,7 +2232,8 @@
             "source_checksum": "f6dcc00b7f539e90d52daa6c4b935952",
             "input_file": "al04sf_08.mp4",
             "output_format": "fltp",
-            "result": "19d650af57f6baa32202f3100aeb1eda"
+            "result": "19d650af57f6baa32202f3100aeb1eda",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as06_16",
@@ -1993,7 +2241,8 @@
             "source_checksum": "8cef265768eb770b4216ed9bbfe46f0f",
             "input_file": "as06_16.mp4",
             "output_format": "fltp",
-            "result": "481e95a7bc8864e6b97edb66cc561aaa"
+            "result": "481e95a7bc8864e6b97edb66cc561aaa",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as12_88",
@@ -2001,7 +2250,8 @@
             "source_checksum": "ba00319344b63c0029190c86949b99ad",
             "input_file": "as12_88.mp4",
             "output_format": "fltp",
-            "result": "ed0edb7557b7ddea6e180555346c8fa4"
+            "result": "ed0edb7557b7ddea6e180555346c8fa4",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al05_88",
@@ -2009,7 +2259,8 @@
             "source_checksum": "893b8780971ea5d8127037972ebaf456",
             "input_file": "al05_88.mp4",
             "output_format": "fltp",
-            "result": "6b609311bb4090654a70cda3b6df7ee4"
+            "result": "6b609311bb4090654a70cda3b6df7ee4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17_22",
@@ -2017,7 +2268,8 @@
             "source_checksum": "b339432b9f9bce1cb8094d87028bbc55",
             "input_file": "al17_22.mp4",
             "output_format": "fltp",
-            "result": "282a105e716a8a6280f5fd9c162dbbce"
+            "result": "282a105e716a8a6280f5fd9c162dbbce",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_44",
@@ -2025,7 +2277,8 @@
             "source_checksum": "caae57b05f32efeafadf24df2b4e0bf9",
             "input_file": "al04_44.mp4",
             "output_format": "fltp",
-            "result": "c0955b55a2703be93ad451a3c0cde34d"
+            "result": "c0955b55a2703be93ad451a3c0cde34d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14_22",
@@ -2033,7 +2286,8 @@
             "source_checksum": "34dbace05ee7c6d724b76cde73a50040",
             "input_file": "al14_22.mp4",
             "output_format": "fltp",
-            "result": "9e85dec1e7c4e72e889eeb3b9a7c5d02"
+            "result": "9e85dec1e7c4e72e889eeb3b9a7c5d02",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07sf_44",
@@ -2041,7 +2295,8 @@
             "source_checksum": "11d19d5ffbbc3c9f9c6f03a33416d8e9",
             "input_file": "al07sf_44.mp4",
             "output_format": "fltp",
-            "result": "79477538a05939dc9a517f9dd4189521"
+            "result": "79477538a05939dc9a517f9dd4189521",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as10_24",
@@ -2049,7 +2304,8 @@
             "source_checksum": "e23e91733bfc7beaaf3aa7086f50afbf",
             "input_file": "as10_24.mp4",
             "output_format": "fltp",
-            "result": "b3e9246d5753333f14341f4cefd6edf2"
+            "result": "b3e9246d5753333f14341f4cefd6edf2",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al04sf_11",
@@ -2057,7 +2313,8 @@
             "source_checksum": "6872e68c729403ccfd445959419bf159",
             "input_file": "al04sf_11.mp4",
             "output_format": "fltp",
-            "result": "ce01170c4b3bbadfb22580879745bb79"
+            "result": "ce01170c4b3bbadfb22580879745bb79",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as00_16",
@@ -2065,7 +2322,8 @@
             "source_checksum": "6a590d9190232f2440303e6a48b0a51b",
             "input_file": "as00_16.mp4",
             "output_format": "fltp",
-            "result": "3fca6788dceea0bfdb8629150d30a0a4"
+            "result": "3fca6788dceea0bfdb8629150d30a0a4",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al00_24",
@@ -2073,7 +2331,8 @@
             "source_checksum": "e92415ee0d65e2e3ce524970f938bec0",
             "input_file": "al00_24.mp4",
             "output_format": "fltp",
-            "result": "3440a3a7649138c087f6b6136314d19d"
+            "result": "3440a3a7649138c087f6b6136314d19d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01_48",
@@ -2081,7 +2340,8 @@
             "source_checksum": "638d62f9d2cc71d7d2ad2abdcf4e3c83",
             "input_file": "al01_48.mp4",
             "output_format": "fltp",
-            "result": "300f8cc27d8b5abfe5720b69f398bad2"
+            "result": "300f8cc27d8b5abfe5720b69f398bad2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as14_12",
@@ -2089,7 +2349,8 @@
             "source_checksum": "150d9f39dd6998cb860e104e4d801c26",
             "input_file": "as14_12.mp4",
             "output_format": "fltp",
-            "result": "9f9fed1c330324dc6957cedd3e6991ca"
+            "result": "9f9fed1c330324dc6957cedd3e6991ca",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al17sf_32",
@@ -2097,7 +2358,8 @@
             "source_checksum": "72544fca368a868ef90ce329905ca58b",
             "input_file": "al17sf_32.mp4",
             "output_format": "fltp",
-            "result": "dd2086ed1265106a1965a524c3575518"
+            "result": "dd2086ed1265106a1965a524c3575518",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as07_16",
@@ -2105,7 +2367,8 @@
             "source_checksum": "bf52071ffe711ccb37355fe06f103060",
             "input_file": "as07_16.mp4",
             "output_format": "fltp",
-            "result": "d5378da42756fbee3af7ed323020dea8"
+            "result": "d5378da42756fbee3af7ed323020dea8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al14_12",
@@ -2113,7 +2376,8 @@
             "source_checksum": "02bda522cc1fae4dbfe683c33029ca6c",
             "input_file": "al14_12.mp4",
             "output_format": "fltp",
-            "result": "0838992422e28225ee77bd8f50505d0a"
+            "result": "0838992422e28225ee77bd8f50505d0a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18_32",
@@ -2121,7 +2385,8 @@
             "source_checksum": "29eb617fea2021b8a569ef13bf9c4b6e",
             "input_file": "al18_32.mp4",
             "output_format": "fltp",
-            "result": "26c2430033002a138568d17ca3317ade"
+            "result": "26c2430033002a138568d17ca3317ade",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_sr_24_2_fsaac24",
@@ -2129,7 +2394,8 @@
             "source_checksum": "ed00868e566b83184cc7e55450d79296",
             "input_file": "al_sbr_sr_24_2_fsaac24.mp4",
             "output_format": "fltp",
-            "result": "a14a5cd3ba671a570afe3c18921031e0"
+            "result": "a14a5cd3ba671a570afe3c18921031e0",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as02_44",
@@ -2137,7 +2403,8 @@
             "source_checksum": "89bd63616088c838393415f38be52658",
             "input_file": "as02_44.mp4",
             "output_format": "fltp",
-            "result": "1d3d1e73b19feeb4ecbe4a702a4361dc"
+            "result": "1d3d1e73b19feeb4ecbe4a702a4361dc",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as00_24",
@@ -2145,7 +2412,8 @@
             "source_checksum": "77d6f518ab6e02b89664d9b4b317720d",
             "input_file": "as00_24.mp4",
             "output_format": "fltp",
-            "result": "f55b20bf2eaaca20b8e12dfe76eb0d7d"
+            "result": "f55b20bf2eaaca20b8e12dfe76eb0d7d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as08_11",
@@ -2153,7 +2421,8 @@
             "source_checksum": "0abb176cf48e302de3143ad75db1be9c",
             "input_file": "as08_11.mp4",
             "output_format": "fltp",
-            "result": "ba9b6025a324f400b8974402fc0cb31d"
+            "result": "ba9b6025a324f400b8974402fc0cb31d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06_32",
@@ -2161,7 +2430,8 @@
             "source_checksum": "c35bc565415d32d2cae6a7cd65e69ba0",
             "input_file": "al06_32.mp4",
             "output_format": "fltp",
-            "result": "359f98bc3c4b898afa31500216a68f8f"
+            "result": "359f98bc3c4b898afa31500216a68f8f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as05_08",
@@ -2169,7 +2439,8 @@
             "source_checksum": "7e9f951b37ad501b77aa1216dbc39678",
             "input_file": "as05_08.mp4",
             "output_format": "fltp",
-            "result": "8cdd94e0953cc708e54a22c5ea799cd1"
+            "result": "8cdd94e0953cc708e54a22c5ea799cd1",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as07_88",
@@ -2177,7 +2448,8 @@
             "source_checksum": "33d8be62ead955c6d23fe4a059a96d8f",
             "input_file": "as07_88.mp4",
             "output_format": "fltp",
-            "result": "5f8f5e004f4e5ab7e72e5fdf87451f18"
+            "result": "5f8f5e004f4e5ab7e72e5fdf87451f18",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06sf_88",
@@ -2185,7 +2457,8 @@
             "source_checksum": "e9b052c5fd453c52e0ddbf0fdef50cc8",
             "input_file": "al06sf_88.mp4",
             "output_format": "fltp",
-            "result": "c172042cbf8e1b2a73b2ac21b5c12ec2"
+            "result": "c172042cbf8e1b2a73b2ac21b5c12ec2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16sf_32",
@@ -2193,7 +2466,8 @@
             "source_checksum": "5dc20e14fea6907055a4c8692d79027b",
             "input_file": "al16sf_32.mp4",
             "output_format": "fltp",
-            "result": "dc2e69c4a698b9b0f5cae72a92cf2af7"
+            "result": "dc2e69c4a698b9b0f5cae72a92cf2af7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06_96",
@@ -2201,7 +2475,8 @@
             "source_checksum": "51b0485cb5b2b5aa7227f57d34a7f468",
             "input_file": "al06_96.mp4",
             "output_format": "fltp",
-            "result": "84e167d143354c50928dfbc54a4b88a2"
+            "result": "84e167d143354c50928dfbc54a4b88a2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03sf_88",
@@ -2209,7 +2484,8 @@
             "source_checksum": "e965fde7fd3c0636dad5e11f72ef3779",
             "input_file": "al03sf_88.mp4",
             "output_format": "fltp",
-            "result": "582225859b9df6f9bb2a25c7ec843fdd"
+            "result": "582225859b9df6f9bb2a25c7ec843fdd",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am07_08",
@@ -2217,7 +2493,8 @@
             "source_checksum": "e18b1d19bd2286d8fb02c1aeba83f783",
             "input_file": "am07_08.mp4",
             "output_format": "fltp",
-            "result": "3ae060bd32f8b810ba5ba5fff1094d8b"
+            "result": "3ae060bd32f8b810ba5ba5fff1094d8b",
+            "profile": "AAC Main"
         },
         {
             "name": "al16_96",
@@ -2225,7 +2502,8 @@
             "source_checksum": "28ff8d52a899b714573a1cb1928159d0",
             "input_file": "al16_96.mp4",
             "output_format": "fltp",
-            "result": "adea56a3d03d3a1eaf8ba8d58ecdd983"
+            "result": "adea56a3d03d3a1eaf8ba8d58ecdd983",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as00_32",
@@ -2233,7 +2511,8 @@
             "source_checksum": "d8077d3896e6722f52d1a5fc975c8002",
             "input_file": "as00_32.mp4",
             "output_format": "fltp",
-            "result": "ba87750cd665c8d17d0515d5162b6899"
+            "result": "ba87750cd665c8d17d0515d5162b6899",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al19sf_22",
@@ -2241,7 +2520,8 @@
             "source_checksum": "4624c9ae845821bebbccb26e6cc6fc81",
             "input_file": "al19sf_22.mp4",
             "output_format": "fltp",
-            "result": "3c5ac88b6143205c814736a3030c8dd9"
+            "result": "3c5ac88b6143205c814736a3030c8dd9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07_64",
@@ -2249,7 +2529,8 @@
             "source_checksum": "04379d41b9796162bf4618eda52c0f75",
             "input_file": "al07_64.mp4",
             "output_format": "fltp",
-            "result": "7b6efd21646d195c7d61bf75b8dd5a31"
+            "result": "7b6efd21646d195c7d61bf75b8dd5a31",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02_24",
@@ -2257,7 +2538,8 @@
             "source_checksum": "08f0a8e22ee22d216a3cf51f078454e1",
             "input_file": "al02_24.mp4",
             "output_format": "fltp",
-            "result": "db09ed12bdb1cbaf49dfe9bd7e1046b5"
+            "result": "db09ed12bdb1cbaf49dfe9bd7e1046b5",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as05_24",
@@ -2265,7 +2547,8 @@
             "source_checksum": "7fb0b1a367ffc0735f34fc81f9ec122e",
             "input_file": "as05_24.mp4",
             "output_format": "fltp",
-            "result": "671432646fd41c54fe0b025f278ad3d5"
+            "result": "671432646fd41c54fe0b025f278ad3d5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al02_11",
@@ -2273,7 +2556,8 @@
             "source_checksum": "9b13120b091adfb35025cdd43264e91d",
             "input_file": "al02_11.mp4",
             "output_format": "fltp",
-            "result": "6919665a2023157452cff79d0ea54f4c"
+            "result": "6919665a2023157452cff79d0ea54f4c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as11_11",
@@ -2281,7 +2565,8 @@
             "source_checksum": "1c4a241e07fc19e4a686d728f2fbc4bc",
             "input_file": "as11_11.mp4",
             "output_format": "fltp",
-            "result": "e9ffff20d1b7741befe645289ad0a79d"
+            "result": "e9ffff20d1b7741befe645289ad0a79d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al14sf_12",
@@ -2289,7 +2574,8 @@
             "source_checksum": "4ea030493de53d7d9e9c7293d015432f",
             "input_file": "al14sf_12.mp4",
             "output_format": "fltp",
-            "result": "0838992422e28225ee77bd8f50505d0a"
+            "result": "0838992422e28225ee77bd8f50505d0a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am01_64",
@@ -2297,7 +2583,8 @@
             "source_checksum": "1ac99f8e227d51a3e5c7f17008baafd4",
             "input_file": "am01_64.mp4",
             "output_format": "fltp",
-            "result": "a6f2f72dbb23e693d815cdcb77d4e0e7"
+            "result": "a6f2f72dbb23e693d815cdcb77d4e0e7",
+            "profile": "AAC Main"
         },
         {
             "name": "al19sf_11",
@@ -2305,7 +2592,8 @@
             "source_checksum": "6b8e51d41474e7780a7b41770802ceea",
             "input_file": "al19sf_11.mp4",
             "output_format": "fltp",
-            "result": "cbf233464d9c8d6cdbca27723e744da8"
+            "result": "cbf233464d9c8d6cdbca27723e744da8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as17_11",
@@ -2313,7 +2601,8 @@
             "source_checksum": "eb359c0992f0d89fd2f56946a765f44d",
             "input_file": "as17_11.mp4",
             "output_format": "fltp",
-            "result": "300e847b3b81826305e6b4c6dc611235"
+            "result": "300e847b3b81826305e6b4c6dc611235",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as15_44",
@@ -2321,7 +2610,8 @@
             "source_checksum": "48f22d6308e9d0f6626c18b9a39c4ef0",
             "input_file": "as15_44.mp4",
             "output_format": "fltp",
-            "result": "a8c6ddf2e47604d26ca6987a403ac0ad"
+            "result": "a8c6ddf2e47604d26ca6987a403ac0ad",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al07sf_24",
@@ -2329,7 +2619,8 @@
             "source_checksum": "c6494437b21079e6c480c786233684d4",
             "input_file": "al07sf_24.mp4",
             "output_format": "fltp",
-            "result": "24c49da2486562d7cabb30e56c54e540"
+            "result": "24c49da2486562d7cabb30e56c54e540",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01sf_64",
@@ -2337,7 +2628,8 @@
             "source_checksum": "0c36ebcfbbefa2b27262316d24b38735",
             "input_file": "al01sf_64.mp4",
             "output_format": "fltp",
-            "result": "567affc7a30b2b05804877c986b93849"
+            "result": "567affc7a30b2b05804877c986b93849",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16sf_64",
@@ -2345,7 +2637,8 @@
             "source_checksum": "dd49860c753874a4ca312db247868eb2",
             "input_file": "al16sf_64.mp4",
             "output_format": "fltp",
-            "result": "637ff0208bfe1f2e69e5ecf70232b2c2"
+            "result": "637ff0208bfe1f2e69e5ecf70232b2c2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as00_12",
@@ -2353,7 +2646,8 @@
             "source_checksum": "642c4e7c6d4770c68522db5998f4b972",
             "input_file": "as00_12.mp4",
             "output_format": "fltp",
-            "result": "30ef66aa6a39b0b5d3a77aea1061928b"
+            "result": "30ef66aa6a39b0b5d3a77aea1061928b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as13_16",
@@ -2361,7 +2655,8 @@
             "source_checksum": "c7a9ab41b0ae1969d0bb556f91d3d19e",
             "input_file": "as13_16.mp4",
             "output_format": "fltp",
-            "result": "ebd81ce618535f8bf38bc54bdda32f64"
+            "result": "ebd81ce618535f8bf38bc54bdda32f64",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al960_sbr_s_44_1",
@@ -2369,7 +2664,8 @@
             "source_checksum": "067debafa8e8481fc097af5cf2c0baa8",
             "input_file": "al960_sbr_s_44_1.mp4",
             "output_format": "fltp",
-            "result": "d6f676c4208cdbd982c2fb477ee61c2c"
+            "result": "d6f676c4208cdbd982c2fb477ee61c2c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_twi_48_1_fsaac24",
@@ -2377,7 +2673,8 @@
             "source_checksum": "8f6f11f5bbbff7745eb6c29d139dcd56",
             "input_file": "al_sbr_twi_48_1_fsaac24.mp4",
             "output_format": "fltp",
-            "result": "a91e589086642266d239c4f6480c5624"
+            "result": "a91e589086642266d239c4f6480c5624",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04sf_44",
@@ -2385,7 +2682,8 @@
             "source_checksum": "a2a418cc7f79993c35424aa77e106018",
             "input_file": "al04sf_44.mp4",
             "output_format": "fltp",
-            "result": "c0955b55a2703be93ad451a3c0cde34d"
+            "result": "c0955b55a2703be93ad451a3c0cde34d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00_12",
@@ -2393,7 +2691,8 @@
             "source_checksum": "2e248737516bd9d6c8e7b1038e480e0f",
             "input_file": "al00_12.mp4",
             "output_format": "fltp",
-            "result": "1003860d480d488f2093171008643ca2"
+            "result": "1003860d480d488f2093171008643ca2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14_11",
@@ -2401,7 +2700,8 @@
             "source_checksum": "7c46b9696ce5017d40f3a5c3626716af",
             "input_file": "al14_11.mp4",
             "output_format": "fltp",
-            "result": "e0f68df4182839866feb36ec0dfa23a2"
+            "result": "e0f68df4182839866feb36ec0dfa23a2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_sr_48_2_fsaac48",
@@ -2409,7 +2709,8 @@
             "source_checksum": "8e0e409d2d36924c124ad55636e90b5c",
             "input_file": "al_sbr_sr_48_2_fsaac48.mp4",
             "output_format": "fltp",
-            "result": "bd202ce4b95f8d00918fe2831c5c6510"
+            "result": "bd202ce4b95f8d00918fe2831c5c6510",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as09_24",
@@ -2417,7 +2718,8 @@
             "source_checksum": "bb1942faf8191f6a16c6bf2b6aeaa349",
             "input_file": "as09_24.mp4",
             "output_format": "fltp",
-            "result": "851b0946a36ffb0d4d309c2a4010ec9b"
+            "result": "851b0946a36ffb0d4d309c2a4010ec9b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03sf_96",
@@ -2425,7 +2727,8 @@
             "source_checksum": "07d9105a4250e449b1f7fb86ae32777a",
             "input_file": "al03sf_96.mp4",
             "output_format": "fltp",
-            "result": "c07660b161c8bf333f7703d39cd7829c"
+            "result": "c07660b161c8bf333f7703d39cd7829c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08_16",
@@ -2433,7 +2736,8 @@
             "source_checksum": "8ae58cfa272b2659b332eb6e72c8f55c",
             "input_file": "al08_16.mp4",
             "output_format": "fltp",
-            "result": "bb5f7e58db2f7940c656fa704596ed5e"
+            "result": "bb5f7e58db2f7940c656fa704596ed5e",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as05_88",
@@ -2441,7 +2745,8 @@
             "source_checksum": "0d47ff5f6e3628160ae4b3c2bb9a3c9d",
             "input_file": "as05_88.mp4",
             "output_format": "fltp",
-            "result": "20b38c0d21a134e573d4d1ca748aad40"
+            "result": "20b38c0d21a134e573d4d1ca748aad40",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al00_08",
@@ -2449,7 +2754,8 @@
             "source_checksum": "e420934e6b638949342cc48636617bcc",
             "input_file": "al00_08.mp4",
             "output_format": "fltp",
-            "result": "974fc5db0dd85a5240956a8a5e593469"
+            "result": "974fc5db0dd85a5240956a8a5e593469",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02_88",
@@ -2457,7 +2763,8 @@
             "source_checksum": "ce777a65dd783e52d849d3a41833bf9b",
             "input_file": "al02_88.mp4",
             "output_format": "fltp",
-            "result": "ea940a21c761f8e87cb3b2b8ceb91ebd"
+            "result": "ea940a21c761f8e87cb3b2b8ceb91ebd",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14_08",
@@ -2465,7 +2772,8 @@
             "source_checksum": "1981b6d96731b5938d592db95f51dec2",
             "input_file": "al14_08.mp4",
             "output_format": "fltp",
-            "result": "c25a053760f16d8340be000648f0a426"
+            "result": "c25a053760f16d8340be000648f0a426",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01sf_16",
@@ -2473,7 +2781,8 @@
             "source_checksum": "9c0e1f66def73be4ab469723cac78adf",
             "input_file": "al01sf_16.mp4",
             "output_format": "fltp",
-            "result": "e2f030fc972340b05f2519b282cdbac3"
+            "result": "e2f030fc972340b05f2519b282cdbac3",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as10_48",
@@ -2481,7 +2790,8 @@
             "source_checksum": "053444ca4f696efa53dd96f3c1ea4106",
             "input_file": "as10_48.mp4",
             "output_format": "fltp",
-            "result": "b66a6582c6c636102251dd3b020e22e2"
+            "result": "b66a6582c6c636102251dd3b020e22e2",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_e_44_1",
@@ -2489,7 +2799,8 @@
             "source_checksum": "36d97ba094a2eb20fbbbceb34b1ca5ed",
             "input_file": "al_sbr_e_44_1.mp4",
             "output_format": "fltp",
-            "result": "1ffa888506f7b10e126be481473b5734"
+            "result": "1ffa888506f7b10e126be481473b5734",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as12_64",
@@ -2497,7 +2808,8 @@
             "source_checksum": "bd7d6d939e20b7d025d8f91a4eeca627",
             "input_file": "as12_64.mp4",
             "output_format": "fltp",
-            "result": "8839665fc97bff6a189aff3bc2d914e9"
+            "result": "8839665fc97bff6a189aff3bc2d914e9",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al04_96",
@@ -2505,7 +2817,8 @@
             "source_checksum": "ef5796c25685b1d5afaff9eb3d7fb250",
             "input_file": "al04_96.mp4",
             "output_format": "fltp",
-            "result": "edb05b74da0fb44f78dc51c5c8e7369f"
+            "result": "edb05b74da0fb44f78dc51c5c8e7369f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00_64",
@@ -2513,7 +2826,8 @@
             "source_checksum": "01f7b2264c7426300ce1d6c666e07e1a",
             "input_file": "al00_64.mp4",
             "output_format": "fltp",
-            "result": "0acee3957588ecf625efa56540f02f6a"
+            "result": "0acee3957588ecf625efa56540f02f6a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07_88",
@@ -2521,7 +2835,8 @@
             "source_checksum": "868ff25b1e1ef696d6df1878defe6776",
             "input_file": "al07_88.mp4",
             "output_format": "fltp",
-            "result": "2f1b3c8c6bb9fbb97febd375d9657f4b"
+            "result": "2f1b3c8c6bb9fbb97febd375d9657f4b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as16_08",
@@ -2529,7 +2844,8 @@
             "source_checksum": "fe34e0cc047002ae4d6fb1b8567eebb5",
             "input_file": "as16_08.mp4",
             "output_format": "fltp",
-            "result": "9ec513bf03915a69409bbd48a30b37a5"
+            "result": "9ec513bf03915a69409bbd48a30b37a5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as14_48",
@@ -2537,7 +2853,8 @@
             "source_checksum": "f759ecf4c6648f643567b365ca43ff4d",
             "input_file": "as14_48.mp4",
             "output_format": "fltp",
-            "result": "3fcdf38f42442e1eaae8996b023131c8"
+            "result": "3fcdf38f42442e1eaae8996b023131c8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al14_88",
@@ -2545,7 +2862,8 @@
             "source_checksum": "58f4072bb280d614b0ab44becba9543c",
             "input_file": "al14_88.mp4",
             "output_format": "fltp",
-            "result": "93099bfdaf22a5847e010eef08f10537"
+            "result": "93099bfdaf22a5847e010eef08f10537",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03sf_11",
@@ -2553,7 +2871,8 @@
             "source_checksum": "f4610de3d7a2946c43959d626eae603f",
             "input_file": "al03sf_11.mp4",
             "output_format": "fltp",
-            "result": "cb5054b764e9019be9d0fcbfe3776835"
+            "result": "cb5054b764e9019be9d0fcbfe3776835",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_ps_01",
@@ -2561,7 +2880,8 @@
             "source_checksum": "0d3b1ae7d2b2c667384b0fbb32962ecb",
             "input_file": "al960_sbr_ps_01.mp4",
             "output_format": "fltp",
-            "result": "d8dd308c2cb9351aa14a6729b7f73986"
+            "result": "d8dd308c2cb9351aa14a6729b7f73986",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02_96",
@@ -2569,7 +2889,8 @@
             "source_checksum": "d9cb220a08e5d42181ad5eba21563267",
             "input_file": "al02_96.mp4",
             "output_format": "fltp",
-            "result": "c91d263e846628e4060cdef6c9b5c81d"
+            "result": "c91d263e846628e4060cdef6c9b5c81d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06sf_24",
@@ -2577,7 +2898,8 @@
             "source_checksum": "fc775c3c0d7de17e48ee0655cde5bcab",
             "input_file": "al06sf_24.mp4",
             "output_format": "fltp",
-            "result": "93405699186566faf24ece95412310fe"
+            "result": "93405699186566faf24ece95412310fe",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as00_48",
@@ -2585,7 +2907,8 @@
             "source_checksum": "9d60f10cf0bc8f3056aaffef2c191c5e",
             "input_file": "as00_48.mp4",
             "output_format": "fltp",
-            "result": "a061cf8a04c5706e71186aa23d4ee307"
+            "result": "a061cf8a04c5706e71186aa23d4ee307",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as09_12",
@@ -2593,7 +2916,8 @@
             "source_checksum": "a57f3ee37e1911cb7003826b3e3a8c0c",
             "input_file": "as09_12.mp4",
             "output_format": "fltp",
-            "result": "ec6dc14c20693f61c10844ed800a375d"
+            "result": "ec6dc14c20693f61c10844ed800a375d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08_08",
@@ -2601,7 +2925,8 @@
             "source_checksum": "45443f90986dbc99f70f5ac31e2afda9",
             "input_file": "al08_08.mp4",
             "output_format": "fltp",
-            "result": "5e4137362e9be4a4f875f45ff642b08d"
+            "result": "5e4137362e9be4a4f875f45ff642b08d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01_16",
@@ -2609,7 +2934,8 @@
             "source_checksum": "baa04933553f1665a365738effb5cef8",
             "input_file": "al01_16.mp4",
             "output_format": "fltp",
-            "result": "e2f030fc972340b05f2519b282cdbac3"
+            "result": "e2f030fc972340b05f2519b282cdbac3",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am01_22",
@@ -2617,7 +2943,8 @@
             "source_checksum": "43f8b18dd38e39e04505a4b2921f2a70",
             "input_file": "am01_22.mp4",
             "output_format": "fltp",
-            "result": "7d384f1aebb4f9f6d919d534f72abf2e"
+            "result": "7d384f1aebb4f9f6d919d534f72abf2e",
+            "profile": "AAC Main"
         },
         {
             "name": "al02sf_24",
@@ -2625,7 +2952,8 @@
             "source_checksum": "9d488dbdedf86719ea8ccca532ccc8d5",
             "input_file": "al02sf_24.mp4",
             "output_format": "fltp",
-            "result": "db09ed12bdb1cbaf49dfe9bd7e1046b5"
+            "result": "db09ed12bdb1cbaf49dfe9bd7e1046b5",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16sf_24",
@@ -2633,7 +2961,8 @@
             "source_checksum": "b231ae2664c1bc0efafe58794e32dccd",
             "input_file": "al16sf_24.mp4",
             "output_format": "fltp",
-            "result": "60b43672daf2a885a164801c21c23b6f"
+            "result": "60b43672daf2a885a164801c21c23b6f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_44",
@@ -2641,7 +2970,8 @@
             "source_checksum": "29f723f10166f1478eec34bff80a4fbb",
             "input_file": "am00_44.mp4",
             "output_format": "fltp",
-            "result": "cbeb791f1771f1d0adcfff9a29fe4223"
+            "result": "cbeb791f1771f1d0adcfff9a29fe4223",
+            "profile": "AAC Main"
         },
         {
             "name": "al06_48",
@@ -2649,7 +2979,8 @@
             "source_checksum": "43c5ffba27fba57156518956d4a868e9",
             "input_file": "al06_48.mp4",
             "output_format": "fltp",
-            "result": "553e7c1cbaa5998e084475fa4b92fc6b"
+            "result": "553e7c1cbaa5998e084475fa4b92fc6b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as08_48",
@@ -2657,7 +2988,8 @@
             "source_checksum": "80e16d98e501748fcd0fb30e1dbfb023",
             "input_file": "as08_48.mp4",
             "output_format": "fltp",
-            "result": "a9e35a70084e01070ce82663131c4b97"
+            "result": "a9e35a70084e01070ce82663131c4b97",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al07_12",
@@ -2665,7 +2997,8 @@
             "source_checksum": "c701278f3b3bd5caf30555448548250f",
             "input_file": "al07_12.mp4",
             "output_format": "fltp",
-            "result": "dacea28648a5b0756c3bc97539d750e8"
+            "result": "dacea28648a5b0756c3bc97539d750e8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as03_88",
@@ -2673,7 +3006,8 @@
             "source_checksum": "40ee7c92ea8d6fb60fa6c82ba1ea0273",
             "input_file": "as03_88.mp4",
             "output_format": "fltp",
-            "result": "7c1d95a7d4e0291f22079effbf894a78"
+            "result": "7c1d95a7d4e0291f22079effbf894a78",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al14_32",
@@ -2681,7 +3015,8 @@
             "source_checksum": "3ba1c2931ee9076190fa5ea49e9cf9a0",
             "input_file": "al14_32.mp4",
             "output_format": "fltp",
-            "result": "72f133b209330a1f080383a4023dd753"
+            "result": "72f133b209330a1f080383a4023dd753",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_i_44_1_new",
@@ -2689,7 +3024,8 @@
             "source_checksum": "5e650cd7dae12faed8e0cbfc13d3e281",
             "input_file": "al_sbr_i_44_1_new.mp4",
             "output_format": "fltp",
-            "result": "7e025ed2b60e113303e83db37889c167"
+            "result": "7e025ed2b60e113303e83db37889c167",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_ps_05",
@@ -2697,7 +3033,8 @@
             "source_checksum": "2adf2cd7d54913f57baf4fb56d53c988",
             "input_file": "al960_sbr_ps_05.mp4",
             "output_format": "fltp",
-            "result": "b5e352ef628def6359ab5ee87071db6b"
+            "result": "b5e352ef628def6359ab5ee87071db6b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14_24",
@@ -2705,7 +3042,8 @@
             "source_checksum": "451dbefedcb621d1ca7d684cc8538f24",
             "input_file": "al14_24.mp4",
             "output_format": "fltp",
-            "result": "744f7fd7aef4005110b26134c89938f6"
+            "result": "744f7fd7aef4005110b26134c89938f6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14sf_22",
@@ -2713,7 +3051,8 @@
             "source_checksum": "9e8834057617c47cf95d4d048dd17013",
             "input_file": "al14sf_22.mp4",
             "output_format": "fltp",
-            "result": "9e85dec1e7c4e72e889eeb3b9a7c5d02"
+            "result": "9e85dec1e7c4e72e889eeb3b9a7c5d02",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00_11",
@@ -2721,7 +3060,8 @@
             "source_checksum": "f71f3a1241fe252de633e7fd18bc77f1",
             "input_file": "al00_11.mp4",
             "output_format": "fltp",
-            "result": "6eb23f7d1b322d167f0c075234ad66ec"
+            "result": "6eb23f7d1b322d167f0c075234ad66ec",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as04_08",
@@ -2729,7 +3069,8 @@
             "source_checksum": "4d1bc12cab3beff626aa28e9955e84a5",
             "input_file": "as04_08.mp4",
             "output_format": "fltp",
-            "result": "b981e023626023db892096c76c051e28"
+            "result": "b981e023626023db892096c76c051e28",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as01_24",
@@ -2737,7 +3078,8 @@
             "source_checksum": "4dd9c4d686e453dd60790d9ee87f2140",
             "input_file": "as01_24.mp4",
             "output_format": "fltp",
-            "result": "a8f4b97f487b82cbe3267f4e06c0f487"
+            "result": "a8f4b97f487b82cbe3267f4e06c0f487",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as08_96",
@@ -2745,7 +3087,8 @@
             "source_checksum": "d6e2e095158da990472d2706f2346519",
             "input_file": "as08_96.mp4",
             "output_format": "fltp",
-            "result": "a5c6e4e4e267f3cf786c7ab76acbe9fa"
+            "result": "a5c6e4e4e267f3cf786c7ab76acbe9fa",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al19_24",
@@ -2753,7 +3096,8 @@
             "source_checksum": "e8f1b52b765f76868609c7081462f38b",
             "input_file": "al19_24.mp4",
             "output_format": "fltp",
-            "result": "3c5ac88b6143205c814736a3030c8dd9"
+            "result": "3c5ac88b6143205c814736a3030c8dd9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_cm_48_1",
@@ -2761,7 +3105,8 @@
             "source_checksum": "581ed926ee8dda609c988c678102559e",
             "input_file": "al_sbr_cm_48_1.mp4",
             "output_format": "fltp",
-            "result": "eecb6cbd7ef33ed5f90376ea8f633eda"
+            "result": "eecb6cbd7ef33ed5f90376ea8f633eda",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am06_16",
@@ -2769,7 +3114,8 @@
             "source_checksum": "30b5704a3979abe96b8060b89fd2cea0",
             "input_file": "am06_16.mp4",
             "output_format": "fltp",
-            "result": "c09f07ac65277cda722c9ea062fd1235"
+            "result": "c09f07ac65277cda722c9ea062fd1235",
+            "profile": "AAC Main"
         },
         {
             "name": "al07_11",
@@ -2777,7 +3123,8 @@
             "source_checksum": "f7c21af5b33c66a915ffd08ca46603ff",
             "input_file": "al07_11.mp4",
             "output_format": "fltp",
-            "result": "f901e5fd1267ecf66a6803278518d006"
+            "result": "f901e5fd1267ecf66a6803278518d006",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04sf_96",
@@ -2785,7 +3132,8 @@
             "source_checksum": "0c1a04af2c8175828c9124de129e20ca",
             "input_file": "al04sf_96.mp4",
             "output_format": "fltp",
-            "result": "edb05b74da0fb44f78dc51c5c8e7369f"
+            "result": "edb05b74da0fb44f78dc51c5c8e7369f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_qmf_32_1",
@@ -2793,7 +3141,8 @@
             "source_checksum": "9ec7742ee6e194a4b585b4e590408ed7",
             "input_file": "al_sbr_qmf_32_1.mp4",
             "output_format": "fltp",
-            "result": "d3029d2c2703211e3696fc05591a92aa"
+            "result": "d3029d2c2703211e3696fc05591a92aa",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_gh_44_2",
@@ -2801,7 +3150,8 @@
             "source_checksum": "d8529b6c87a56472848052670e7f23e3",
             "input_file": "al960_sbr_gh_44_2.mp4",
             "output_format": "fltp",
-            "result": "6fb383777dd84d469e499ba00237635f"
+            "result": "6fb383777dd84d469e499ba00237635f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08sf_12",
@@ -2809,7 +3159,8 @@
             "source_checksum": "ae253dd4329465eeccb0affb70d62b9c",
             "input_file": "al08sf_12.mp4",
             "output_format": "fltp",
-            "result": "a273a49706ea5efed833bcc4df2fd467"
+            "result": "a273a49706ea5efed833bcc4df2fd467",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16_11",
@@ -2817,7 +3168,8 @@
             "source_checksum": "1059cdc022b1bb308eb842a4fd4e52d4",
             "input_file": "al16_11.mp4",
             "output_format": "fltp",
-            "result": "8d4dcbc5964d35450f5f44accb0fa076"
+            "result": "8d4dcbc5964d35450f5f44accb0fa076",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17sf_44",
@@ -2825,7 +3177,8 @@
             "source_checksum": "91c6f9c05fbe3ca1ad03ac3c61f7b8a6",
             "input_file": "al17sf_44.mp4",
             "output_format": "fltp",
-            "result": "784fdd0888e46c9ec4eb50a08fdb3cc6"
+            "result": "784fdd0888e46c9ec4eb50a08fdb3cc6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_i_48_1",
@@ -2833,7 +3186,8 @@
             "source_checksum": "d052544c6583c7bf715e75727a2b3ffb",
             "input_file": "al_sbr_i_48_1.mp4",
             "output_format": "fltp",
-            "result": "1776373e073b22bae1b881ceb019984c"
+            "result": "1776373e073b22bae1b881ceb019984c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01_11",
@@ -2841,7 +3195,8 @@
             "source_checksum": "8318acdee6ce988f68e073ba200a7cf9",
             "input_file": "al01_11.mp4",
             "output_format": "fltp",
-            "result": "68ebaf2c433c13381e815db62a7c3385"
+            "result": "68ebaf2c433c13381e815db62a7c3385",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as08_16",
@@ -2849,7 +3204,8 @@
             "source_checksum": "4e7899af8f739c1b06d7c44ed94be536",
             "input_file": "as08_16.mp4",
             "output_format": "fltp",
-            "result": "de780ed0c5bc65a8b7fc268dda22b8b5"
+            "result": "de780ed0c5bc65a8b7fc268dda22b8b5",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as01_32",
@@ -2857,7 +3213,8 @@
             "source_checksum": "f880bdb9fcbf57d3de87e65e3b5d6e7c",
             "input_file": "as01_32.mp4",
             "output_format": "fltp",
-            "result": "1c0e61a364a51f8e59d34d3f11caba1d"
+            "result": "1c0e61a364a51f8e59d34d3f11caba1d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08_88",
@@ -2865,7 +3222,8 @@
             "source_checksum": "a90054b220701a7e16de00f735051742",
             "input_file": "al08_88.mp4",
             "output_format": "fltp",
-            "result": "fc18f917a53ab031889a5eb3215fcf1e"
+            "result": "fc18f917a53ab031889a5eb3215fcf1e",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05_22",
@@ -2873,7 +3231,8 @@
             "source_checksum": "f74dc46f856a4eaf0e8d9f51a0d3cc60",
             "input_file": "al05_22.mp4",
             "output_format": "fltp",
-            "result": "c297fd5aba3dbe1b55f41757e0ad518d"
+            "result": "c297fd5aba3dbe1b55f41757e0ad518d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as16_88",
@@ -2881,7 +3240,8 @@
             "source_checksum": "b1bcb17c66f458be90013c04494d481f",
             "input_file": "as16_88.mp4",
             "output_format": "fltp",
-            "result": "5a567ba80283799aa51c5883891e6c8a"
+            "result": "5a567ba80283799aa51c5883891e6c8a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am01_48",
@@ -2889,7 +3249,8 @@
             "source_checksum": "bd805934ed8caaf89415f153e94ebbd5",
             "input_file": "am01_48.mp4",
             "output_format": "fltp",
-            "result": "caefa9d212de6d4553691071d144d98c"
+            "result": "caefa9d212de6d4553691071d144d98c",
+            "profile": "AAC Main"
         },
         {
             "name": "am00_32",
@@ -2897,7 +3258,8 @@
             "source_checksum": "bf7d2f5d96d87e40f87bcd4b49712e7b",
             "input_file": "am00_32.mp4",
             "output_format": "fltp",
-            "result": "dff0a5b583b837e9b7586b54299dddba"
+            "result": "dff0a5b583b837e9b7586b54299dddba",
+            "profile": "AAC Main"
         },
         {
             "name": "al960_sbr_s_48_1",
@@ -2905,7 +3267,8 @@
             "source_checksum": "b8d9951f3fe1681f1d1a4f0808385a54",
             "input_file": "al960_sbr_s_48_1.mp4",
             "output_format": "fltp",
-            "result": "21a50c43038a597e8189f26feca1c4b3"
+            "result": "21a50c43038a597e8189f26feca1c4b3",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08sf_44",
@@ -2913,7 +3276,8 @@
             "source_checksum": "adad2d11f9210feb7ee91ed862870251",
             "input_file": "al08sf_44.mp4",
             "output_format": "fltp",
-            "result": "8bb64d92adfe6489adc2bed0a8af25b0"
+            "result": "8bb64d92adfe6489adc2bed0a8af25b0",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03sf_44",
@@ -2921,7 +3285,8 @@
             "source_checksum": "5f2b94996f409e1b45f390fcb60486af",
             "input_file": "al03sf_44.mp4",
             "output_format": "fltp",
-            "result": "bc6428f68eeac99961b07928d5efb76f"
+            "result": "bc6428f68eeac99961b07928d5efb76f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08sf_24",
@@ -2929,7 +3294,8 @@
             "source_checksum": "da351f5cdc7375de4a0ab3ef268bd745",
             "input_file": "al08sf_24.mp4",
             "output_format": "fltp",
-            "result": "e497d939a3b8af75295f7ef8165d1912"
+            "result": "e497d939a3b8af75295f7ef8165d1912",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as13_96",
@@ -2937,7 +3303,8 @@
             "source_checksum": "c64887f5dcff8c1abd69991662b6205d",
             "input_file": "as13_96.mp4",
             "output_format": "fltp",
-            "result": "b0c0fc0d4a72fe2e7755ce33ffccfd14"
+            "result": "b0c0fc0d4a72fe2e7755ce33ffccfd14",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al02_08",
@@ -2945,7 +3312,8 @@
             "source_checksum": "ee3fe98c1b8899c42e09866ee31264a4",
             "input_file": "al02_08.mp4",
             "output_format": "fltp",
-            "result": "48e6870f8ccdcaefacd80036e6971aa4"
+            "result": "48e6870f8ccdcaefacd80036e6971aa4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01_22",
@@ -2953,7 +3321,8 @@
             "source_checksum": "b375a5f20b21d8bba7f77baac3690e4c",
             "input_file": "al01_22.mp4",
             "output_format": "fltp",
-            "result": "bac71f1c4723760f6c595287d8e8f7a1"
+            "result": "bac71f1c4723760f6c595287d8e8f7a1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am06_64",
@@ -2961,7 +3330,8 @@
             "source_checksum": "5e0485aa85d5c4bdc67749e0adaa202d",
             "input_file": "am06_64.mp4",
             "output_format": "fltp",
-            "result": "9c64164b0c509ec00f2848a0be04e823"
+            "result": "9c64164b0c509ec00f2848a0be04e823",
+            "profile": "AAC Main"
         },
         {
             "name": "al02_12",
@@ -2969,7 +3339,8 @@
             "source_checksum": "c3fff529e25417b776e9cc4de7ea14c5",
             "input_file": "al02_12.mp4",
             "output_format": "fltp",
-            "result": "fba7a9108012d70f844bbfe73f862d15"
+            "result": "fba7a9108012d70f844bbfe73f862d15",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05sf_32",
@@ -2977,7 +3348,8 @@
             "source_checksum": "fb451fcca3ea2cb952788de0e7933fae",
             "input_file": "al05sf_32.mp4",
             "output_format": "fltp",
-            "result": "1515aaa1eaa68dcce36c2a31d27dcd82"
+            "result": "1515aaa1eaa68dcce36c2a31d27dcd82",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18_12",
@@ -2985,7 +3357,8 @@
             "source_checksum": "f0187c6c8f2168667209402cc143d287",
             "input_file": "al18_12.mp4",
             "output_format": "fltp",
-            "result": "721af0545b93204b6ddf4372cf5e10c5"
+            "result": "721af0545b93204b6ddf4372cf5e10c5",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as00_96",
@@ -2993,7 +3366,8 @@
             "source_checksum": "e6ddf4e8c464cfc27a15781202132c57",
             "input_file": "as00_96.mp4",
             "output_format": "fltp",
-            "result": "44ea7c5eec39221a7d480380ff7a3ce9"
+            "result": "44ea7c5eec39221a7d480380ff7a3ce9",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al05sf_11",
@@ -3001,7 +3375,8 @@
             "source_checksum": "24ffa1875ca14f6ccaf8329d9beed458",
             "input_file": "al05sf_11.mp4",
             "output_format": "fltp",
-            "result": "915e57e4e3865a3ea6a0d4e89f81ba45"
+            "result": "915e57e4e3865a3ea6a0d4e89f81ba45",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as10_32",
@@ -3009,7 +3384,8 @@
             "source_checksum": "8058e568041f1214c43e6ef32e85d4ba",
             "input_file": "as10_32.mp4",
             "output_format": "fltp",
-            "result": "ab0ddce25aaa8554c5eec91b10c0c546"
+            "result": "ab0ddce25aaa8554c5eec91b10c0c546",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_ps_00_new",
@@ -3017,7 +3393,8 @@
             "source_checksum": "7c5fb10c494b4034e87569906fc539f0",
             "input_file": "al_sbr_ps_00_new.mp4",
             "output_format": "fltp",
-            "result": "32acad45c27fcc6ca9686f9b73872c0c"
+            "result": "32acad45c27fcc6ca9686f9b73872c0c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05_16",
@@ -3025,7 +3402,8 @@
             "source_checksum": "e42f5eac7da03c274fab4a94c7e586c7",
             "input_file": "al05_16.mp4",
             "output_format": "fltp",
-            "result": "3e17aa815d1dfbb8228c0723179d9840"
+            "result": "3e17aa815d1dfbb8228c0723179d9840",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_s_44_1",
@@ -3033,7 +3411,8 @@
             "source_checksum": "73db622719933df9bc75d98b54e5d3b5",
             "input_file": "al_sbr_s_44_1.mp4",
             "output_format": "fltp",
-            "result": "8ca31d4b51f0b8366908b6b420ad91f7"
+            "result": "8ca31d4b51f0b8366908b6b420ad91f7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am06_12",
@@ -3041,7 +3420,8 @@
             "source_checksum": "670b46195b97da9da8b0372710b494f4",
             "input_file": "am06_12.mp4",
             "output_format": "fltp",
-            "result": "c648e55a851558fc8f1370a6e46f2e0e"
+            "result": "c648e55a851558fc8f1370a6e46f2e0e",
+            "profile": "AAC Main"
         },
         {
             "name": "al00_48",
@@ -3049,7 +3429,8 @@
             "source_checksum": "cd6366f7fed82e86241817be2e3e6b39",
             "input_file": "al00_48.mp4",
             "output_format": "fltp",
-            "result": "81aed3ed01060d1453cc96ad6e8e7222"
+            "result": "81aed3ed01060d1453cc96ad6e8e7222",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_88",
@@ -3057,7 +3438,8 @@
             "source_checksum": "87b19eea1e2cf72fd6f14055f20b4124",
             "input_file": "al04_88.mp4",
             "output_format": "fltp",
-            "result": "854a65ea3d37c7357482d415acaf826e"
+            "result": "854a65ea3d37c7357482d415acaf826e",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as13_24",
@@ -3065,7 +3447,8 @@
             "source_checksum": "3557998811c6ab68724b97e70552ea29",
             "input_file": "as13_24.mp4",
             "output_format": "fltp",
-            "result": "486a1bad87cfe813b6fb7cb1586aa32d"
+            "result": "486a1bad87cfe813b6fb7cb1586aa32d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as10_88",
@@ -3073,7 +3456,8 @@
             "source_checksum": "5001a715e54ad20f8fc53fa1b6549713",
             "input_file": "as10_88.mp4",
             "output_format": "fltp",
-            "result": "89d1a1d770e20273220f50c283de459a"
+            "result": "89d1a1d770e20273220f50c283de459a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as10_16",
@@ -3081,7 +3465,8 @@
             "source_checksum": "d680372b0db8de741b2efd7f67098e00",
             "input_file": "as10_16.mp4",
             "output_format": "fltp",
-            "result": "075d22277ae9e0a8b47cd7c028a4d3c0"
+            "result": "075d22277ae9e0a8b47cd7c028a4d3c0",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al16_24",
@@ -3089,7 +3474,8 @@
             "source_checksum": "56e495d1280159e92d018a79d6bdb98d",
             "input_file": "al16_24.mp4",
             "output_format": "fltp",
-            "result": "60b43672daf2a885a164801c21c23b6f"
+            "result": "60b43672daf2a885a164801c21c23b6f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as17_22",
@@ -3097,7 +3483,8 @@
             "source_checksum": "2e6fc7e76d2ba6f2d5b7f6bd949dad20",
             "input_file": "as17_22.mp4",
             "output_format": "fltp",
-            "result": "8f1c79031d95623682ecf9fd8e33392a"
+            "result": "8f1c79031d95623682ecf9fd8e33392a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08_32",
@@ -3105,7 +3492,8 @@
             "source_checksum": "62459de49a6e9be86f8d5bc879e5952e",
             "input_file": "al08_32.mp4",
             "output_format": "fltp",
-            "result": "06501c5f244300b512341a1493c96849"
+            "result": "06501c5f244300b512341a1493c96849",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_s_32_1",
@@ -3113,7 +3501,8 @@
             "source_checksum": "41dce26e032fc35ca19a8127eaa6032f",
             "input_file": "al960_sbr_s_32_1.mp4",
             "output_format": "fltp",
-            "result": "a88bba0a454cee762330e12032992e3c"
+            "result": "a88bba0a454cee762330e12032992e3c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_gh_32_2",
@@ -3121,7 +3510,8 @@
             "source_checksum": "2bc5ce4f62ba8f323c39aa3c34fc6c01",
             "input_file": "al_sbr_gh_32_2.mp4",
             "output_format": "fltp",
-            "result": "535357c32586f633d3bae99f9692b54e"
+            "result": "535357c32586f633d3bae99f9692b54e",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17_08",
@@ -3129,7 +3519,8 @@
             "source_checksum": "80b44362426f21cc514481fde592f492",
             "input_file": "al17_08.mp4",
             "output_format": "fltp",
-            "result": "9ce0c79e5a3b97ba1cd7f9051b9cb813"
+            "result": "9ce0c79e5a3b97ba1cd7f9051b9cb813",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as17_24",
@@ -3137,7 +3528,8 @@
             "source_checksum": "7015de8c53f62f24d1e2b9f9a264ac9e",
             "input_file": "as17_24.mp4",
             "output_format": "fltp",
-            "result": "5ec07fb1254f038776533d41dd00e67e"
+            "result": "5ec07fb1254f038776533d41dd00e67e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am02_48",
@@ -3145,7 +3537,8 @@
             "source_checksum": "45a57892591431abed93dcb5126fc287",
             "input_file": "am02_48.mp4",
             "output_format": "fltp",
-            "result": "41045aa7d349d9fe233869793d48f322"
+            "result": "41045aa7d349d9fe233869793d48f322",
+            "profile": "AAC Main"
         },
         {
             "name": "al03_22",
@@ -3153,7 +3546,8 @@
             "source_checksum": "4dfe4522d7a3f087178be379340ee410",
             "input_file": "al03_22.mp4",
             "output_format": "fltp",
-            "result": "6819ba04cee182d2aa3247ed93b9923d"
+            "result": "6819ba04cee182d2aa3247ed93b9923d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_cm_48_5",
@@ -3161,7 +3555,8 @@
             "source_checksum": "9061405c961b6ea6746820d0148797fe",
             "input_file": "al_sbr_cm_48_5.mp4",
             "output_format": "fltp",
-            "result": "7784c903d7f17b98581f04c7425a07f4"
+            "result": "7784c903d7f17b98581f04c7425a07f4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_88",
@@ -3169,7 +3564,8 @@
             "source_checksum": "5d39ca3d821e014b61465a96537b14ea",
             "input_file": "am00_88.mp4",
             "output_format": "fltp",
-            "result": "2c28bbe633abb0995a7d9d6b2bbd163c"
+            "result": "2c28bbe633abb0995a7d9d6b2bbd163c",
+            "profile": "AAC Main"
         },
         {
             "name": "al_sbr_sr_48_2_fsaac24",
@@ -3177,7 +3573,8 @@
             "source_checksum": "9a3207a28b042f2689f27377d1891f12",
             "input_file": "al_sbr_sr_48_2_fsaac24.mp4",
             "output_format": "fltp",
-            "result": "0067d37aa712b90303a9b60e9648ca9c"
+            "result": "0067d37aa712b90303a9b60e9648ca9c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16sf_44",
@@ -3185,7 +3582,8 @@
             "source_checksum": "8229f887c1d564e136394a654ba406bd",
             "input_file": "al16sf_44.mp4",
             "output_format": "fltp",
-            "result": "b364313bc224edfe5f40d49cbd14dc3a"
+            "result": "b364313bc224edfe5f40d49cbd14dc3a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am04_08",
@@ -3193,7 +3591,8 @@
             "source_checksum": "946b536b995470f91bf5f7a1e6c4390e",
             "input_file": "am04_08.mp4",
             "output_format": "fltp",
-            "result": "c38e48672d70d47fbf2712935eb94cc4"
+            "result": "c38e48672d70d47fbf2712935eb94cc4",
+            "profile": "AAC Main"
         },
         {
             "name": "al05_64",
@@ -3201,7 +3600,8 @@
             "source_checksum": "0e8db5457d591fa8c76a664b528db698",
             "input_file": "al05_64.mp4",
             "output_format": "fltp",
-            "result": "fd32fac5c93040674baf30e5ebf57c52"
+            "result": "fd32fac5c93040674baf30e5ebf57c52",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as14_16",
@@ -3209,7 +3609,8 @@
             "source_checksum": "686815d71fd3cbdb672dec42013dd71b",
             "input_file": "as14_16.mp4",
             "output_format": "fltp",
-            "result": "2a3e842a15a7bc5c13a0832551b42511"
+            "result": "2a3e842a15a7bc5c13a0832551b42511",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_i_32_1_new",
@@ -3217,7 +3618,8 @@
             "source_checksum": "191d4ad6fd4aa33bba03fe046ee0aeeb",
             "input_file": "al_sbr_i_32_1_new.mp4",
             "output_format": "fltp",
-            "result": "9897fc5a545797dfe6693efaa551343d"
+            "result": "9897fc5a545797dfe6693efaa551343d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06sf_22",
@@ -3225,7 +3627,8 @@
             "source_checksum": "4a5f502eebfd5a5a1cc598367e5c7cb2",
             "input_file": "al06sf_22.mp4",
             "output_format": "fltp",
-            "result": "f50bd18a7adc9a417550c3499a277d16"
+            "result": "f50bd18a7adc9a417550c3499a277d16",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_48",
@@ -3233,7 +3636,8 @@
             "source_checksum": "b23300879dc9ac8b3f84435169a589e1",
             "input_file": "al04_48.mp4",
             "output_format": "fltp",
-            "result": "1f04cda750065aad2633d369241e9aed"
+            "result": "1f04cda750065aad2633d369241e9aed",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as07_12",
@@ -3241,7 +3645,8 @@
             "source_checksum": "9980c9ae83e1e1beb9cc22352cd248a7",
             "input_file": "as07_12.mp4",
             "output_format": "fltp",
-            "result": "b166a694a0cf6373bea354e056d5910b"
+            "result": "b166a694a0cf6373bea354e056d5910b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al19sf_08",
@@ -3249,7 +3654,8 @@
             "source_checksum": "62b84a4b3a3eace5498dee792fce3b63",
             "input_file": "al19sf_08.mp4",
             "output_format": "fltp",
-            "result": "64d301b16399d5ad296ec3dbd216ecde"
+            "result": "64d301b16399d5ad296ec3dbd216ecde",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00sf_08",
@@ -3257,7 +3663,8 @@
             "source_checksum": "0c3e82af6f22daddccf34c1932e8e5c6",
             "input_file": "al00sf_08.mp4",
             "output_format": "fltp",
-            "result": "974fc5db0dd85a5240956a8a5e593469"
+            "result": "974fc5db0dd85a5240956a8a5e593469",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05sf_12",
@@ -3265,7 +3672,8 @@
             "source_checksum": "09d3a666bc9eb0f93e8a11c7fac48ee1",
             "input_file": "al05sf_12.mp4",
             "output_format": "fltp",
-            "result": "afbc1483e6a4a6dc56901b63b047969f"
+            "result": "afbc1483e6a4a6dc56901b63b047969f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18sf_22",
@@ -3273,7 +3681,8 @@
             "source_checksum": "8ef3828683844ed928ca7b4f9a547f38",
             "input_file": "al18sf_22.mp4",
             "output_format": "fltp",
-            "result": "55774039a7d9a8f590a198c4424aa3be"
+            "result": "55774039a7d9a8f590a198c4424aa3be",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as00_64",
@@ -3281,7 +3690,8 @@
             "source_checksum": "4bba3fba1c9591880d8301bb9c415f77",
             "input_file": "as00_64.mp4",
             "output_format": "fltp",
-            "result": "1b1b0e509d85afae5f2b6df6ddecbadd"
+            "result": "1b1b0e509d85afae5f2b6df6ddecbadd",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_ps_04",
@@ -3289,7 +3699,8 @@
             "source_checksum": "596100860fe4ed5e53fcfcd5a1648f73",
             "input_file": "al_sbr_ps_04.mp4",
             "output_format": "fltp",
-            "result": "39af940a4c17958c9f3c0ebdf0d5f830"
+            "result": "39af940a4c17958c9f3c0ebdf0d5f830",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01_24",
@@ -3297,7 +3708,8 @@
             "source_checksum": "6618551acf5368df3246e6b9625bc53e",
             "input_file": "al01_24.mp4",
             "output_format": "fltp",
-            "result": "2a1f9b80e590bf4009bdcc7feab11a47"
+            "result": "2a1f9b80e590bf4009bdcc7feab11a47",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am01_08",
@@ -3305,7 +3717,8 @@
             "source_checksum": "0cc565164f128fe7e95df2d7f918aa37",
             "input_file": "am01_08.mp4",
             "output_format": "fltp",
-            "result": "2fcc843014bca5b1ac137a5227478579"
+            "result": "2fcc843014bca5b1ac137a5227478579",
+            "profile": "AAC Main"
         },
         {
             "name": "al16_32",
@@ -3313,7 +3726,8 @@
             "source_checksum": "f599b1a5580bf0362cf8830e7db678e7",
             "input_file": "al16_32.mp4",
             "output_format": "fltp",
-            "result": "dc2e69c4a698b9b0f5cae72a92cf2af7"
+            "result": "dc2e69c4a698b9b0f5cae72a92cf2af7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_sr_88_2_fsaac44",
@@ -3321,7 +3735,8 @@
             "source_checksum": "11065bff2f92ce7fce67aa83a43d48b5",
             "input_file": "al_sbr_sr_88_2_fsaac44.mp4",
             "output_format": "fltp",
-            "result": "d273c2d2e4fbbf838526909b52eb4bdf"
+            "result": "d273c2d2e4fbbf838526909b52eb4bdf",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04sf_22",
@@ -3329,7 +3744,8 @@
             "source_checksum": "ecb7092c35f7cc8103bed85626371ba3",
             "input_file": "al04sf_22.mp4",
             "output_format": "fltp",
-            "result": "4fc2b48d87982cf7a70e12d167d3c1dd"
+            "result": "4fc2b48d87982cf7a70e12d167d3c1dd",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07_96",
@@ -3337,7 +3753,8 @@
             "source_checksum": "7e561b5baa80f810ea925e0c94962be7",
             "input_file": "al07_96.mp4",
             "output_format": "fltp",
-            "result": "a6a2782f869b6a1e52f89a6eca8519e4"
+            "result": "a6a2782f869b6a1e52f89a6eca8519e4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_16",
@@ -3345,7 +3762,8 @@
             "source_checksum": "2cafacf01ee22ca81c571ffba0613f30",
             "input_file": "am00_16.mp4",
             "output_format": "fltp",
-            "result": "2f5b31721e04afd861d59a6194308565"
+            "result": "2f5b31721e04afd861d59a6194308565",
+            "profile": "AAC Main"
         },
         {
             "name": "as04_16",
@@ -3353,7 +3771,8 @@
             "source_checksum": "03a8fc0507437b4e176c22ce6d21e50b",
             "input_file": "as04_16.mp4",
             "output_format": "fltp",
-            "result": "2aa8ede9facecfd47e2da49c7e0b0bf1"
+            "result": "2aa8ede9facecfd47e2da49c7e0b0bf1",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as03_11",
@@ -3361,7 +3780,8 @@
             "source_checksum": "1f09faf75b79afdb8c760a77b82632d5",
             "input_file": "as03_11.mp4",
             "output_format": "fltp",
-            "result": "5ae89c7acd05098ab622609fc0ea2750"
+            "result": "5ae89c7acd05098ab622609fc0ea2750",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am01_44",
@@ -3369,7 +3789,8 @@
             "source_checksum": "361d719e2ac4093db07011d60456b082",
             "input_file": "am01_44.mp4",
             "output_format": "fltp",
-            "result": "bd59a63283c94d5f5c0c0046d06481e9"
+            "result": "bd59a63283c94d5f5c0c0046d06481e9",
+            "profile": "AAC Main"
         },
         {
             "name": "al14sf_44",
@@ -3377,7 +3798,8 @@
             "source_checksum": "5a3d435c4846b028a89bbdce9983304e",
             "input_file": "al14sf_44.mp4",
             "output_format": "fltp",
-            "result": "1ea3fc56401dc70963f7a6d7897a7377"
+            "result": "1ea3fc56401dc70963f7a6d7897a7377",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as15_32",
@@ -3385,7 +3807,8 @@
             "source_checksum": "47075e542067cf5cb0929307152b69d0",
             "input_file": "as15_32.mp4",
             "output_format": "fltp",
-            "result": "8e7cc241fb0039eed1712cb8548f4fb8"
+            "result": "8e7cc241fb0039eed1712cb8548f4fb8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am05_64",
@@ -3393,7 +3816,8 @@
             "source_checksum": "e3fea348af3f8f4d251e156c3580739c",
             "input_file": "am05_64.mp4",
             "output_format": "fltp",
-            "result": "f884c483eaf0efac5c184a0a7b3d9b0e"
+            "result": "f884c483eaf0efac5c184a0a7b3d9b0e",
+            "profile": "AAC Main"
         },
         {
             "name": "as01_12",
@@ -3401,7 +3825,8 @@
             "source_checksum": "7d49c20438ba9a0105a73918c0b66b7d",
             "input_file": "as01_12.mp4",
             "output_format": "fltp",
-            "result": "d83c4c702798b93f6e57812c4064ab1f"
+            "result": "d83c4c702798b93f6e57812c4064ab1f",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as10_44",
@@ -3409,7 +3834,8 @@
             "source_checksum": "a566fea96fb45fdaa5e4292d51f7f359",
             "input_file": "as10_44.mp4",
             "output_format": "fltp",
-            "result": "66442b358ffc0b17ff458ebcb910a78d"
+            "result": "66442b358ffc0b17ff458ebcb910a78d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al19_16",
@@ -3417,7 +3843,8 @@
             "source_checksum": "b55947ba9d2966e4a84fc984cf2b7c82",
             "input_file": "al19_16.mp4",
             "output_format": "fltp",
-            "result": "cbf233464d9c8d6cdbca27723e744da8"
+            "result": "cbf233464d9c8d6cdbca27723e744da8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as09_22",
@@ -3425,7 +3852,8 @@
             "source_checksum": "a82ebabe9147f7dd88bc6d66852d16ee",
             "input_file": "as09_22.mp4",
             "output_format": "fltp",
-            "result": "6b70f0fe4befa112330a1b4ca9ddd465"
+            "result": "6b70f0fe4befa112330a1b4ca9ddd465",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as09_48",
@@ -3433,7 +3861,8 @@
             "source_checksum": "8004bb65fbf47c00666a32c9ee00d644",
             "input_file": "as09_48.mp4",
             "output_format": "fltp",
-            "result": "27d560f65a1e11a757ad189a1f8bde77"
+            "result": "27d560f65a1e11a757ad189a1f8bde77",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_e_32_1",
@@ -3441,7 +3870,8 @@
             "source_checksum": "49e90e0f2d2910d4cfe261fc6bbda42f",
             "input_file": "al_sbr_e_32_1.mp4",
             "output_format": "fltp",
-            "result": "3b1d9dfecc717761088ff96a431115e5"
+            "result": "3b1d9dfecc717761088ff96a431115e5",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17_88",
@@ -3449,7 +3879,8 @@
             "source_checksum": "72fdc70697b00fe9a8495bc418c5b70a",
             "input_file": "al17_88.mp4",
             "output_format": "fltp",
-            "result": "ad70e0b02635cfcb30c928dc70b4ef05"
+            "result": "ad70e0b02635cfcb30c928dc70b4ef05",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03_11",
@@ -3457,7 +3888,8 @@
             "source_checksum": "e7663a1b6ac7de4f706d4dd92362d378",
             "input_file": "al03_11.mp4",
             "output_format": "fltp",
-            "result": "cb5054b764e9019be9d0fcbfe3776835"
+            "result": "cb5054b764e9019be9d0fcbfe3776835",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00sf_48",
@@ -3465,7 +3897,8 @@
             "source_checksum": "25ad69747d03ae0ac7d418f4ce39daea",
             "input_file": "al00sf_48.mp4",
             "output_format": "fltp",
-            "result": "81aed3ed01060d1453cc96ad6e8e7222"
+            "result": "81aed3ed01060d1453cc96ad6e8e7222",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18_08",
@@ -3473,7 +3906,8 @@
             "source_checksum": "c946f1f016063a413f968a13be610716",
             "input_file": "al18_08.mp4",
             "output_format": "fltp",
-            "result": "b2927751ae7a97613a9d9d0d2748eca7"
+            "result": "b2927751ae7a97613a9d9d0d2748eca7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am06_48",
@@ -3481,7 +3915,8 @@
             "source_checksum": "702e52f621d0d8132c1f9a71b258973d",
             "input_file": "am06_48.mp4",
             "output_format": "fltp",
-            "result": "16d6f33a5e10cab33fc2e886dcec76b2"
+            "result": "16d6f33a5e10cab33fc2e886dcec76b2",
+            "profile": "AAC Main"
         },
         {
             "name": "as08_44",
@@ -3489,7 +3924,8 @@
             "source_checksum": "04f26e1a759b3c6dc832ba2ece1a99e1",
             "input_file": "as08_44.mp4",
             "output_format": "fltp",
-            "result": "cf0ed6a192d5677699cdd2d0ed48690e"
+            "result": "cf0ed6a192d5677699cdd2d0ed48690e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06_08",
@@ -3497,7 +3933,8 @@
             "source_checksum": "05efe944476e4f1f22f3369dd3a0eb4d",
             "input_file": "al06_08.mp4",
             "output_format": "fltp",
-            "result": "45e04543ce989cb061362b84855d6107"
+            "result": "45e04543ce989cb061362b84855d6107",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08sf_32",
@@ -3505,7 +3942,8 @@
             "source_checksum": "338b1e7b27644c6951324baa3e075eea",
             "input_file": "al08sf_32.mp4",
             "output_format": "fltp",
-            "result": "e64a8285a6107c98d1b8ba87c6fd57d2"
+            "result": "e64a8285a6107c98d1b8ba87c6fd57d2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al19_64",
@@ -3513,7 +3951,8 @@
             "source_checksum": "bbadeae1fb61300620b18c1323466584",
             "input_file": "al19_64.mp4",
             "output_format": "fltp",
-            "result": "c063c9667651a1ee43c6d6a539d6f1b6"
+            "result": "c063c9667651a1ee43c6d6a539d6f1b6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am05_88",
@@ -3521,7 +3960,8 @@
             "source_checksum": "a95635aba8b3c7a1dc3c53da736461d0",
             "input_file": "am05_88.mp4",
             "output_format": "fltp",
-            "result": "89acab9b6fe4bc4d144ef02c29eb89e8"
+            "result": "89acab9b6fe4bc4d144ef02c29eb89e8",
+            "profile": "AAC Main"
         },
         {
             "name": "al_sbr_ps_00",
@@ -3529,7 +3969,8 @@
             "source_checksum": "1289909057f413705e21e636c333929b",
             "input_file": "al_sbr_ps_00.mp4",
             "output_format": "fltp",
-            "result": "32acad45c27fcc6ca9686f9b73872c0c"
+            "result": "32acad45c27fcc6ca9686f9b73872c0c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16_16",
@@ -3537,7 +3978,8 @@
             "source_checksum": "f34efbd30a07ed4240a77e9cadf66b51",
             "input_file": "al16_16.mp4",
             "output_format": "fltp",
-            "result": "0bc72c62df843828b386be714b0fb5fe"
+            "result": "0bc72c62df843828b386be714b0fb5fe",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as07_64",
@@ -3545,7 +3987,8 @@
             "source_checksum": "c2dbe49ff073639b4fe2c96e2c3255d4",
             "input_file": "as07_64.mp4",
             "output_format": "fltp",
-            "result": "c8dccbd7a2c94b812341b369757f2cf6"
+            "result": "c8dccbd7a2c94b812341b369757f2cf6",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_cm_48_2",
@@ -3553,7 +3996,8 @@
             "source_checksum": "878de38bdc2098de27bbf0c197b53f13",
             "input_file": "al_sbr_cm_48_2.mp4",
             "output_format": "fltp",
-            "result": "e995e2813134404aebbbad49270a2cae"
+            "result": "e995e2813134404aebbbad49270a2cae",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al19sf_48",
@@ -3561,7 +4005,8 @@
             "source_checksum": "d1837c5c2020aec89317235fce6dcf7c",
             "input_file": "al19sf_48.mp4",
             "output_format": "fltp",
-            "result": "5557f7070528f4d5aeb1a69655d934e9"
+            "result": "5557f7070528f4d5aeb1a69655d934e9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_i_44_1",
@@ -3569,7 +4014,8 @@
             "source_checksum": "7da09760f4387b6ba5acf9c8febcf713",
             "input_file": "al_sbr_i_44_1.mp4",
             "output_format": "fltp",
-            "result": "7de302e5dca81689c8ffb5fb3646482e"
+            "result": "7de302e5dca81689c8ffb5fb3646482e",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_e_48_2",
@@ -3577,7 +4023,8 @@
             "source_checksum": "c437f7aa57eb4759699921ef97841525",
             "input_file": "al_sbr_e_48_2.mp4",
             "output_format": "fltp",
-            "result": "c11a645ae695347d7a537d217a3c525b"
+            "result": "c11a645ae695347d7a537d217a3c525b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05_44",
@@ -3585,7 +4032,8 @@
             "source_checksum": "b29aa529c53cab58795e62eb7818685c",
             "input_file": "al05_44.mp4",
             "output_format": "fltp",
-            "result": "33f981c92cde037b3941040e2ae8bafa"
+            "result": "33f981c92cde037b3941040e2ae8bafa",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14_64",
@@ -3593,7 +4041,8 @@
             "source_checksum": "c0c4ad65a59c92b2bb355250c17b933f",
             "input_file": "al14_64.mp4",
             "output_format": "fltp",
-            "result": "fee87c426ffe310d83008121fa592bd9"
+            "result": "fee87c426ffe310d83008121fa592bd9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08sf_22",
@@ -3601,7 +4050,8 @@
             "source_checksum": "e325d7345813c03e3d9fbdb13927268e",
             "input_file": "al08sf_22.mp4",
             "output_format": "fltp",
-            "result": "dec77b61bcff3f2d211248abcb521963"
+            "result": "dec77b61bcff3f2d211248abcb521963",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03_08",
@@ -3609,7 +4059,8 @@
             "source_checksum": "c1e1b1b960fd00d52f0a7b1ba6c4df03",
             "input_file": "al03_08.mp4",
             "output_format": "fltp",
-            "result": "9e0c9f7586ea7460b87d47f03a2e64d9"
+            "result": "9e0c9f7586ea7460b87d47f03a2e64d9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am02_11",
@@ -3617,7 +4068,8 @@
             "source_checksum": "43d9f6c2a4a45ad7ebec3aa365f6af34",
             "input_file": "am02_11.mp4",
             "output_format": "fltp",
-            "result": "90a57c1f6b8d6d79b8356b734c1c98e4"
+            "result": "90a57c1f6b8d6d79b8356b734c1c98e4",
+            "profile": "AAC Main"
         },
         {
             "name": "al960_sbr_gh_48_1",
@@ -3625,7 +4077,8 @@
             "source_checksum": "dc76be858b2f52b63a3ac31664ae5068",
             "input_file": "al960_sbr_gh_48_1.mp4",
             "output_format": "fltp",
-            "result": "af071ff156490381e4dabd1a481f4cf5"
+            "result": "af071ff156490381e4dabd1a481f4cf5",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01sf_32",
@@ -3633,7 +4086,8 @@
             "source_checksum": "621cf292764263787e1d2294c9da6ff5",
             "input_file": "al01sf_32.mp4",
             "output_format": "fltp",
-            "result": "62c5dda7e168f22fe5d1f45e4b8626a1"
+            "result": "62c5dda7e168f22fe5d1f45e4b8626a1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07sf_22",
@@ -3641,7 +4095,8 @@
             "source_checksum": "59504e213fb5d141fe02b2a2537f7e01",
             "input_file": "al07sf_22.mp4",
             "output_format": "fltp",
-            "result": "fc08bb87b480477170e755f76abac8ae"
+            "result": "fc08bb87b480477170e755f76abac8ae",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as04_32",
@@ -3649,7 +4104,8 @@
             "source_checksum": "5d0bd68b8541b01f3e890c8d543fac45",
             "input_file": "as04_32.mp4",
             "output_format": "fltp",
-            "result": "5d727123f8f9b07c5e0eae9bf445b72e"
+            "result": "5d727123f8f9b07c5e0eae9bf445b72e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_sig_48_2_sig1",
@@ -3657,7 +4113,8 @@
             "source_checksum": "51710c3362c2eb1f2c0b3eb4b28d2f23",
             "input_file": "al_sbr_sig_48_2_sig1.mp4",
             "output_format": "fltp",
-            "result": "0067d37aa712b90303a9b60e9648ca9c"
+            "result": "0067d37aa712b90303a9b60e9648ca9c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17_11",
@@ -3665,7 +4122,8 @@
             "source_checksum": "b761d19038a0311c35cb2f755581dc64",
             "input_file": "al17_11.mp4",
             "output_format": "fltp",
-            "result": "77d09b536b5c5cc251faa21e5aecb413"
+            "result": "77d09b536b5c5cc251faa21e5aecb413",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01_08",
@@ -3673,7 +4131,8 @@
             "source_checksum": "4b82c44a4495789bc15262c242b65123",
             "input_file": "al01_08.mp4",
             "output_format": "fltp",
-            "result": "341ba3ace921eb3a805d31cb5c69852a"
+            "result": "341ba3ace921eb3a805d31cb5c69852a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_qmf_44_1",
@@ -3681,7 +4140,8 @@
             "source_checksum": "8c185c545b6920328923c9e119015ba5",
             "input_file": "al960_sbr_qmf_44_1.mp4",
             "output_format": "fltp",
-            "result": "4ea217578f3e0cfc88d8754b24d4c8f0"
+            "result": "4ea217578f3e0cfc88d8754b24d4c8f0",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07sf_96",
@@ -3689,7 +4149,8 @@
             "source_checksum": "f6a1ceaaf805494e859fa98817f02cf1",
             "input_file": "al07sf_96.mp4",
             "output_format": "fltp",
-            "result": "a6a2782f869b6a1e52f89a6eca8519e4"
+            "result": "a6a2782f869b6a1e52f89a6eca8519e4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_sr_16_2_fsaac16",
@@ -3697,7 +4158,8 @@
             "source_checksum": "83707bc096568aa0599364441da254a0",
             "input_file": "al_sbr_sr_16_2_fsaac16.mp4",
             "output_format": "fltp",
-            "result": "7632c304b995cd9a242f4c0a26cd11eb"
+            "result": "7632c304b995cd9a242f4c0a26cd11eb",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as11_96",
@@ -3705,7 +4167,8 @@
             "source_checksum": "de27ae692e901e74dbcd4d3906131fcf",
             "input_file": "as11_96.mp4",
             "output_format": "fltp",
-            "result": "3877801e23700673823b2678c93c8e3e"
+            "result": "3877801e23700673823b2678c93c8e3e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as16_16",
@@ -3713,7 +4176,8 @@
             "source_checksum": "7b2e8fe46f2f80c5ececa21f37fbcd2e",
             "input_file": "as16_16.mp4",
             "output_format": "fltp",
-            "result": "59e85a5af3cc9b8010d7544a3e04ab0b"
+            "result": "59e85a5af3cc9b8010d7544a3e04ab0b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as05_96",
@@ -3721,7 +4185,8 @@
             "source_checksum": "377f9a0aff3e7316c544db6b92f788c2",
             "input_file": "as05_96.mp4",
             "output_format": "fltp",
-            "result": "692a1720c71b0f8ed917ddf21a38f390"
+            "result": "692a1720c71b0f8ed917ddf21a38f390",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08_11",
@@ -3729,7 +4194,8 @@
             "source_checksum": "32a04ca4afa3169cd6ebf415733ad7cb",
             "input_file": "al08_11.mp4",
             "output_format": "fltp",
-            "result": "d8c40ec2fdc54badf9adfff75031b79a"
+            "result": "d8c40ec2fdc54badf9adfff75031b79a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as09_16",
@@ -3737,7 +4203,8 @@
             "source_checksum": "3a258273cc5fa46bb765dcb103097edc",
             "input_file": "as09_16.mp4",
             "output_format": "fltp",
-            "result": "5a610ae32b3dc675c9b76f7d31426795"
+            "result": "5a610ae32b3dc675c9b76f7d31426795",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al01sf_22",
@@ -3745,7 +4212,8 @@
             "source_checksum": "87457ed95eb206ce0066c72c3abbc30a",
             "input_file": "al01sf_22.mp4",
             "output_format": "fltp",
-            "result": "bac71f1c4723760f6c595287d8e8f7a1"
+            "result": "bac71f1c4723760f6c595287d8e8f7a1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02sf_96",
@@ -3753,7 +4221,8 @@
             "source_checksum": "23d41b62d5c798a70702422f7b373abe",
             "input_file": "al02sf_96.mp4",
             "output_format": "fltp",
-            "result": "c91d263e846628e4060cdef6c9b5c81d"
+            "result": "c91d263e846628e4060cdef6c9b5c81d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am07_22",
@@ -3761,7 +4230,8 @@
             "source_checksum": "f8e817085063beab9c2e27885f82bb64",
             "input_file": "am07_22.mp4",
             "output_format": "fltp",
-            "result": "8ac9f283f1f280bcc8b0e7b1648225b4"
+            "result": "8ac9f283f1f280bcc8b0e7b1648225b4",
+            "profile": "AAC Main"
         },
         {
             "name": "al_sbr_s_48_1",
@@ -3769,7 +4239,8 @@
             "source_checksum": "47ef66d48ae5531b69896add749368ee",
             "input_file": "al_sbr_s_48_1.mp4",
             "output_format": "fltp",
-            "result": "1f0cede469d71bc4328a9157b8225e57"
+            "result": "1f0cede469d71bc4328a9157b8225e57",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16_08",
@@ -3777,7 +4248,8 @@
             "source_checksum": "1a67d3584403b85e3a0f3c2fa36f7d50",
             "input_file": "al16_08.mp4",
             "output_format": "fltp",
-            "result": "7f65c99d709dae8d35f31a55b78837a4"
+            "result": "7f65c99d709dae8d35f31a55b78837a4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as11_32",
@@ -3785,7 +4257,8 @@
             "source_checksum": "68b82a241d8e9e211412440ec014c7c0",
             "input_file": "as11_32.mp4",
             "output_format": "fltp",
-            "result": "52b9b783e682ce807b26425bfd01bbe7"
+            "result": "52b9b783e682ce807b26425bfd01bbe7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_i_48_1_new",
@@ -3793,7 +4266,8 @@
             "source_checksum": "a9a67a69b6a676c273685b77f81d1528",
             "input_file": "al_sbr_i_48_1_new.mp4",
             "output_format": "fltp",
-            "result": "08516898b4cd40d98c51b8c329911485"
+            "result": "08516898b4cd40d98c51b8c329911485",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18_24",
@@ -3801,7 +4275,8 @@
             "source_checksum": "e0047fd1173f0bfe9b53b9e683ee13bb",
             "input_file": "al18_24.mp4",
             "output_format": "fltp",
-            "result": "9c650228dea2c563560dcf3fbc31bff1"
+            "result": "9c650228dea2c563560dcf3fbc31bff1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06_11",
@@ -3809,7 +4284,8 @@
             "source_checksum": "bc8794a266ab4892163bdeca474bc6dc",
             "input_file": "al06_11.mp4",
             "output_format": "fltp",
-            "result": "7a87c14fd11bbc3b60aa9e4f33c197f1"
+            "result": "7a87c14fd11bbc3b60aa9e4f33c197f1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as06_32",
@@ -3817,7 +4293,8 @@
             "source_checksum": "93aa58eac841d0dd885607905ae9e514",
             "input_file": "as06_32.mp4",
             "output_format": "fltp",
-            "result": "fcf22800a2bd08404106ba73071589e9"
+            "result": "fcf22800a2bd08404106ba73071589e9",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as14_32",
@@ -3825,7 +4302,8 @@
             "source_checksum": "cbf0c36119afc25dd1d31232ffd43e74",
             "input_file": "as14_32.mp4",
             "output_format": "fltp",
-            "result": "0bd5427b27904bc462acf174b3b7f413"
+            "result": "0bd5427b27904bc462acf174b3b7f413",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as04_24",
@@ -3833,7 +4311,8 @@
             "source_checksum": "412146438500065cf6879587d9d9130c",
             "input_file": "as04_24.mp4",
             "output_format": "fltp",
-            "result": "05807367a5683dedb6d3d549cd10db77"
+            "result": "05807367a5683dedb6d3d549cd10db77",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_gh_44_2",
@@ -3841,7 +4320,8 @@
             "source_checksum": "233d3417b96149bae78a49a7271ee442",
             "input_file": "al_sbr_gh_44_2.mp4",
             "output_format": "fltp",
-            "result": "cca108702ce5c0285a40657b6d1ae5f5"
+            "result": "cca108702ce5c0285a40657b6d1ae5f5",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17_16",
@@ -3849,7 +4329,8 @@
             "source_checksum": "b6b39006eb0a8d9adff466ece23794ef",
             "input_file": "al17_16.mp4",
             "output_format": "fltp",
-            "result": "578f691643c105bc6e12665c4f595a0a"
+            "result": "578f691643c105bc6e12665c4f595a0a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02sf_88",
@@ -3857,7 +4338,8 @@
             "source_checksum": "feb6615811409aca30c98c14e23df993",
             "input_file": "al02sf_88.mp4",
             "output_format": "fltp",
-            "result": "ea940a21c761f8e87cb3b2b8ceb91ebd"
+            "result": "ea940a21c761f8e87cb3b2b8ceb91ebd",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as01_48",
@@ -3865,7 +4347,8 @@
             "source_checksum": "4df496356317b2f7c9ab30d638313cbc",
             "input_file": "as01_48.mp4",
             "output_format": "fltp",
-            "result": "39601f6c36e9bed60b5e2b1d700a9acf"
+            "result": "39601f6c36e9bed60b5e2b1d700a9acf",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_ps_04_new",
@@ -3873,7 +4356,8 @@
             "source_checksum": "568183c0cdc6c457615f513c0f69aa14",
             "input_file": "al_sbr_ps_04_new.mp4",
             "output_format": "fltp",
-            "result": "39af940a4c17958c9f3c0ebdf0d5f830"
+            "result": "39af940a4c17958c9f3c0ebdf0d5f830",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16_64",
@@ -3881,7 +4365,8 @@
             "source_checksum": "15405956bcffeac73437683938222e0b",
             "input_file": "al16_64.mp4",
             "output_format": "fltp",
-            "result": "637ff0208bfe1f2e69e5ecf70232b2c2"
+            "result": "637ff0208bfe1f2e69e5ecf70232b2c2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am02_16",
@@ -3889,7 +4374,8 @@
             "source_checksum": "793b296d3099767c80f61f2638e1fbe7",
             "input_file": "am02_16.mp4",
             "output_format": "fltp",
-            "result": "424bf0862916cb427c09a4c3a1a1f05a"
+            "result": "424bf0862916cb427c09a4c3a1a1f05a",
+            "profile": "AAC Main"
         },
         {
             "name": "al17_64",
@@ -3897,7 +4383,8 @@
             "source_checksum": "077bf181b5ad396cf05869612dabcfc8",
             "input_file": "al17_64.mp4",
             "output_format": "fltp",
-            "result": "9c3bc834d40d27a441ab80ae72eda8c4"
+            "result": "9c3bc834d40d27a441ab80ae72eda8c4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as10_64",
@@ -3905,7 +4392,8 @@
             "source_checksum": "66d4345f49153feb4b4d62ca06cc89ff",
             "input_file": "as10_64.mp4",
             "output_format": "fltp",
-            "result": "f098fc1ece5df2f3e5ae72b49f7801ec"
+            "result": "f098fc1ece5df2f3e5ae72b49f7801ec",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_qmf_44_1",
@@ -3913,7 +4401,8 @@
             "source_checksum": "49e24a234a72f0b50d0fbed854bacf89",
             "input_file": "al_sbr_qmf_44_1.mp4",
             "output_format": "fltp",
-            "result": "745d413ac4b8be2fceffcf3f94e069d2"
+            "result": "745d413ac4b8be2fceffcf3f94e069d2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as12_22",
@@ -3921,7 +4410,8 @@
             "source_checksum": "79da384fc8e245c6291989feddc9a3b1",
             "input_file": "as12_22.mp4",
             "output_format": "fltp",
-            "result": "793bdf4e548eec828ae840f15c7c8417"
+            "result": "793bdf4e548eec828ae840f15c7c8417",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al18sf_11",
@@ -3929,7 +4419,8 @@
             "source_checksum": "bf97a2a9057e211a5a4c3998a00ee10c",
             "input_file": "al18sf_11.mp4",
             "output_format": "fltp",
-            "result": "621bfe9dc4c755520ae97b2f400c563a"
+            "result": "621bfe9dc4c755520ae97b2f400c563a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as14_11",
@@ -3937,7 +4428,8 @@
             "source_checksum": "e842304ce84f248dc9f42cf782d2d294",
             "input_file": "as14_11.mp4",
             "output_format": "fltp",
-            "result": "4c7845eec51c8150995db35c55843c0b"
+            "result": "4c7845eec51c8150995db35c55843c0b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al960_sbr_i_48_2",
@@ -3945,7 +4437,8 @@
             "source_checksum": "34818d6ef2f6715fec963ff847340b71",
             "input_file": "al960_sbr_i_48_2.mp4",
             "output_format": "fltp",
-            "result": "1802909755b8a04996034b587ca7b2da"
+            "result": "1802909755b8a04996034b587ca7b2da",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06sf_96",
@@ -3953,7 +4446,8 @@
             "source_checksum": "5c7d524b1cdb9374ac790b20a59cc74c",
             "input_file": "al06sf_96.mp4",
             "output_format": "fltp",
-            "result": "84e167d143354c50928dfbc54a4b88a2"
+            "result": "84e167d143354c50928dfbc54a4b88a2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am06_08",
@@ -3961,7 +4455,8 @@
             "source_checksum": "ff36a115598cab35eb8ff42237451ab4",
             "input_file": "am06_08.mp4",
             "output_format": "fltp",
-            "result": "45c69a627acad058b41cced226857ba6"
+            "result": "45c69a627acad058b41cced226857ba6",
+            "profile": "AAC Main"
         },
         {
             "name": "al14sf_32",
@@ -3969,7 +4464,8 @@
             "source_checksum": "161d4b00cb5d5b185ed72faf23b245e5",
             "input_file": "al14sf_32.mp4",
             "output_format": "fltp",
-            "result": "72f133b209330a1f080383a4023dd753"
+            "result": "72f133b209330a1f080383a4023dd753",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_12",
@@ -3977,7 +4473,8 @@
             "source_checksum": "0b24ddbfd4acf8a4757f8228eb2df7f0",
             "input_file": "al04_12.mp4",
             "output_format": "fltp",
-            "result": "4320324e32f3eb59a745643911e04e99"
+            "result": "4320324e32f3eb59a745643911e04e99",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17sf_12",
@@ -3985,7 +4482,8 @@
             "source_checksum": "1aaa7865d57a2fb502a8be4653d7195a",
             "input_file": "al17sf_12.mp4",
             "output_format": "fltp",
-            "result": "bca856a6877d9a5324d8a1cf5cf8864c"
+            "result": "bca856a6877d9a5324d8a1cf5cf8864c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as11_88",
@@ -3993,7 +4491,8 @@
             "source_checksum": "82ebdb128449b938b62af3a798a83dda",
             "input_file": "as11_88.mp4",
             "output_format": "fltp",
-            "result": "77b571d0663181c946c4707c98dda8fd"
+            "result": "77b571d0663181c946c4707c98dda8fd",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al00_16",
@@ -4001,7 +4500,8 @@
             "source_checksum": "c7da330147aec23623246d501dfe8111",
             "input_file": "al00_16.mp4",
             "output_format": "fltp",
-            "result": "5c6c8350621b3ba4c744712746c66213"
+            "result": "5c6c8350621b3ba4c744712746c66213",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as14_64",
@@ -4009,7 +4509,8 @@
             "source_checksum": "a003f362198661240d567b6584de59b5",
             "input_file": "as14_64.mp4",
             "output_format": "fltp",
-            "result": "8c6e163148642a733d07fcfe05c3e71b"
+            "result": "8c6e163148642a733d07fcfe05c3e71b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as06_88",
@@ -4017,7 +4518,8 @@
             "source_checksum": "eae59b3ac9a016aa9df474e34ff7bc30",
             "input_file": "as06_88.mp4",
             "output_format": "fltp",
-            "result": "d9fcaa849e98d43d5c9e1272cb45ed5a"
+            "result": "d9fcaa849e98d43d5c9e1272cb45ed5a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "ap01_48",
@@ -4025,7 +4527,8 @@
             "source_checksum": "bcbf4a494981134650d562aedce44a74",
             "input_file": "ap01_48.mp4",
             "output_format": "fltp",
-            "result": "cb8a260c08236e342d2122496ae126d9"
+            "result": "cb8a260c08236e342d2122496ae126d9",
+            "profile": "AAC Long Term Prediction"
         },
         {
             "name": "al14sf_16",
@@ -4033,7 +4536,8 @@
             "source_checksum": "ba2371cfd829ca5ba99958389044a13d",
             "input_file": "al14sf_16.mp4",
             "output_format": "fltp",
-            "result": "adcf17383ea63c860aca7c047bb4acd5"
+            "result": "adcf17383ea63c860aca7c047bb4acd5",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am04_48",
@@ -4041,7 +4545,8 @@
             "source_checksum": "6e1a45c0ad27e730bfed9aac3bf136bd",
             "input_file": "am04_48.mp4",
             "output_format": "fltp",
-            "result": "21787f144ab240452a7c0b32016f0c0c"
+            "result": "21787f144ab240452a7c0b32016f0c0c",
+            "profile": "AAC Main"
         },
         {
             "name": "al05sf_88",
@@ -4049,7 +4554,8 @@
             "source_checksum": "fc1311b24a9a75ab7c973d7f0fbbaf31",
             "input_file": "al05sf_88.mp4",
             "output_format": "fltp",
-            "result": "6b609311bb4090654a70cda3b6df7ee4"
+            "result": "6b609311bb4090654a70cda3b6df7ee4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07_44",
@@ -4057,7 +4563,8 @@
             "source_checksum": "5b89e95ae190edda4f0c6d4c04984823",
             "input_file": "al07_44.mp4",
             "output_format": "fltp",
-            "result": "79477538a05939dc9a517f9dd4189521"
+            "result": "79477538a05939dc9a517f9dd4189521",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as17_64",
@@ -4065,7 +4572,8 @@
             "source_checksum": "cc346f622afb7c1c1b4c32c594bcb792",
             "input_file": "as17_64.mp4",
             "output_format": "fltp",
-            "result": "95e70c5865bb22a9b7389af0b3d024fb"
+            "result": "95e70c5865bb22a9b7389af0b3d024fb",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as13_22",
@@ -4073,7 +4581,8 @@
             "source_checksum": "09cd56caaf9a706ba648bde7ff2091e9",
             "input_file": "as13_22.mp4",
             "output_format": "fltp",
-            "result": "1688d05ae06308d9131f3dd2741a0693"
+            "result": "1688d05ae06308d9131f3dd2741a0693",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al02_48",
@@ -4081,7 +4590,8 @@
             "source_checksum": "7bfee22ba34a2809b56825412ca40c3f",
             "input_file": "al02_48.mp4",
             "output_format": "fltp",
-            "result": "efce3a472bba51ef2c22a68981f7bd40"
+            "result": "efce3a472bba51ef2c22a68981f7bd40",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_22",
@@ -4089,7 +4599,8 @@
             "source_checksum": "e725ed8ab39ebb8cdb4e6f8b4e261213",
             "input_file": "al04_22.mp4",
             "output_format": "fltp",
-            "result": "4fc2b48d87982cf7a70e12d167d3c1dd"
+            "result": "4fc2b48d87982cf7a70e12d167d3c1dd",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am07_12",
@@ -4097,7 +4608,8 @@
             "source_checksum": "543475df8b2672c11c527558f7e655ef",
             "input_file": "am07_12.mp4",
             "output_format": "fltp",
-            "result": "1f28df62809987f40907d225e3900caa"
+            "result": "1f28df62809987f40907d225e3900caa",
+            "profile": "AAC Main"
         },
         {
             "name": "as17_12",
@@ -4105,7 +4617,8 @@
             "source_checksum": "1b6ba485ba74569bc4cbbfaddc467d06",
             "input_file": "as17_12.mp4",
             "output_format": "fltp",
-            "result": "5a4f0593e9931db3b638b234a6796cc0"
+            "result": "5a4f0593e9931db3b638b234a6796cc0",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as08_88",
@@ -4113,7 +4626,8 @@
             "source_checksum": "4cd00c15be53afa276a650ad99503a90",
             "input_file": "as08_88.mp4",
             "output_format": "fltp",
-            "result": "617034d7418dbaf0d71811fb915d8a53"
+            "result": "617034d7418dbaf0d71811fb915d8a53",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_twi_22_1_fsaac22",
@@ -4121,7 +4635,8 @@
             "source_checksum": "cf3eb2f924b0bc62f3908a267f11e8e7",
             "input_file": "al_sbr_twi_22_1_fsaac22.mp4",
             "output_format": "fltp",
-            "result": "f7974dc6279606de06de596689e96467"
+            "result": "f7974dc6279606de06de596689e96467",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01sf_08",
@@ -4129,7 +4644,8 @@
             "source_checksum": "c26a53dca13784e41bf7b17ba459b5b9",
             "input_file": "al01sf_08.mp4",
             "output_format": "fltp",
-            "result": "341ba3ace921eb3a805d31cb5c69852a"
+            "result": "341ba3ace921eb3a805d31cb5c69852a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am05_24",
@@ -4137,7 +4653,8 @@
             "source_checksum": "b75591d27f6348ecbccab61e62ad8da7",
             "input_file": "am05_24.mp4",
             "output_format": "fltp",
-            "result": "944cd8a56cd54da026a67d45a2b500ac"
+            "result": "944cd8a56cd54da026a67d45a2b500ac",
+            "profile": "AAC Main"
         },
         {
             "name": "al17_96",
@@ -4145,7 +4662,8 @@
             "source_checksum": "b21f85bd4df3104e6d2731413a2d421b",
             "input_file": "al17_96.mp4",
             "output_format": "fltp",
-            "result": "2db5470e36e27f85dbbe9e49d1ff0c13"
+            "result": "2db5470e36e27f85dbbe9e49d1ff0c13",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as01_08",
@@ -4153,7 +4671,8 @@
             "source_checksum": "89069280aaa5ab6549d6858d57c64b3b",
             "input_file": "as01_08.mp4",
             "output_format": "fltp",
-            "result": "0b43057f093305a27b52f168adaaf255"
+            "result": "0b43057f093305a27b52f168adaaf255",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al17sf_96",
@@ -4161,7 +4680,8 @@
             "source_checksum": "4846bf6828d3434f0dbcd6f59cf4d903",
             "input_file": "al17sf_96.mp4",
             "output_format": "fltp",
-            "result": "2db5470e36e27f85dbbe9e49d1ff0c13"
+            "result": "2db5470e36e27f85dbbe9e49d1ff0c13",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07sf_12",
@@ -4169,7 +4689,8 @@
             "source_checksum": "817119f677a9964908ac131eb2bd2f83",
             "input_file": "al07sf_12.mp4",
             "output_format": "fltp",
-            "result": "dacea28648a5b0756c3bc97539d750e8"
+            "result": "dacea28648a5b0756c3bc97539d750e8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17sf_48",
@@ -4177,7 +4698,8 @@
             "source_checksum": "593fd8d4dcc051a895266bcc8b28e648",
             "input_file": "al17sf_48.mp4",
             "output_format": "fltp",
-            "result": "639ae11166bd1ce3bd23b4d5337008c8"
+            "result": "639ae11166bd1ce3bd23b4d5337008c8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am05_32",
@@ -4185,7 +4707,8 @@
             "source_checksum": "66deb0b5089e88dbccfd35a5ac811572",
             "input_file": "am05_32.mp4",
             "output_format": "fltp",
-            "result": "fd46e5712882f3f994194b6c796c6700"
+            "result": "fd46e5712882f3f994194b6c796c6700",
+            "profile": "AAC Main"
         },
         {
             "name": "al01sf_96",
@@ -4193,7 +4716,8 @@
             "source_checksum": "618a01f96456473488a29e8b8b8889d3",
             "input_file": "al01sf_96.mp4",
             "output_format": "fltp",
-            "result": "4677b93aa04c55103ebd1dce77c6f4c8"
+            "result": "4677b93aa04c55103ebd1dce77c6f4c8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03_48",
@@ -4201,7 +4725,8 @@
             "source_checksum": "4bbded140f19d1024f63f148db2ca9d9",
             "input_file": "al03_48.mp4",
             "output_format": "fltp",
-            "result": "908d650ff51a6b6f09d22d70ed0eafc3"
+            "result": "908d650ff51a6b6f09d22d70ed0eafc3",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_e_44_2",
@@ -4209,7 +4734,8 @@
             "source_checksum": "079a7bd3d938ee9da525dfd2d9a599ae",
             "input_file": "al960_sbr_e_44_2.mp4",
             "output_format": "fltp",
-            "result": "af3347434a5ec8ce2406b5f362703d05"
+            "result": "af3347434a5ec8ce2406b5f362703d05",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as15_16",
@@ -4217,7 +4743,8 @@
             "source_checksum": "2986285e99b5e8adbac167752b94c5ff",
             "input_file": "as15_16.mp4",
             "output_format": "fltp",
-            "result": "e90e5eeaed05bceb2e25bf73de30a5c7"
+            "result": "e90e5eeaed05bceb2e25bf73de30a5c7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as17_48",
@@ -4225,7 +4752,8 @@
             "source_checksum": "281fe46b3314de5dddea1b4276595757",
             "input_file": "as17_48.mp4",
             "output_format": "fltp",
-            "result": "ebd19ef16b3576a8bad95c819c42aa47"
+            "result": "ebd19ef16b3576a8bad95c819c42aa47",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al19sf_44",
@@ -4233,7 +4761,8 @@
             "source_checksum": "27f2ea6171d48bd339322e2f0e920af5",
             "input_file": "al19sf_44.mp4",
             "output_format": "fltp",
-            "result": "5557f7070528f4d5aeb1a69655d934e9"
+            "result": "5557f7070528f4d5aeb1a69655d934e9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_cm_96_5",
@@ -4241,7 +4770,8 @@
             "source_checksum": "e1e595c68796a80466521928625d1c05",
             "input_file": "al_sbr_cm_96_5.mp4",
             "output_format": "fltp",
-            "result": "676d683d77b226883eb7a90c3dbe62e2"
+            "result": "676d683d77b226883eb7a90c3dbe62e2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17_44",
@@ -4249,7 +4779,8 @@
             "source_checksum": "3072c11bfce51d929925d2326253a10a",
             "input_file": "al17_44.mp4",
             "output_format": "fltp",
-            "result": "784fdd0888e46c9ec4eb50a08fdb3cc6"
+            "result": "784fdd0888e46c9ec4eb50a08fdb3cc6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as16_48",
@@ -4257,7 +4788,8 @@
             "source_checksum": "c434c63afdba6e92801e8fa7cf197ab1",
             "input_file": "as16_48.mp4",
             "output_format": "fltp",
-            "result": "6b0e9308cc906ff888b2a48b3e1d09ca"
+            "result": "6b0e9308cc906ff888b2a48b3e1d09ca",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al18_22",
@@ -4265,7 +4797,8 @@
             "source_checksum": "274b2cfe5463dcdacfb7412906ffe4de",
             "input_file": "al18_22.mp4",
             "output_format": "fltp",
-            "result": "9c650228dea2c563560dcf3fbc31bff1"
+            "result": "9c650228dea2c563560dcf3fbc31bff1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14sf_48",
@@ -4273,7 +4806,8 @@
             "source_checksum": "598d264a119cbe92d7e083c148218f52",
             "input_file": "al14sf_48.mp4",
             "output_format": "fltp",
-            "result": "7b4fb2dd812dd2ecdd449e30e0034086"
+            "result": "7b4fb2dd812dd2ecdd449e30e0034086",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18_11",
@@ -4281,7 +4815,8 @@
             "source_checksum": "950870bb40071f970ba6638935ead4ff",
             "input_file": "al18_11.mp4",
             "output_format": "fltp",
-            "result": "721af0545b93204b6ddf4372cf5e10c5"
+            "result": "721af0545b93204b6ddf4372cf5e10c5",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02_22",
@@ -4289,7 +4824,8 @@
             "source_checksum": "fe4fd93353b3d8f339d1f76c6f5ec625",
             "input_file": "al02_22.mp4",
             "output_format": "fltp",
-            "result": "f17cde07183e4e9e9986248b099d098c"
+            "result": "f17cde07183e4e9e9986248b099d098c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_i_32_1",
@@ -4297,7 +4833,8 @@
             "source_checksum": "824151e8fcbf51c4b91db2c0c3388388",
             "input_file": "al960_sbr_i_32_1.mp4",
             "output_format": "fltp",
-            "result": "eff5f1c236da48221aae2faf4b6aa520"
+            "result": "eff5f1c236da48221aae2faf4b6aa520",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_sr_32_2_fsaac16",
@@ -4305,7 +4842,8 @@
             "source_checksum": "379f19055c19751d670366becd279325",
             "input_file": "al_sbr_sr_32_2_fsaac16.mp4",
             "output_format": "fltp",
-            "result": "36aaa9adc98637803d56ac3409c95a08"
+            "result": "36aaa9adc98637803d56ac3409c95a08",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07sf_48",
@@ -4313,7 +4851,8 @@
             "source_checksum": "88b0a2ceed062144c2e4ecd302c47ed4",
             "input_file": "al07sf_48.mp4",
             "output_format": "fltp",
-            "result": "d3b2a85fb3f09c5496c53736ff2d3bd7"
+            "result": "d3b2a85fb3f09c5496c53736ff2d3bd7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as13_08",
@@ -4321,7 +4860,8 @@
             "source_checksum": "6884d6277734b63f93bdfaadf50bd020",
             "input_file": "as13_08.mp4",
             "output_format": "fltp",
-            "result": "a79a648f35b4a6e5dcab24bf416edd1d"
+            "result": "a79a648f35b4a6e5dcab24bf416edd1d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al14_96",
@@ -4329,7 +4869,8 @@
             "source_checksum": "3d95dd54f7d8f994169d0eeda6222514",
             "input_file": "al14_96.mp4",
             "output_format": "fltp",
-            "result": "ab6c0c02ab8224bc5f126264ee403a42"
+            "result": "ab6c0c02ab8224bc5f126264ee403a42",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02sf_22",
@@ -4337,7 +4878,8 @@
             "source_checksum": "4907347959ad6f9a20f4d10263cf3a4e",
             "input_file": "al02sf_22.mp4",
             "output_format": "fltp",
-            "result": "f17cde07183e4e9e9986248b099d098c"
+            "result": "f17cde07183e4e9e9986248b099d098c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am04_44",
@@ -4345,7 +4887,8 @@
             "source_checksum": "e8de8bdd160aa9e2c4952994378d3645",
             "input_file": "am04_44.mp4",
             "output_format": "fltp",
-            "result": "6b124b1f9b0d8b5942b803db436ba439"
+            "result": "6b124b1f9b0d8b5942b803db436ba439",
+            "profile": "AAC Main"
         },
         {
             "name": "al05sf_24",
@@ -4353,7 +4896,8 @@
             "source_checksum": "d87a9ffa217f856ea17436d1d899b8e6",
             "input_file": "al05sf_24.mp4",
             "output_format": "fltp",
-            "result": "6420d66039cd4cef3ff15fbbbe94459b"
+            "result": "6420d66039cd4cef3ff15fbbbe94459b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07sf_64",
@@ -4361,7 +4905,8 @@
             "source_checksum": "7af5407fecc0961eebe5ebdde0ea12d9",
             "input_file": "al07sf_64.mp4",
             "output_format": "fltp",
-            "result": "7b6efd21646d195c7d61bf75b8dd5a31"
+            "result": "7b6efd21646d195c7d61bf75b8dd5a31",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as06_24",
@@ -4369,7 +4914,8 @@
             "source_checksum": "cde92b742552b0e83a80b07332e25160",
             "input_file": "as06_24.mp4",
             "output_format": "fltp",
-            "result": "2d6e341afd09aa7225a3286e6aeca4e7"
+            "result": "2d6e341afd09aa7225a3286e6aeca4e7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al05_08",
@@ -4377,7 +4923,8 @@
             "source_checksum": "a885bae33702b12b4d80e5329f097963",
             "input_file": "al05_08.mp4",
             "output_format": "fltp",
-            "result": "0af6ed73f0e59937b0ffff6da27a9bc8"
+            "result": "0af6ed73f0e59937b0ffff6da27a9bc8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03sf_08",
@@ -4385,7 +4932,8 @@
             "source_checksum": "99af385d06fe43502636082c0806aa2b",
             "input_file": "al03sf_08.mp4",
             "output_format": "fltp",
-            "result": "9e0c9f7586ea7460b87d47f03a2e64d9"
+            "result": "9e0c9f7586ea7460b87d47f03a2e64d9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am07_88",
@@ -4393,7 +4941,8 @@
             "source_checksum": "706396a0d021a37a22183523d0a3bdee",
             "input_file": "am07_88.mp4",
             "output_format": "fltp",
-            "result": "8b2497adbdc8d005d491ca45b8743d87"
+            "result": "8b2497adbdc8d005d491ca45b8743d87",
+            "profile": "AAC Main"
         },
         {
             "name": "as15_24",
@@ -4401,7 +4950,8 @@
             "source_checksum": "eb6f7b5a5118bcf840b663861f1eea89",
             "input_file": "as15_24.mp4",
             "output_format": "fltp",
-            "result": "a06075f09b3a8be50cd7d5664cccb17f"
+            "result": "a06075f09b3a8be50cd7d5664cccb17f",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al16_22",
@@ -4409,7 +4959,8 @@
             "source_checksum": "85cebc1765ab0cc4b5d41ccfe8e15e07",
             "input_file": "al16_22.mp4",
             "output_format": "fltp",
-            "result": "04ad280f43867978faec2b55cab05817"
+            "result": "04ad280f43867978faec2b55cab05817",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as14_44",
@@ -4417,7 +4968,8 @@
             "source_checksum": "a97bedcbd7f50098b46444ad351d2fe4",
             "input_file": "as14_44.mp4",
             "output_format": "fltp",
-            "result": "b2c53f72ea5db3e76d04f1bab9c59659"
+            "result": "b2c53f72ea5db3e76d04f1bab9c59659",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al07_32",
@@ -4425,7 +4977,8 @@
             "source_checksum": "52e439abc7de90e16cb7803f37f7d8bb",
             "input_file": "al07_32.mp4",
             "output_format": "fltp",
-            "result": "ff2b32c235da8fb26eb0cd6ab7c55cda"
+            "result": "ff2b32c235da8fb26eb0cd6ab7c55cda",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as02_12",
@@ -4433,7 +4986,8 @@
             "source_checksum": "bc8b034c8752410fe1405692dabee05d",
             "input_file": "as02_12.mp4",
             "output_format": "fltp",
-            "result": "11af3f565ca36a6ceab18aaabdca4f46"
+            "result": "11af3f565ca36a6ceab18aaabdca4f46",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as03_96",
@@ -4441,7 +4995,8 @@
             "source_checksum": "01227892517369c1f1e90dcedf4f8084",
             "input_file": "as03_96.mp4",
             "output_format": "fltp",
-            "result": "821297607b9b166cebad6a5ba5de4dc7"
+            "result": "821297607b9b166cebad6a5ba5de4dc7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al960_sbr_s_48_2",
@@ -4449,7 +5004,8 @@
             "source_checksum": "100283424294920d249faf99e38275ab",
             "input_file": "al960_sbr_s_48_2.mp4",
             "output_format": "fltp",
-            "result": "078ac0b72c2c66dd16c111f85f1aa368"
+            "result": "078ac0b72c2c66dd16c111f85f1aa368",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al19sf_16",
@@ -4457,7 +5013,8 @@
             "source_checksum": "6dcfbfc54c638b9d411cc8af3a19ee80",
             "input_file": "al19sf_16.mp4",
             "output_format": "fltp",
-            "result": "cbf233464d9c8d6cdbca27723e744da8"
+            "result": "cbf233464d9c8d6cdbca27723e744da8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as17_16",
@@ -4465,7 +5022,8 @@
             "source_checksum": "8702aa5d14f2b69634e343dd26eea4f6",
             "input_file": "as17_16.mp4",
             "output_format": "fltp",
-            "result": "1aeb35eba5cdc0541e08964402f9b281"
+            "result": "1aeb35eba5cdc0541e08964402f9b281",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as16_11",
@@ -4473,7 +5031,8 @@
             "source_checksum": "fdae6e15afaa07aaaf051b3333627338",
             "input_file": "as16_11.mp4",
             "output_format": "fltp",
-            "result": "e0a55b3b41edc256e12fb37867ac2aae"
+            "result": "e0a55b3b41edc256e12fb37867ac2aae",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03sf_48",
@@ -4481,7 +5040,8 @@
             "source_checksum": "f0ec4570989d81e4cc64a227cf27d559",
             "input_file": "al03sf_48.mp4",
             "output_format": "fltp",
-            "result": "908d650ff51a6b6f09d22d70ed0eafc3"
+            "result": "908d650ff51a6b6f09d22d70ed0eafc3",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as06_08",
@@ -4489,7 +5049,8 @@
             "source_checksum": "1cfd6fc1689b4dc396e0d64734e2eefc",
             "input_file": "as06_08.mp4",
             "output_format": "fltp",
-            "result": "555df93edaf95cbe5197e493659311f0"
+            "result": "555df93edaf95cbe5197e493659311f0",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as03_64",
@@ -4497,7 +5058,8 @@
             "source_checksum": "65977418957b2fc7c927c778273adcf3",
             "input_file": "as03_64.mp4",
             "output_format": "fltp",
-            "result": "4309816d3606d6c508746f843df54599"
+            "result": "4309816d3606d6c508746f843df54599",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_s_48_2",
@@ -4505,7 +5067,8 @@
             "source_checksum": "a10d4945997c60a05f9baa84a572b205",
             "input_file": "al_sbr_s_48_2.mp4",
             "output_format": "fltp",
-            "result": "10b7dc043cae2a402c705c428392837b"
+            "result": "10b7dc043cae2a402c705c428392837b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as02_96",
@@ -4513,7 +5076,8 @@
             "source_checksum": "2027d3901596844f125749870b58fb8c",
             "input_file": "as02_96.mp4",
             "output_format": "fltp",
-            "result": "d5c8999daac06c904e5327603f51f0cb"
+            "result": "d5c8999daac06c904e5327603f51f0cb",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al16sf_48",
@@ -4521,7 +5085,8 @@
             "source_checksum": "42af7dca439ba98891e9e7fb85add054",
             "input_file": "al16sf_48.mp4",
             "output_format": "fltp",
-            "result": "fed73f6c3a14de13d8509399f3eeaa6c"
+            "result": "fed73f6c3a14de13d8509399f3eeaa6c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18sf_32",
@@ -4529,7 +5094,8 @@
             "source_checksum": "192e1fcfad60641a19cc836e1b72c019",
             "input_file": "al18sf_32.mp4",
             "output_format": "fltp",
-            "result": "726ec3b795ed9a3bd0426a8fe7a5ed3b"
+            "result": "726ec3b795ed9a3bd0426a8fe7a5ed3b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as13_88",
@@ -4537,7 +5103,8 @@
             "source_checksum": "e3143a446d03a6d3a0bb3452e231a70b",
             "input_file": "as13_88.mp4",
             "output_format": "fltp",
-            "result": "194d0e4abaa96b83a853ab98bfe11e51"
+            "result": "194d0e4abaa96b83a853ab98bfe11e51",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am04_96",
@@ -4545,7 +5112,8 @@
             "source_checksum": "a878a66cbe73eab9b7b5f5970c16d6f7",
             "input_file": "am04_96.mp4",
             "output_format": "fltp",
-            "result": "82e79eac474dc6bda0337aa3871ee962"
+            "result": "82e79eac474dc6bda0337aa3871ee962",
+            "profile": "AAC Main"
         },
         {
             "name": "al16sf_96",
@@ -4553,7 +5121,8 @@
             "source_checksum": "164aad1fbbff5b515167ab2c8a50c1bd",
             "input_file": "al16sf_96.mp4",
             "output_format": "fltp",
-            "result": "adea56a3d03d3a1eaf8ba8d58ecdd983"
+            "result": "adea56a3d03d3a1eaf8ba8d58ecdd983",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am02_24",
@@ -4561,7 +5130,8 @@
             "source_checksum": "da08e0d0241fb206f2a510538a8af2a8",
             "input_file": "am02_24.mp4",
             "output_format": "fltp",
-            "result": "5af42c51a7b2968efb484f0ad933a157"
+            "result": "5af42c51a7b2968efb484f0ad933a157",
+            "profile": "AAC Main"
         },
         {
             "name": "al960_sbr_ps_00",
@@ -4569,7 +5139,8 @@
             "source_checksum": "cefb3ceb1ba8f9e053e15f110442ead1",
             "input_file": "al960_sbr_ps_00.mp4",
             "output_format": "fltp",
-            "result": "ea6bf8d45d2a642567dae7ceb3ba4761"
+            "result": "ea6bf8d45d2a642567dae7ceb3ba4761",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_gh_32_1",
@@ -4577,7 +5148,8 @@
             "source_checksum": "62c6854046835285ddc83678e0392a99",
             "input_file": "al960_sbr_gh_32_1.mp4",
             "output_format": "fltp",
-            "result": "1ab506b3b103ce6c5da4ddfdfc6e8966"
+            "result": "1ab506b3b103ce6c5da4ddfdfc6e8966",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as04_96",
@@ -4585,7 +5157,8 @@
             "source_checksum": "f39f08c27f13e2d0e6c532df24049d5e",
             "input_file": "as04_96.mp4",
             "output_format": "fltp",
-            "result": "427a7b0857a8a9b9e5d10c57c3d7f56d"
+            "result": "427a7b0857a8a9b9e5d10c57c3d7f56d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as11_22",
@@ -4593,7 +5166,8 @@
             "source_checksum": "3d3fe1e30be9e5e869a44b0e0474b61b",
             "input_file": "as11_22.mp4",
             "output_format": "fltp",
-            "result": "240d65d4f0e91934c0385d84db957d4a"
+            "result": "240d65d4f0e91934c0385d84db957d4a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03_24",
@@ -4601,7 +5175,8 @@
             "source_checksum": "ae796bae7bbdfd94ab1ed35712fd43ad",
             "input_file": "al03_24.mp4",
             "output_format": "fltp",
-            "result": "b1b73118761159fff81b5c7af18892c7"
+            "result": "b1b73118761159fff81b5c7af18892c7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01sf_88",
@@ -4609,7 +5184,8 @@
             "source_checksum": "03cc5eea8f51d3df02fcd3bc2329675f",
             "input_file": "al01sf_88.mp4",
             "output_format": "fltp",
-            "result": "444692a2f66a9e51e07daec8a1d1a584"
+            "result": "444692a2f66a9e51e07daec8a1d1a584",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00sf_88",
@@ -4617,7 +5193,8 @@
             "source_checksum": "a58f956e34eb5231a2cd9ee19b5e9185",
             "input_file": "al00sf_88.mp4",
             "output_format": "fltp",
-            "result": "70118d5e3c508f4709d4944e098c1c9b"
+            "result": "70118d5e3c508f4709d4944e098c1c9b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as15_96",
@@ -4625,7 +5202,8 @@
             "source_checksum": "475dcf583ec67d98a6b41feebdd411b1",
             "input_file": "as15_96.mp4",
             "output_format": "fltp",
-            "result": "c990694c0d27c0011bb4d4b030457e73"
+            "result": "c990694c0d27c0011bb4d4b030457e73",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al04sf_24",
@@ -4633,7 +5211,8 @@
             "source_checksum": "02bb7ce4a3362cc198f7e2f52de95c23",
             "input_file": "al04sf_24.mp4",
             "output_format": "fltp",
-            "result": "9bfbda2644d94dca52dd3b7b5b6a49b6"
+            "result": "9bfbda2644d94dca52dd3b7b5b6a49b6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as08_24",
@@ -4641,7 +5220,8 @@
             "source_checksum": "f3569ee75480278bc9101ab0dc99e8ec",
             "input_file": "as08_24.mp4",
             "output_format": "fltp",
-            "result": "b081fdd346de4da4a7896cfaecba28e1"
+            "result": "b081fdd346de4da4a7896cfaecba28e1",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_cm_48_5.1",
@@ -4649,7 +5229,8 @@
             "source_checksum": "13ec258a49634fc66123ac7dc47087aa",
             "input_file": "al_sbr_cm_48_5.1.mp4",
             "output_format": "fltp",
-            "result": "293331d96b024fba2564557ec473ab8a"
+            "result": "293331d96b024fba2564557ec473ab8a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am01_24",
@@ -4657,7 +5238,8 @@
             "source_checksum": "7b9318cfe9481af7c2c93da4126fd7ce",
             "input_file": "am01_24.mp4",
             "output_format": "fltp",
-            "result": "383fe028008446dc9540854da6b1122a"
+            "result": "383fe028008446dc9540854da6b1122a",
+            "profile": "AAC Main"
         },
         {
             "name": "al19sf_24",
@@ -4665,7 +5247,8 @@
             "source_checksum": "bf58cd6d1a44261b4e2e6e6660515b0b",
             "input_file": "al19sf_24.mp4",
             "output_format": "fltp",
-            "result": "3c5ac88b6143205c814736a3030c8dd9"
+            "result": "3c5ac88b6143205c814736a3030c8dd9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_sr_44_2_fsaac22",
@@ -4673,7 +5256,8 @@
             "source_checksum": "a5216885fcdf279326c066b38507254d",
             "input_file": "al_sbr_sr_44_2_fsaac22.mp4",
             "output_format": "fltp",
-            "result": "1a91cc247e7066343716bf51b4d84df9"
+            "result": "1a91cc247e7066343716bf51b4d84df9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06_16",
@@ -4681,7 +5265,8 @@
             "source_checksum": "6f40f9520536d064b4e4bf8cec6388ac",
             "input_file": "al06_16.mp4",
             "output_format": "fltp",
-            "result": "729917620326455911d3e057ee5b1951"
+            "result": "729917620326455911d3e057ee5b1951",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am01_12",
@@ -4689,7 +5274,8 @@
             "source_checksum": "94952d2b681b5d64bba828ebac99db51",
             "input_file": "am01_12.mp4",
             "output_format": "fltp",
-            "result": "0257eecdaaf011bd58ea3000fcbd089d"
+            "result": "0257eecdaaf011bd58ea3000fcbd089d",
+            "profile": "AAC Main"
         },
         {
             "name": "al16sf_12",
@@ -4697,7 +5283,8 @@
             "source_checksum": "52ee5e9eb258fd02228a9c2157db77e3",
             "input_file": "al16sf_12.mp4",
             "output_format": "fltp",
-            "result": "8be4074a4050e87afc9f9229cd6bd4ff"
+            "result": "8be4074a4050e87afc9f9229cd6bd4ff",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al19_12",
@@ -4705,7 +5292,8 @@
             "source_checksum": "8f719bd0faa459617166291d8e2b6b64",
             "input_file": "al19_12.mp4",
             "output_format": "fltp",
-            "result": "cbf233464d9c8d6cdbca27723e744da8"
+            "result": "cbf233464d9c8d6cdbca27723e744da8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as05_64",
@@ -4713,7 +5301,8 @@
             "source_checksum": "7891e11ff742b1b039740f27792fb221",
             "input_file": "as05_64.mp4",
             "output_format": "fltp",
-            "result": "82667487c94e609a16cd32285574253c"
+            "result": "82667487c94e609a16cd32285574253c",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al04sf_64",
@@ -4721,7 +5310,8 @@
             "source_checksum": "83c920abad4c14e2fc8c1851d15933f6",
             "input_file": "al04sf_64.mp4",
             "output_format": "fltp",
-            "result": "334e1e916f28c240965ed8e8f3ce6b38"
+            "result": "334e1e916f28c240965ed8e8f3ce6b38",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00sf_44",
@@ -4729,7 +5319,8 @@
             "source_checksum": "1e5bf13f88a02c893a71a87c7789e5af",
             "input_file": "al00sf_44.mp4",
             "output_format": "fltp",
-            "result": "31f0d7315b2d03acb22d7920f5814855"
+            "result": "31f0d7315b2d03acb22d7920f5814855",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05sf_16",
@@ -4737,7 +5328,8 @@
             "source_checksum": "d9f41df74158657e35f6ae1f15ded10a",
             "input_file": "al05sf_16.mp4",
             "output_format": "fltp",
-            "result": "3e17aa815d1dfbb8228c0723179d9840"
+            "result": "3e17aa815d1dfbb8228c0723179d9840",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06sf_32",
@@ -4745,7 +5337,8 @@
             "source_checksum": "ab3c740849c8cec23218e417a4b9bd56",
             "input_file": "al06sf_32.mp4",
             "output_format": "fltp",
-            "result": "61397a51fed37bfbb0323fa019fec43d"
+            "result": "61397a51fed37bfbb0323fa019fec43d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as14_96",
@@ -4753,7 +5346,8 @@
             "source_checksum": "2b764f0e8828add1f6736c5c1a249172",
             "input_file": "as14_96.mp4",
             "output_format": "fltp",
-            "result": "d1233080f9731fc0cd5ac03b2405130d"
+            "result": "d1233080f9731fc0cd5ac03b2405130d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al01_44",
@@ -4761,7 +5355,8 @@
             "source_checksum": "fc2477b9c8693987462e68503a57f524",
             "input_file": "al01_44.mp4",
             "output_format": "fltp",
-            "result": "0ac8f10d9023e838fd99b79fbd158eab"
+            "result": "0ac8f10d9023e838fd99b79fbd158eab",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as12_48",
@@ -4769,7 +5364,8 @@
             "source_checksum": "7569dc5069402d65e6e9f543998d9fce",
             "input_file": "as12_48.mp4",
             "output_format": "fltp",
-            "result": "4dc47947189b4cf08e4f5feee6b2ea48"
+            "result": "4dc47947189b4cf08e4f5feee6b2ea48",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al07_24",
@@ -4777,7 +5373,8 @@
             "source_checksum": "8828cf3fff7152de0cb58c353956e8f8",
             "input_file": "al07_24.mp4",
             "output_format": "fltp",
-            "result": "24c49da2486562d7cabb30e56c54e540"
+            "result": "24c49da2486562d7cabb30e56c54e540",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al01_64",
@@ -4785,7 +5382,8 @@
             "source_checksum": "85ff11e5d033e04b589a6f290313ebfb",
             "input_file": "al01_64.mp4",
             "output_format": "fltp",
-            "result": "567affc7a30b2b05804877c986b93849"
+            "result": "567affc7a30b2b05804877c986b93849",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18sf_08",
@@ -4793,7 +5391,8 @@
             "source_checksum": "ff8d29574a48d6b33393b304b50a153c",
             "input_file": "al18sf_08.mp4",
             "output_format": "fltp",
-            "result": "b2927751ae7a97613a9d9d0d2748eca7"
+            "result": "b2927751ae7a97613a9d9d0d2748eca7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as15_88",
@@ -4801,7 +5400,8 @@
             "source_checksum": "bfa9fc76491cb88407be3f7116ed9854",
             "input_file": "as15_88.mp4",
             "output_format": "fltp",
-            "result": "cf7d62555bf0c2f35086f6a5588d9e5d"
+            "result": "cf7d62555bf0c2f35086f6a5588d9e5d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as00_44",
@@ -4809,7 +5409,8 @@
             "source_checksum": "b2af48ef829071a0f0a6e8e22126798e",
             "input_file": "as00_44.mp4",
             "output_format": "fltp",
-            "result": "b54c4156d525170f40cff12eb4f0afd8"
+            "result": "b54c4156d525170f40cff12eb4f0afd8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as12_11",
@@ -4817,7 +5418,8 @@
             "source_checksum": "bf84cefb4e4a25e57e902b9f8be3df3f",
             "input_file": "as12_11.mp4",
             "output_format": "fltp",
-            "result": "78df5d5b0f389a36d0965568e053b126"
+            "result": "78df5d5b0f389a36d0965568e053b126",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as13_11",
@@ -4825,7 +5427,8 @@
             "source_checksum": "5f10302a00fe14bd48c6628101791be0",
             "input_file": "as13_11.mp4",
             "output_format": "fltp",
-            "result": "ef949796fe002827cc88106bc5381c9d"
+            "result": "ef949796fe002827cc88106bc5381c9d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as06_48",
@@ -4833,7 +5436,8 @@
             "source_checksum": "fe62582fc51dc3a15b3f62344fd171a3",
             "input_file": "as06_48.mp4",
             "output_format": "fltp",
-            "result": "b244b4e92cad9813cd100e1dd92ae8a4"
+            "result": "b244b4e92cad9813cd100e1dd92ae8a4",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as09_64",
@@ -4841,7 +5445,8 @@
             "source_checksum": "8692177f9fd762f2e7536f99c5fec8c6",
             "input_file": "as09_64.mp4",
             "output_format": "fltp",
-            "result": "eaf17ab6b54acc45bd1bf4a0c50b99a1"
+            "result": "eaf17ab6b54acc45bd1bf4a0c50b99a1",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06sf_64",
@@ -4849,7 +5454,8 @@
             "source_checksum": "9981baec8b18dda2da3d8bccb36c8bb2",
             "input_file": "al06sf_64.mp4",
             "output_format": "fltp",
-            "result": "7ff08384d907e611cbb4b7333f41d9fe"
+            "result": "7ff08384d907e611cbb4b7333f41d9fe",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_24",
@@ -4857,7 +5463,8 @@
             "source_checksum": "ddc0b85f3a116e5db4c42ad9be6ef43e",
             "input_file": "al04_24.mp4",
             "output_format": "fltp",
-            "result": "9bfbda2644d94dca52dd3b7b5b6a49b6"
+            "result": "9bfbda2644d94dca52dd3b7b5b6a49b6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_qmf_48_1",
@@ -4865,7 +5472,8 @@
             "source_checksum": "93015e1b60d77a4b3afb8d3363440802",
             "input_file": "al960_sbr_qmf_48_1.mp4",
             "output_format": "fltp",
-            "result": "8898ca4598103aa5399718077f64322c"
+            "result": "8898ca4598103aa5399718077f64322c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02_32",
@@ -4873,7 +5481,8 @@
             "source_checksum": "17e7376ca9a29bcc39c0bf4a56812bbe",
             "input_file": "al02_32.mp4",
             "output_format": "fltp",
-            "result": "6ba7ac6c9ce17617f2b8e192d64111ca"
+            "result": "6ba7ac6c9ce17617f2b8e192d64111ca",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_gh_32_2",
@@ -4881,7 +5490,8 @@
             "source_checksum": "f7af30cef839d1f47ede544dcf3e192d",
             "input_file": "al960_sbr_gh_32_2.mp4",
             "output_format": "fltp",
-            "result": "5afc232d1410eea16dca80a090a1ddad"
+            "result": "5afc232d1410eea16dca80a090a1ddad",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as02_16",
@@ -4889,7 +5499,8 @@
             "source_checksum": "df64cb15f4c2a84bedebd246f2a2648c",
             "input_file": "as02_16.mp4",
             "output_format": "fltp",
-            "result": "21842cc363c6ba31f829806c76c0d488"
+            "result": "21842cc363c6ba31f829806c76c0d488",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al00sf_22",
@@ -4897,7 +5508,8 @@
             "source_checksum": "8476cc13bdd8508fba5f4973b3e7883d",
             "input_file": "al00sf_22.mp4",
             "output_format": "fltp",
-            "result": "fc7d20249eb3f883c9244e88986eebb9"
+            "result": "fc7d20249eb3f883c9244e88986eebb9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am02_08",
@@ -4905,7 +5517,8 @@
             "source_checksum": "6fd2f5f0ea81d34f18d94938fa3f5327",
             "input_file": "am02_08.mp4",
             "output_format": "fltp",
-            "result": "c1e3516dadbb4efbae4dd6103276e4e2"
+            "result": "c1e3516dadbb4efbae4dd6103276e4e2",
+            "profile": "AAC Main"
         },
         {
             "name": "al_sbr_i_44_2",
@@ -4913,7 +5526,8 @@
             "source_checksum": "9d0f30275823c332843caca31444c9d6",
             "input_file": "al_sbr_i_44_2.mp4",
             "output_format": "fltp",
-            "result": "53ff1deb2edc112f13f5b61935bda109"
+            "result": "53ff1deb2edc112f13f5b61935bda109",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as11_44",
@@ -4921,7 +5535,8 @@
             "source_checksum": "60d5a3f7e27c73cf9c079cd9d5570337",
             "input_file": "as11_44.mp4",
             "output_format": "fltp",
-            "result": "6faa8f6cad155d54f232fdfcc1c1a001"
+            "result": "6faa8f6cad155d54f232fdfcc1c1a001",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as10_08",
@@ -4929,7 +5544,8 @@
             "source_checksum": "33adad923f6faedb1b61f576e902e0b7",
             "input_file": "as10_08.mp4",
             "output_format": "fltp",
-            "result": "4e6e445af75a79b600f4759c45dca3c8"
+            "result": "4e6e445af75a79b600f4759c45dca3c8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as07_08",
@@ -4937,7 +5553,8 @@
             "source_checksum": "720a1220dab2cd0390327a9fd5110b33",
             "input_file": "as07_08.mp4",
             "output_format": "fltp",
-            "result": "4374f44fca297d68a85e64e1c2ad591d"
+            "result": "4374f44fca297d68a85e64e1c2ad591d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as05_32",
@@ -4945,7 +5562,8 @@
             "source_checksum": "a530c6edbd8d17f4672a06863f6bf52c",
             "input_file": "as05_32.mp4",
             "output_format": "fltp",
-            "result": "81c8e7279518789f3aca4218330f3dc3"
+            "result": "81c8e7279518789f3aca4218330f3dc3",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_s_32_1",
@@ -4953,7 +5571,8 @@
             "source_checksum": "a25d3d069293475099adc2155118a938",
             "input_file": "al_sbr_s_32_1.mp4",
             "output_format": "fltp",
-            "result": "e4cb9d83bd5506e3dcd38d51d083f058"
+            "result": "e4cb9d83bd5506e3dcd38d51d083f058",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_sr_24_2_fsaac12",
@@ -4961,7 +5580,8 @@
             "source_checksum": "2ef2f7426b467ab151accad0b3942b42",
             "input_file": "al_sbr_sr_24_2_fsaac12.mp4",
             "output_format": "fltp",
-            "result": "e5ffd2c7b5bdfd435fc15e51c8bc21b7"
+            "result": "e5ffd2c7b5bdfd435fc15e51c8bc21b7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03_96",
@@ -4969,7 +5589,8 @@
             "source_checksum": "15f412827be9c2e7b091a99a79ab15c7",
             "input_file": "al03_96.mp4",
             "output_format": "fltp",
-            "result": "c07660b161c8bf333f7703d39cd7829c"
+            "result": "c07660b161c8bf333f7703d39cd7829c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al17_24",
@@ -4977,7 +5598,8 @@
             "source_checksum": "0c78e0ab65aff7287ead3eadde0525a7",
             "input_file": "al17_24.mp4",
             "output_format": "fltp",
-            "result": "81e7f63e34e349fd6138172552c55936"
+            "result": "81e7f63e34e349fd6138172552c55936",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02sf_48",
@@ -4985,7 +5607,8 @@
             "source_checksum": "b33e215efd14ed1b3cb09b784bf6e64c",
             "input_file": "al02sf_48.mp4",
             "output_format": "fltp",
-            "result": "efce3a472bba51ef2c22a68981f7bd40"
+            "result": "efce3a472bba51ef2c22a68981f7bd40",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am02_12",
@@ -4993,7 +5616,8 @@
             "source_checksum": "de5c8857a7ce80aed2c78e17a576ea76",
             "input_file": "am02_12.mp4",
             "output_format": "fltp",
-            "result": "81e3ce4054eac8fc69e85c305aacee0a"
+            "result": "81e3ce4054eac8fc69e85c305aacee0a",
+            "profile": "AAC Main"
         },
         {
             "name": "al19_96",
@@ -5001,7 +5625,8 @@
             "source_checksum": "549228680311d19f4493381f2fd38b40",
             "input_file": "al19_96.mp4",
             "output_format": "fltp",
-            "result": "c063c9667651a1ee43c6d6a539d6f1b6"
+            "result": "c063c9667651a1ee43c6d6a539d6f1b6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_ps_05",
@@ -5009,7 +5634,8 @@
             "source_checksum": "89f3427b347c3bb08cd15aab74ba4690",
             "input_file": "al_sbr_ps_05.mp4",
             "output_format": "fltp",
-            "result": "147a48639a3a6379eae36bc7066a9502"
+            "result": "147a48639a3a6379eae36bc7066a9502",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05_12",
@@ -5017,7 +5643,8 @@
             "source_checksum": "95799d0dc3d9e6ff8d97085c0b51b7f3",
             "input_file": "al05_12.mp4",
             "output_format": "fltp",
-            "result": "afbc1483e6a4a6dc56901b63b047969f"
+            "result": "afbc1483e6a4a6dc56901b63b047969f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am06_24",
@@ -5025,7 +5652,8 @@
             "source_checksum": "b5d0a8f8df76df8103c60243c6d3f032",
             "input_file": "am06_24.mp4",
             "output_format": "fltp",
-            "result": "87804f335ccf18e86203e3f28ccdd550"
+            "result": "87804f335ccf18e86203e3f28ccdd550",
+            "profile": "AAC Main"
         },
         {
             "name": "al19_32",
@@ -5033,7 +5661,8 @@
             "source_checksum": "7e6b41f815260fd550cbbae0b7060dcd",
             "input_file": "al19_32.mp4",
             "output_format": "fltp",
-            "result": "5557f7070528f4d5aeb1a69655d934e9"
+            "result": "5557f7070528f4d5aeb1a69655d934e9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_s_44_2",
@@ -5041,7 +5670,8 @@
             "source_checksum": "4872d7a24570b10a781f562cf88d2979",
             "input_file": "al_sbr_s_44_2.mp4",
             "output_format": "fltp",
-            "result": "949ee334e3c900453c9d35f9ceaeae30"
+            "result": "949ee334e3c900453c9d35f9ceaeae30",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am04_24",
@@ -5049,7 +5679,8 @@
             "source_checksum": "ee4b195cab29208e054824e6fe09b199",
             "input_file": "am04_24.mp4",
             "output_format": "fltp",
-            "result": "b1f7a855024212ea1278a995b014dc21"
+            "result": "b1f7a855024212ea1278a995b014dc21",
+            "profile": "AAC Main"
         },
         {
             "name": "ap04_48",
@@ -5057,7 +5688,8 @@
             "source_checksum": "1685bce2f8b43d087ecda3b3cb898fc5",
             "input_file": "ap04_48.mp4",
             "output_format": "fltp",
-            "result": "6e1767241de43646691c21587ccbab9f"
+            "result": "6e1767241de43646691c21587ccbab9f",
+            "profile": "AAC Long Term Prediction"
         },
         {
             "name": "am07_44",
@@ -5065,7 +5697,8 @@
             "source_checksum": "95bb437a67e41b2bf143c519692e9034",
             "input_file": "am07_44.mp4",
             "output_format": "fltp",
-            "result": "0c53879c6ba9f549ee83037e9bc5d561"
+            "result": "0c53879c6ba9f549ee83037e9bc5d561",
+            "profile": "AAC Main"
         },
         {
             "name": "as06_64",
@@ -5073,7 +5706,8 @@
             "source_checksum": "75962cd05633d36059a3b351e845034c",
             "input_file": "as06_64.mp4",
             "output_format": "fltp",
-            "result": "b269ccbec78278261e9f9d829366b686"
+            "result": "b269ccbec78278261e9f9d829366b686",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al05_96",
@@ -5081,7 +5715,8 @@
             "source_checksum": "9629d251249f29c2407abaf2b7de9d19",
             "input_file": "al05_96.mp4",
             "output_format": "fltp",
-            "result": "d4dfff5dbf498aabb7ab71ebf71fc6de"
+            "result": "d4dfff5dbf498aabb7ab71ebf71fc6de",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as16_44",
@@ -5089,7 +5724,8 @@
             "source_checksum": "3d03997cdbff1141edef3562b308c472",
             "input_file": "as16_44.mp4",
             "output_format": "fltp",
-            "result": "5f3d4268932023aa50801fac91a9defb"
+            "result": "5f3d4268932023aa50801fac91a9defb",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as04_12",
@@ -5097,7 +5733,8 @@
             "source_checksum": "74051cb1078a7153aaa2469197224ba6",
             "input_file": "as04_12.mp4",
             "output_format": "fltp",
-            "result": "1f56b8ef778b40628b873e55c03dba60"
+            "result": "1f56b8ef778b40628b873e55c03dba60",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al960_sbr_gh_44_1",
@@ -5105,7 +5742,8 @@
             "source_checksum": "d5775ae5845e06664f8876d10365f506",
             "input_file": "al960_sbr_gh_44_1.mp4",
             "output_format": "fltp",
-            "result": "fc5a79fa5e5c3938239e179a74318f7f"
+            "result": "fc5a79fa5e5c3938239e179a74318f7f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as06_12",
@@ -5113,7 +5751,8 @@
             "source_checksum": "50b95774a0599097d944377680e1620c",
             "input_file": "as06_12.mp4",
             "output_format": "fltp",
-            "result": "adaa0667e7581ff3d6f56ba40bb1c457"
+            "result": "adaa0667e7581ff3d6f56ba40bb1c457",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06_88",
@@ -5121,7 +5760,8 @@
             "source_checksum": "f6ac207e454eac1355fb4082d7b55a75",
             "input_file": "al06_88.mp4",
             "output_format": "fltp",
-            "result": "c172042cbf8e1b2a73b2ac21b5c12ec2"
+            "result": "c172042cbf8e1b2a73b2ac21b5c12ec2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02sf_11",
@@ -5129,7 +5769,8 @@
             "source_checksum": "28821fae7b0e4528d0618dd2953499d5",
             "input_file": "al02sf_11.mp4",
             "output_format": "fltp",
-            "result": "6919665a2023157452cff79d0ea54f4c"
+            "result": "6919665a2023157452cff79d0ea54f4c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am07_32",
@@ -5137,7 +5778,8 @@
             "source_checksum": "e89dc90593dc336542f94828fea8155e",
             "input_file": "am07_32.mp4",
             "output_format": "fltp",
-            "result": "4f10ad3578bd9e00f338e45757e181f1"
+            "result": "4f10ad3578bd9e00f338e45757e181f1",
+            "profile": "AAC Main"
         },
         {
             "name": "al16sf_11",
@@ -5145,7 +5787,8 @@
             "source_checksum": "2f4a475e056d5045cf7f2be78cbd443d",
             "input_file": "al16sf_11.mp4",
             "output_format": "fltp",
-            "result": "8d4dcbc5964d35450f5f44accb0fa076"
+            "result": "8d4dcbc5964d35450f5f44accb0fa076",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03_44",
@@ -5153,7 +5796,8 @@
             "source_checksum": "934aa14759dabc0a715ce5a670bec955",
             "input_file": "al03_44.mp4",
             "output_format": "fltp",
-            "result": "bc6428f68eeac99961b07928d5efb76f"
+            "result": "bc6428f68eeac99961b07928d5efb76f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am04_16",
@@ -5161,7 +5805,8 @@
             "source_checksum": "ed5cd142eef23c2effc2e995ec54e435",
             "input_file": "am04_16.mp4",
             "output_format": "fltp",
-            "result": "558b5b0b4eb34fc35f0a81289f710458"
+            "result": "558b5b0b4eb34fc35f0a81289f710458",
+            "profile": "AAC Main"
         },
         {
             "name": "am04_12",
@@ -5169,7 +5814,8 @@
             "source_checksum": "3c501a6e413aa94d4114523836f71dd5",
             "input_file": "am04_12.mp4",
             "output_format": "fltp",
-            "result": "e34d7c1761878e8a32dad69d8065ee37"
+            "result": "e34d7c1761878e8a32dad69d8065ee37",
+            "profile": "AAC Main"
         },
         {
             "name": "al02sf_16",
@@ -5177,7 +5823,8 @@
             "source_checksum": "856dbfceac4acb9527a76297ec736848",
             "input_file": "al02sf_16.mp4",
             "output_format": "fltp",
-            "result": "3895a8eb4c3f795f621c0591dac9e076"
+            "result": "3895a8eb4c3f795f621c0591dac9e076",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16_48",
@@ -5185,7 +5832,8 @@
             "source_checksum": "3c7639c849340d5054b9a5a8ddbde0cd",
             "input_file": "al16_48.mp4",
             "output_format": "fltp",
-            "result": "fed73f6c3a14de13d8509399f3eeaa6c"
+            "result": "fed73f6c3a14de13d8509399f3eeaa6c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as17_32",
@@ -5193,7 +5841,8 @@
             "source_checksum": "bd066fba4f0a2f4d28af2bac7050ff0e",
             "input_file": "as17_32.mp4",
             "output_format": "fltp",
-            "result": "f905cf951369cd78ff5dbc5fc03b82a7"
+            "result": "f905cf951369cd78ff5dbc5fc03b82a7",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al07_48",
@@ -5201,7 +5850,8 @@
             "source_checksum": "f481a380e70ac8c5f5f1727f9adbfbc6",
             "input_file": "al07_48.mp4",
             "output_format": "fltp",
-            "result": "d3b2a85fb3f09c5496c53736ff2d3bd7"
+            "result": "d3b2a85fb3f09c5496c53736ff2d3bd7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as07_44",
@@ -5209,7 +5859,8 @@
             "source_checksum": "9755c4e65dcccb29ce8aa40c2ef6a933",
             "input_file": "as07_44.mp4",
             "output_format": "fltp",
-            "result": "085350565881a963a3ad4cae99a91f02"
+            "result": "085350565881a963a3ad4cae99a91f02",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al00sf_11",
@@ -5217,7 +5868,8 @@
             "source_checksum": "9e14703e5d6ca502d0392cc336eea58d",
             "input_file": "al00sf_11.mp4",
             "output_format": "fltp",
-            "result": "6eb23f7d1b322d167f0c075234ad66ec"
+            "result": "6eb23f7d1b322d167f0c075234ad66ec",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al14sf_64",
@@ -5225,7 +5877,8 @@
             "source_checksum": "c1c8e745ecf4536a670a3cdc2e31765e",
             "input_file": "al14sf_64.mp4",
             "output_format": "fltp",
-            "result": "fee87c426ffe310d83008121fa592bd9"
+            "result": "fee87c426ffe310d83008121fa592bd9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_22",
@@ -5233,7 +5886,8 @@
             "source_checksum": "fdd42f1a02870adf56a5983fb0f4b6b2",
             "input_file": "am00_22.mp4",
             "output_format": "fltp",
-            "result": "3a5c20bbd8e6da448b58f24fcc1406e4"
+            "result": "3a5c20bbd8e6da448b58f24fcc1406e4",
+            "profile": "AAC Main"
         },
         {
             "name": "al19sf_88",
@@ -5241,7 +5895,8 @@
             "source_checksum": "d5528eb7c85a4ef86170dbf0aa6d88db",
             "input_file": "al19sf_88.mp4",
             "output_format": "fltp",
-            "result": "c063c9667651a1ee43c6d6a539d6f1b6"
+            "result": "c063c9667651a1ee43c6d6a539d6f1b6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18sf_16",
@@ -5249,7 +5904,8 @@
             "source_checksum": "25545fca7e53e7f376f0f51db996eab6",
             "input_file": "al18sf_16.mp4",
             "output_format": "fltp",
-            "result": "621bfe9dc4c755520ae97b2f400c563a"
+            "result": "621bfe9dc4c755520ae97b2f400c563a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as09_96",
@@ -5257,7 +5913,8 @@
             "source_checksum": "8961951f1801a2fe980bf85f11e2cfda",
             "input_file": "as09_96.mp4",
             "output_format": "fltp",
-            "result": "dacba353af93ca1befcabcc4e4d28e0a"
+            "result": "dacba353af93ca1befcabcc4e4d28e0a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as01_16",
@@ -5265,7 +5922,8 @@
             "source_checksum": "b82246c7b0b70847ea7922aed65c169b",
             "input_file": "as01_16.mp4",
             "output_format": "fltp",
-            "result": "0bda27fe86e947592e92ec47c050621a"
+            "result": "0bda27fe86e947592e92ec47c050621a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am07_64",
@@ -5273,7 +5931,8 @@
             "source_checksum": "7d2d9fbbeb05d943c1342730300fb0d7",
             "input_file": "am07_64.mp4",
             "output_format": "fltp",
-            "result": "9aaa8ad36219fc401c90205b48aa7749"
+            "result": "9aaa8ad36219fc401c90205b48aa7749",
+            "profile": "AAC Main"
         },
         {
             "name": "al04_11",
@@ -5281,7 +5940,8 @@
             "source_checksum": "509a2f176345dae30423c4422a986f35",
             "input_file": "al04_11.mp4",
             "output_format": "fltp",
-            "result": "ce01170c4b3bbadfb22580879745bb79"
+            "result": "ce01170c4b3bbadfb22580879745bb79",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_ps_05_new",
@@ -5289,7 +5949,8 @@
             "source_checksum": "f004d4605bfe881b4edbd437d9f69de5",
             "input_file": "al_sbr_ps_05_new.mp4",
             "output_format": "fltp",
-            "result": "147a48639a3a6379eae36bc7066a9502"
+            "result": "147a48639a3a6379eae36bc7066a9502",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al07_22",
@@ -5297,7 +5958,8 @@
             "source_checksum": "6e4ed3bd7e215e39f36d8ef4e35dcd8b",
             "input_file": "al07_22.mp4",
             "output_format": "fltp",
-            "result": "fc08bb87b480477170e755f76abac8ae"
+            "result": "fc08bb87b480477170e755f76abac8ae",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am02_64",
@@ -5305,7 +5967,8 @@
             "source_checksum": "aa4cc87e2c7d43bce9c8e9ebc38477e8",
             "input_file": "am02_64.mp4",
             "output_format": "fltp",
-            "result": "f2a0570e3ee6227c76d2b151cf959347"
+            "result": "f2a0570e3ee6227c76d2b151cf959347",
+            "profile": "AAC Main"
         },
         {
             "name": "al_sbr_ps_02_new",
@@ -5313,7 +5976,8 @@
             "source_checksum": "07842048def7e7e28530d5a4b5b6288b",
             "input_file": "al_sbr_ps_02_new.mp4",
             "output_format": "fltp",
-            "result": "ea9769c002c80ca8fce59e93d37ab79f"
+            "result": "ea9769c002c80ca8fce59e93d37ab79f",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as15_11",
@@ -5321,7 +5985,8 @@
             "source_checksum": "132d6833103d95527f19960012d32606",
             "input_file": "as15_11.mp4",
             "output_format": "fltp",
-            "result": "9f0c5f8ec100812088288ffdb7fd5aba"
+            "result": "9f0c5f8ec100812088288ffdb7fd5aba",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al06_24",
@@ -5329,7 +5994,8 @@
             "source_checksum": "7cb02b9a95492c05a00ec031458e8324",
             "input_file": "al06_24.mp4",
             "output_format": "fltp",
-            "result": "93405699186566faf24ece95412310fe"
+            "result": "93405699186566faf24ece95412310fe",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as02_64",
@@ -5337,7 +6003,8 @@
             "source_checksum": "171674973fda6604689f4f81d7cfa607",
             "input_file": "as02_64.mp4",
             "output_format": "fltp",
-            "result": "251ea0e1b3821235909aba69892ad7d8"
+            "result": "251ea0e1b3821235909aba69892ad7d8",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al08sf_96",
@@ -5345,7 +6012,8 @@
             "source_checksum": "12c6ae01d190190b08f3c179e4a3b646",
             "input_file": "al08sf_96.mp4",
             "output_format": "fltp",
-            "result": "4fe3261089df0bb3f3c584eda4930147"
+            "result": "4fe3261089df0bb3f3c584eda4930147",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05_32",
@@ -5353,7 +6021,8 @@
             "source_checksum": "69aa2c2fa85a7ae9a50c04ce36d57aa9",
             "input_file": "al05_32.mp4",
             "output_format": "fltp",
-            "result": "d8fd8cbd4707458c7dbc2331ad792e67"
+            "result": "d8fd8cbd4707458c7dbc2331ad792e67",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al00_88",
@@ -5361,7 +6030,8 @@
             "source_checksum": "b2105985d63491c7d61f964f5ac667cb",
             "input_file": "al00_88.mp4",
             "output_format": "fltp",
-            "result": "70118d5e3c508f4709d4944e098c1c9b"
+            "result": "70118d5e3c508f4709d4944e098c1c9b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al04_08",
@@ -5369,7 +6039,8 @@
             "source_checksum": "9f81fb01b172e8adafdda6d0cf590649",
             "input_file": "al04_08.mp4",
             "output_format": "fltp",
-            "result": "19d650af57f6baa32202f3100aeb1eda"
+            "result": "19d650af57f6baa32202f3100aeb1eda",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as02_48",
@@ -5377,7 +6048,8 @@
             "source_checksum": "8b29b73ffe0f759f77b7be3c36c75e57",
             "input_file": "as02_48.mp4",
             "output_format": "fltp",
-            "result": "8f0fec654f8b846b229f8a656c6aca0d"
+            "result": "8f0fec654f8b846b229f8a656c6aca0d",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as07_24",
@@ -5385,7 +6057,8 @@
             "source_checksum": "6cf402f95d4b8943f8af1b51b7eae8fd",
             "input_file": "as07_24.mp4",
             "output_format": "fltp",
-            "result": "8a6f5b90e5fdd48feb04a0d7bbe10b73"
+            "result": "8a6f5b90e5fdd48feb04a0d7bbe10b73",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as02_08",
@@ -5393,7 +6066,8 @@
             "source_checksum": "1fc4419d127e4135412260188231c061",
             "input_file": "as02_08.mp4",
             "output_format": "fltp",
-            "result": "19b5d8f467aac0f0f9c3cd5b841f392e"
+            "result": "19b5d8f467aac0f0f9c3cd5b841f392e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03_16",
@@ -5401,7 +6075,8 @@
             "source_checksum": "230531de8dbda73a7da30ff86c5cf8bc",
             "input_file": "al03_16.mp4",
             "output_format": "fltp",
-            "result": "98b5f0df41b303b02037224f09cf45ea"
+            "result": "98b5f0df41b303b02037224f09cf45ea",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as09_88",
@@ -5409,7 +6084,8 @@
             "source_checksum": "9997aa77a0f8eb314bfe85e008b2b5a8",
             "input_file": "as09_88.mp4",
             "output_format": "fltp",
-            "result": "3c45cb22edbf1ffbd69471f1f9e3057e"
+            "result": "3c45cb22edbf1ffbd69471f1f9e3057e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al00_32",
@@ -5417,7 +6093,8 @@
             "source_checksum": "ec1c0cb294f8b99a3bf6770d155eee47",
             "input_file": "al00_32.mp4",
             "output_format": "fltp",
-            "result": "9379f05a63dbbf78e458e88f8b36a4bc"
+            "result": "9379f05a63dbbf78e458e88f8b36a4bc",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_qmf_48_1",
@@ -5425,7 +6102,8 @@
             "source_checksum": "4368a1fa14067f2495975cbba2db59b3",
             "input_file": "al_sbr_qmf_48_1.mp4",
             "output_format": "fltp",
-            "result": "1baf3b0a6d2ce613d4aa57f3499f13f7"
+            "result": "1baf3b0a6d2ce613d4aa57f3499f13f7",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al_sbr_ps_06_new",
@@ -5433,7 +6111,8 @@
             "source_checksum": "0295396fe1a25bdea14371c764b7dd96",
             "input_file": "al_sbr_ps_06_new.mp4",
             "output_format": "fltp",
-            "result": "f181b26d3fa66a999216967f4d86861c"
+            "result": "f181b26d3fa66a999216967f4d86861c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am05_22",
@@ -5441,7 +6120,8 @@
             "source_checksum": "8fe188aef595f0c3eb7d144b43ddc600",
             "input_file": "am05_22.mp4",
             "output_format": "fltp",
-            "result": "4583fff864365ec8ea7a8ce404717ada"
+            "result": "4583fff864365ec8ea7a8ce404717ada",
+            "profile": "AAC Main"
         },
         {
             "name": "al18sf_24",
@@ -5449,7 +6129,8 @@
             "source_checksum": "2af3fb950ddc1194758be71479e2e0c8",
             "input_file": "al18sf_24.mp4",
             "output_format": "fltp",
-            "result": "55774039a7d9a8f590a198c4424aa3be"
+            "result": "55774039a7d9a8f590a198c4424aa3be",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08_48",
@@ -5457,7 +6138,8 @@
             "source_checksum": "28d137e459204dcab7f0c146ac1bcee6",
             "input_file": "al08_48.mp4",
             "output_format": "fltp",
-            "result": "8f516b5865c47cca496bc37853843af9"
+            "result": "8f516b5865c47cca496bc37853843af9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_08",
@@ -5465,7 +6147,8 @@
             "source_checksum": "7cc0c1d913ff6b45448c17d25c75b4fd",
             "input_file": "am00_08.mp4",
             "output_format": "fltp",
-            "result": "5421b0bfa2287dd9a0b4abbcd784d924"
+            "result": "5421b0bfa2287dd9a0b4abbcd784d924",
+            "profile": "AAC Main"
         },
         {
             "name": "al05sf_96",
@@ -5473,7 +6156,8 @@
             "source_checksum": "c3890c593bd7ecd6124d26b41f42f9ed",
             "input_file": "al05sf_96.mp4",
             "output_format": "fltp",
-            "result": "d4dfff5dbf498aabb7ab71ebf71fc6de"
+            "result": "d4dfff5dbf498aabb7ab71ebf71fc6de",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al960_sbr_qmf_32_1",
@@ -5481,7 +6165,8 @@
             "source_checksum": "ca210bc14cecc57e2dfb7032ce7dfe44",
             "input_file": "al960_sbr_qmf_32_1.mp4",
             "output_format": "fltp",
-            "result": "7231056d14afdcc2e4877f14da6d3603"
+            "result": "7231056d14afdcc2e4877f14da6d3603",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as10_22",
@@ -5489,7 +6174,8 @@
             "source_checksum": "d0b2b46f6789c10199f39f67d3c20344",
             "input_file": "as10_22.mp4",
             "output_format": "fltp",
-            "result": "bc7e903ad7664ee5e0fbbb655e1e32ee"
+            "result": "bc7e903ad7664ee5e0fbbb655e1e32ee",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as05_16",
@@ -5497,7 +6183,8 @@
             "source_checksum": "36cac1a34f87661c1730e4752c3f7510",
             "input_file": "as05_16.mp4",
             "output_format": "fltp",
-            "result": "748cfa097ad0e6fce489f0a44a788742"
+            "result": "748cfa097ad0e6fce489f0a44a788742",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al02_16",
@@ -5505,7 +6192,8 @@
             "source_checksum": "8b2c7401d460e07ef55c2e584a16c6d8",
             "input_file": "al02_16.mp4",
             "output_format": "fltp",
-            "result": "3895a8eb4c3f795f621c0591dac9e076"
+            "result": "3895a8eb4c3f795f621c0591dac9e076",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as06_96",
@@ -5513,7 +6201,8 @@
             "source_checksum": "a15a830e07343c1faa03406c117c11d1",
             "input_file": "as06_96.mp4",
             "output_format": "fltp",
-            "result": "186d598b2d6798f3e41cdb3fe57f4469"
+            "result": "186d598b2d6798f3e41cdb3fe57f4469",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al04sf_88",
@@ -5521,7 +6210,8 @@
             "source_checksum": "f41d17fb49944916b40974291c5af4d2",
             "input_file": "al04sf_88.mp4",
             "output_format": "fltp",
-            "result": "854a65ea3d37c7357482d415acaf826e"
+            "result": "854a65ea3d37c7357482d415acaf826e",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08_44",
@@ -5529,7 +6219,8 @@
             "source_checksum": "4e3a6fd07dae11080baca60bf1166fa8",
             "input_file": "al08_44.mp4",
             "output_format": "fltp",
-            "result": "8bb64d92adfe6489adc2bed0a8af25b0"
+            "result": "8bb64d92adfe6489adc2bed0a8af25b0",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al03sf_64",
@@ -5537,7 +6228,8 @@
             "source_checksum": "ca24621d192afcca928a90def9055fca",
             "input_file": "al03sf_64.mp4",
             "output_format": "fltp",
-            "result": "352d2c45ae42514dde7d018bbcdd538c"
+            "result": "352d2c45ae42514dde7d018bbcdd538c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am01_11",
@@ -5545,7 +6237,8 @@
             "source_checksum": "8d92bbdb390bc11486845da4a952874a",
             "input_file": "am01_11.mp4",
             "output_format": "fltp",
-            "result": "104361bdcc1b9d4d24e5863e2c35e050"
+            "result": "104361bdcc1b9d4d24e5863e2c35e050",
+            "profile": "AAC Main"
         },
         {
             "name": "am05_16",
@@ -5553,7 +6246,8 @@
             "source_checksum": "b436103b97fc6bfe1261c7247b60ed4d",
             "input_file": "am05_16.mp4",
             "output_format": "fltp",
-            "result": "a2508711d017ecfb1b46b5a22078bfd4"
+            "result": "a2508711d017ecfb1b46b5a22078bfd4",
+            "profile": "AAC Main"
         },
         {
             "name": "al19_48",
@@ -5561,7 +6255,8 @@
             "source_checksum": "f3ccd8d5882daab6254202a7cbd1d7c2",
             "input_file": "al19_48.mp4",
             "output_format": "fltp",
-            "result": "5557f7070528f4d5aeb1a69655d934e9"
+            "result": "5557f7070528f4d5aeb1a69655d934e9",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08_24",
@@ -5569,7 +6264,8 @@
             "source_checksum": "567b25a72bf32316d3885abd6c133e7d",
             "input_file": "al08_24.mp4",
             "output_format": "fltp",
-            "result": "e497d939a3b8af75295f7ef8165d1912"
+            "result": "e497d939a3b8af75295f7ef8165d1912",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al19sf_12",
@@ -5577,7 +6273,8 @@
             "source_checksum": "81954dfe604caef2b636199083dc014f",
             "input_file": "al19sf_12.mp4",
             "output_format": "fltp",
-            "result": "cbf233464d9c8d6cdbca27723e744da8"
+            "result": "cbf233464d9c8d6cdbca27723e744da8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am05_11",
@@ -5585,7 +6282,8 @@
             "source_checksum": "e61544bfef837da898e51751fc0c5305",
             "input_file": "am05_11.mp4",
             "output_format": "fltp",
-            "result": "000b30c2b4c45ed1c9ad9dad55500eef"
+            "result": "000b30c2b4c45ed1c9ad9dad55500eef",
+            "profile": "AAC Main"
         },
         {
             "name": "am06_88",
@@ -5593,7 +6291,8 @@
             "source_checksum": "dded0d940875e799e61cfb499c5836bd",
             "input_file": "am06_88.mp4",
             "output_format": "fltp",
-            "result": "8a55c91e304071a60301b54b380f1af2"
+            "result": "8a55c91e304071a60301b54b380f1af2",
+            "profile": "AAC Main"
         },
         {
             "name": "al01_88",
@@ -5601,7 +6300,8 @@
             "source_checksum": "621f16a9d07cfb20b5248894f047f944",
             "input_file": "al01_88.mp4",
             "output_format": "fltp",
-            "result": "444692a2f66a9e51e07daec8a1d1a584"
+            "result": "444692a2f66a9e51e07daec8a1d1a584",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al06_64",
@@ -5609,7 +6309,8 @@
             "source_checksum": "369b34adb97f8c85ef4e67af4bccff15",
             "input_file": "al06_64.mp4",
             "output_format": "fltp",
-            "result": "7ff08384d907e611cbb4b7333f41d9fe"
+            "result": "7ff08384d907e611cbb4b7333f41d9fe",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as03_32",
@@ -5617,7 +6318,8 @@
             "source_checksum": "6a5f734b70df98ae706efe583eceb6c3",
             "input_file": "as03_32.mp4",
             "output_format": "fltp",
-            "result": "920794a07f55ca188bb2fdcc09dd990a"
+            "result": "920794a07f55ca188bb2fdcc09dd990a",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al16sf_88",
@@ -5625,7 +6327,8 @@
             "source_checksum": "620f949437596e0f0f2b020f53e03c3c",
             "input_file": "al16sf_88.mp4",
             "output_format": "fltp",
-            "result": "97cd06e5939f630e7f5a510dd5e7a813"
+            "result": "97cd06e5939f630e7f5a510dd5e7a813",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18_48",
@@ -5633,7 +6336,8 @@
             "source_checksum": "cbed89713df6e571762af22e86da5cf7",
             "input_file": "al18_48.mp4",
             "output_format": "fltp",
-            "result": "13b25122d84f8f04af614e23eb6550a1"
+            "result": "13b25122d84f8f04af614e23eb6550a1",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as02_88",
@@ -5641,7 +6345,8 @@
             "source_checksum": "0566eeb208b4b3bf6d7ae75bebf839ed",
             "input_file": "as02_88.mp4",
             "output_format": "fltp",
-            "result": "f669b471bf5bfd82e5a24f6715ca5e8b"
+            "result": "f669b471bf5bfd82e5a24f6715ca5e8b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al17sf_16",
@@ -5649,7 +6354,8 @@
             "source_checksum": "8c304df96141fc9e3da3b8c1a283960a",
             "input_file": "al17sf_16.mp4",
             "output_format": "fltp",
-            "result": "578f691643c105bc6e12665c4f595a0a"
+            "result": "578f691643c105bc6e12665c4f595a0a",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as09_08",
@@ -5657,7 +6363,8 @@
             "source_checksum": "4de70a91518c6a991537769b9881e3fa",
             "input_file": "as09_08.mp4",
             "output_format": "fltp",
-            "result": "c90abb148c09f3fe5eb768fcd283213b"
+            "result": "c90abb148c09f3fe5eb768fcd283213b",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as06_11",
@@ -5665,7 +6372,8 @@
             "source_checksum": "b7a0674054d0dc7943aa77d159632290",
             "input_file": "as06_11.mp4",
             "output_format": "fltp",
-            "result": "64d28b9d388a06953a33cc5b556f41ab"
+            "result": "64d28b9d388a06953a33cc5b556f41ab",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al05sf_44",
@@ -5673,7 +6381,8 @@
             "source_checksum": "c636b8b15a4ca9660a1fc0706fac0248",
             "input_file": "al05sf_44.mp4",
             "output_format": "fltp",
-            "result": "33f981c92cde037b3941040e2ae8bafa"
+            "result": "33f981c92cde037b3941040e2ae8bafa",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al18_88",
@@ -5681,7 +6390,8 @@
             "source_checksum": "a4599ffedd2c4561b5ff42f5cd68e9d6",
             "input_file": "al18_88.mp4",
             "output_format": "fltp",
-            "result": "02b0f333d4caa37379a8ab513dbc4dbf"
+            "result": "02b0f333d4caa37379a8ab513dbc4dbf",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al19sf_96",
@@ -5689,7 +6399,8 @@
             "source_checksum": "a3cbd72178c0d2d09bffd82d7359422c",
             "input_file": "al19sf_96.mp4",
             "output_format": "fltp",
-            "result": "c063c9667651a1ee43c6d6a539d6f1b6"
+            "result": "c063c9667651a1ee43c6d6a539d6f1b6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al05sf_22",
@@ -5697,7 +6408,8 @@
             "source_checksum": "d3060da435a7b1484762461840ab0788",
             "input_file": "al05sf_22.mp4",
             "output_format": "fltp",
-            "result": "c297fd5aba3dbe1b55f41757e0ad518d"
+            "result": "c297fd5aba3dbe1b55f41757e0ad518d",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am05_96",
@@ -5705,7 +6417,8 @@
             "source_checksum": "14cdc53ff9c55582eb2b2a00dabd4cf8",
             "input_file": "am05_96.mp4",
             "output_format": "fltp",
-            "result": "3c767851bcbdfd81880288649bfbf6e2"
+            "result": "3c767851bcbdfd81880288649bfbf6e2",
+            "profile": "AAC Main"
         },
         {
             "name": "al19_11",
@@ -5713,7 +6426,8 @@
             "source_checksum": "c058684333938aa1ad45a9070aeeb25f",
             "input_file": "al19_11.mp4",
             "output_format": "fltp",
-            "result": "cbf233464d9c8d6cdbca27723e744da8"
+            "result": "cbf233464d9c8d6cdbca27723e744da8",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al08_96",
@@ -5721,7 +6435,8 @@
             "source_checksum": "89675c09826b6dedae2650ba2f6647dc",
             "input_file": "al08_96.mp4",
             "output_format": "fltp",
-            "result": "4fe3261089df0bb3f3c584eda4930147"
+            "result": "4fe3261089df0bb3f3c584eda4930147",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as06_44",
@@ -5729,7 +6444,8 @@
             "source_checksum": "d5d5cc065ca0b9aebc354bcfcff75fb9",
             "input_file": "as06_44.mp4",
             "output_format": "fltp",
-            "result": "23f4438eb7a24465d9c1ad6b18d3fe94"
+            "result": "23f4438eb7a24465d9c1ad6b18d3fe94",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as15_64",
@@ -5737,7 +6453,8 @@
             "source_checksum": "a6ae9ba18931b259a0be53189af9966b",
             "input_file": "as15_64.mp4",
             "output_format": "fltp",
-            "result": "e20b00c1c0e0a687cefea609ad52dfa4"
+            "result": "e20b00c1c0e0a687cefea609ad52dfa4",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am01_32",
@@ -5745,7 +6462,8 @@
             "source_checksum": "156ded4135ecdf086ea7024deb33968e",
             "input_file": "am01_32.mp4",
             "output_format": "fltp",
-            "result": "1bcf994fb90b2f3eb5f15420a869f823"
+            "result": "1bcf994fb90b2f3eb5f15420a869f823",
+            "profile": "AAC Main"
         },
         {
             "name": "al05_24",
@@ -5753,7 +6471,8 @@
             "source_checksum": "fff8204fefdfa1fc29c54851911589e1",
             "input_file": "al05_24.mp4",
             "output_format": "fltp",
-            "result": "6420d66039cd4cef3ff15fbbbe94459b"
+            "result": "6420d66039cd4cef3ff15fbbbe94459b",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am06_11",
@@ -5761,7 +6480,8 @@
             "source_checksum": "830a4c37e4371ff155e8a7ce18c526b8",
             "input_file": "am06_11.mp4",
             "output_format": "fltp",
-            "result": "38193ebd7047a355fa93f3c9c48564bf"
+            "result": "38193ebd7047a355fa93f3c9c48564bf",
+            "profile": "AAC Main"
         },
         {
             "name": "al05sf_64",
@@ -5769,7 +6489,8 @@
             "source_checksum": "2bc15245a657d9d3f25214409e1a4c29",
             "input_file": "al05sf_64.mp4",
             "output_format": "fltp",
-            "result": "fd32fac5c93040674baf30e5ebf57c52"
+            "result": "fd32fac5c93040674baf30e5ebf57c52",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al02sf_08",
@@ -5777,7 +6498,8 @@
             "source_checksum": "a7841041e01f69824ac81d451c24e911",
             "input_file": "al02sf_08.mp4",
             "output_format": "fltp",
-            "result": "48e6870f8ccdcaefacd80036e6971aa4"
+            "result": "48e6870f8ccdcaefacd80036e6971aa4",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16_12",
@@ -5785,7 +6507,8 @@
             "source_checksum": "882e1e515ccc08659e6342732b017ca8",
             "input_file": "al16_12.mp4",
             "output_format": "fltp",
-            "result": "8be4074a4050e87afc9f9229cd6bd4ff"
+            "result": "8be4074a4050e87afc9f9229cd6bd4ff",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as16_22",
@@ -5793,7 +6516,8 @@
             "source_checksum": "d1a21fed4a49b321ac17b8962bc9b73f",
             "input_file": "as16_22.mp4",
             "output_format": "fltp",
-            "result": "d42e8ffc0b5cc6331bfe109d9e041ad3"
+            "result": "d42e8ffc0b5cc6331bfe109d9e041ad3",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_sig_48_2_sig2",
@@ -5801,7 +6525,8 @@
             "source_checksum": "2ac3609efdad0216db32471807e8a161",
             "input_file": "al_sbr_sig_48_2_sig2.mp4",
             "output_format": "fltp",
-            "result": "0067d37aa712b90303a9b60e9648ca9c"
+            "result": "0067d37aa712b90303a9b60e9648ca9c",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am00_12",
@@ -5809,7 +6534,8 @@
             "source_checksum": "60ec3e557d14fed71d084618a972e773",
             "input_file": "am00_12.mp4",
             "output_format": "fltp",
-            "result": "2365631d91808e0aaf921944dd078466"
+            "result": "2365631d91808e0aaf921944dd078466",
+            "profile": "AAC Main"
         },
         {
             "name": "al19sf_64",
@@ -5817,7 +6543,8 @@
             "source_checksum": "347fe4f72686b55b60f032ac76a70029",
             "input_file": "al19sf_64.mp4",
             "output_format": "fltp",
-            "result": "c063c9667651a1ee43c6d6a539d6f1b6"
+            "result": "c063c9667651a1ee43c6d6a539d6f1b6",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as05_12",
@@ -5825,7 +6552,8 @@
             "source_checksum": "76bc1150ba5d114b69b151f89e3aff56",
             "input_file": "as05_12.mp4",
             "output_format": "fltp",
-            "result": "5f962095c6a282b2d1de1628b91ff623"
+            "result": "5f962095c6a282b2d1de1628b91ff623",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as13_12",
@@ -5833,7 +6561,8 @@
             "source_checksum": "e7547dc84ea2b36f0426538151dbbcf6",
             "input_file": "as13_12.mp4",
             "output_format": "fltp",
-            "result": "0d0a04302c70d1bde0628478d9424aad"
+            "result": "0d0a04302c70d1bde0628478d9424aad",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al_sbr_e_48_1",
@@ -5841,7 +6570,8 @@
             "source_checksum": "296887bd47894666680d5304737d7526",
             "input_file": "al_sbr_e_48_1.mp4",
             "output_format": "fltp",
-            "result": "496cbeee5eaf2a4efd01e31e6e733221"
+            "result": "496cbeee5eaf2a4efd01e31e6e733221",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "al16sf_22",
@@ -5849,7 +6579,8 @@
             "source_checksum": "094231e579001698ab8cbcf7a7b0d929",
             "input_file": "al16sf_22.mp4",
             "output_format": "fltp",
-            "result": "04ad280f43867978faec2b55cab05817"
+            "result": "04ad280f43867978faec2b55cab05817",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "am05_12",
@@ -5857,7 +6588,8 @@
             "source_checksum": "84c419e39f351dc6d6e77dc276948049",
             "input_file": "am05_12.mp4",
             "output_format": "fltp",
-            "result": "20c610a67a273f9e7bbef3767a562426"
+            "result": "20c610a67a273f9e7bbef3767a562426",
+            "profile": "AAC Main"
         },
         {
             "name": "al01_12",
@@ -5865,7 +6597,8 @@
             "source_checksum": "8d7294f69b279cf56d3a78a793465efa",
             "input_file": "al01_12.mp4",
             "output_format": "fltp",
-            "result": "1bf3c602a298c1b7b2f65080c83d4b49"
+            "result": "1bf3c602a298c1b7b2f65080c83d4b49",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as09_11",
@@ -5873,7 +6606,8 @@
             "source_checksum": "f560df5ef1b035091b2fef9791189d2b",
             "input_file": "as09_11.mp4",
             "output_format": "fltp",
-            "result": "f1e414104151e770be3a8de90fae8b7e"
+            "result": "f1e414104151e770be3a8de90fae8b7e",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al14_44",
@@ -5881,7 +6615,8 @@
             "source_checksum": "5879ca971cc5a7d853139cd5520db2e2",
             "input_file": "al14_44.mp4",
             "output_format": "fltp",
-            "result": "1ea3fc56401dc70963f7a6d7897a7377"
+            "result": "1ea3fc56401dc70963f7a6d7897a7377",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as05_22",
@@ -5889,7 +6624,8 @@
             "source_checksum": "a9fdb2ac70b7deb02baf4ac188288ae5",
             "input_file": "as05_22.mp4",
             "output_format": "fltp",
-            "result": "bbd39cff4466d45eb47427488d5332db"
+            "result": "bbd39cff4466d45eb47427488d5332db",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as07_22",
@@ -5897,7 +6633,8 @@
             "source_checksum": "47e4b06158704bea075539d3e80b6fe8",
             "input_file": "as07_22.mp4",
             "output_format": "fltp",
-            "result": "ab4981a6ac7a37d903277c886a14b893"
+            "result": "ab4981a6ac7a37d903277c886a14b893",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "al03_12",
@@ -5905,7 +6642,8 @@
             "source_checksum": "11269901077bcb44e252773196481931",
             "input_file": "al03_12.mp4",
             "output_format": "fltp",
-            "result": "97c9a4a96818ef0c03dc1c8797aa7279"
+            "result": "97c9a4a96818ef0c03dc1c8797aa7279",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as02_11",
@@ -5913,7 +6651,8 @@
             "source_checksum": "98b2a869df71fcbe96dd5196608a6cfc",
             "input_file": "as02_11.mp4",
             "output_format": "fltp",
-            "result": "a9dbc7369832bc9ce70391719891fb98"
+            "result": "a9dbc7369832bc9ce70391719891fb98",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "as00_08",
@@ -5921,7 +6660,8 @@
             "source_checksum": "aa1fbefff39fc500d500017d818c0a5d",
             "input_file": "as00_08.mp4",
             "output_format": "fltp",
-            "result": "f852727b02e8195bc975fe7342821cb3"
+            "result": "f852727b02e8195bc975fe7342821cb3",
+            "profile": "AAC Scalable Sampling Rate"
         },
         {
             "name": "am02_44",
@@ -5929,7 +6669,8 @@
             "source_checksum": "4390510d57278631ee031a0050b66cdf",
             "input_file": "am02_44.mp4",
             "output_format": "fltp",
-            "result": "a6411c703a1ac140889d5eb6dd0d9bf1"
+            "result": "a6411c703a1ac140889d5eb6dd0d9bf1",
+            "profile": "AAC Main"
         },
         {
             "name": "al06_44",
@@ -5937,7 +6678,8 @@
             "source_checksum": "19903817fa98764385f393c3734c1d7c",
             "input_file": "al06_44.mp4",
             "output_format": "fltp",
-            "result": "1a44da7dc44a968dd889bd4a8ce861f2"
+            "result": "1a44da7dc44a968dd889bd4a8ce861f2",
+            "profile": "AAC Low Complexity"
         },
         {
             "name": "as12_24",
@@ -5945,7 +6687,8 @@
             "source_checksum": "30ab81336a4dab8a6287178ca27866c7",
             "input_file": "as12_24.mp4",
             "output_format": "fltp",
-            "result": "cfabdc64e2e652806354ed8b821690c5"
+            "result": "cfabdc64e2e652806354ed8b821690c5",
+            "profile": "AAC Scalable Sampling Rate"
         }
     ]
 }


### PR DESCRIPTION
More info here:

https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_IEC_14496-26_2010_Bitstreams/DVD1/mpeg4audio-conformance/doc/fileNameConventions.html

Test:
```

## System Information

**OS:** Linux 6.17.0-35-generic

**CPU:** AMD Ryzen 7 7745HX with Radeon Graphics

**GPU:** 00.0 VGA compatible controller: NVIDIA Corporation AD107M, 00.0 VGA compatible controller: Advanced Micro Devices, Inc. [PRIMARY]

**RAM:** 30.5 GB

**Backends:**
- VDPAU: G3DVL VDPAU Driver Shared Library version 1.0
- NVDEC: Available (NVIDIA Driver 595.71.05)

**Test Suite: MPEG4_AAC-ADTS**

|Test|Fluendo-AAC-SW|
|-|-|
|PASSED|0/9|
|FAILED\ERROR|9/9|
|TOTAL TIME|0.568s|

|Profile|Fluendo-AAC-SW|
|-|-|
|AAC_LC|0/5|
|AAC_LTP|0/4|

|Test|Fluendo-AAC-SW|
|-|-|
|al18_32|❌|
|al18_22|❌|
|ap04_48|❌|
|al18_64|❌|
|ap02_48|❌|
|al18_08|❌|
|ap01_48|❌|
|al18_96|❌|
|ap05_48|❌|
```