### PR TITLE
fix: pass GST_PLUGIN_FEATURE_RANK via subprocess env instead of cmd string

### DIFF
--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -129,14 +129,19 @@ class GStreamer(Decoder):
         element_desc = decoder_bin.strip().split("!", 1)[0].strip()
         return element_desc.split()[0] if element_desc else ""
 
-    def _wrap_cmd(self) -> str:
-        """Prepend GST_PLUGIN_FEATURE_RANK so parsebin's autoplugger picks this decoder's factory"""
+    def _extra_env(self) -> Dict[str, str]:
+        """Extra env vars so parsebin's autoplugger picks this decoder's factory"""
         if "parsebin" not in self.parser:
-            return self.cmd
+            return {}
         factory_name = self._decoder_factory_name(self.decoder_bin)
         if not factory_name:
-            return self.cmd
-        return f"GST_PLUGIN_FEATURE_RANK={factory_name}:MAX {self.cmd}"
+            return {}
+        return {"GST_PLUGIN_FEATURE_RANK": f"{factory_name}:MAX"}
+
+    def _run_env(self) -> Optional[Dict[str, str]]:
+        """Current env plus decoder-specific overrides, for subprocess calls"""
+        extra = self._extra_env()
+        return {**os.environ, **extra} if extra else None
 
     def gen_pipeline(
         self,
@@ -148,7 +153,7 @@ class GStreamer(Decoder):
         """Generate the GStreamer pipeline used to decode the test vector"""
         output = f"location={output_filepath}" if output_filepath else ""
         return PIPELINE_TPL.format(
-            self._wrap_cmd(),
+            self.cmd,
             input_filepath,
             self.parser,
             self.decoder_bin,
@@ -190,6 +195,7 @@ class GStreamer(Decoder):
         optional_params: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Decode the test vector and do the checksum"""
+        env = self._run_env()
         # When using videocodectestsink we can avoid writing files to disk
         # completely, or avoid a full raw file read in order to compute the MD5
         # SUM.
@@ -198,19 +204,19 @@ class GStreamer(Decoder):
             pipeline = self.gen_pipeline(input_filepath, output_param, output_format, optional_params)
             command = shlex.split(pipeline)
             command.append("-m")
-            data = run_command_with_output(command, timeout=timeout, verbose=verbose).splitlines()
+            data = run_command_with_output(command, timeout=timeout, verbose=verbose, env=env).splitlines()
             return self.parse_videocodectestsink_md5sum(data)
 
         pipeline = self.gen_pipeline(input_filepath, output_filepath, output_format, optional_params)
-        run_command(shlex.split(pipeline), timeout=timeout, verbose=verbose)
+        run_command(shlex.split(pipeline), timeout=timeout, verbose=verbose, env=env)
         return file_checksum(output_filepath)
 
     @lru_cache(maxsize=128)
     def check(self, verbose: bool) -> bool:
         """Check if GStreamer decoder is valid (better than gst-inspect)"""
         try:
-            pipeline = f"{self._wrap_cmd()} --no-fault appsrc num-buffers=0 ! {self.decoder_bin} ! fakesink"
-            run_command(shlex.split(pipeline), verbose=verbose)
+            pipeline = f"{self.cmd} --no-fault appsrc num-buffers=0 ! {self.decoder_bin} ! fakesink"
+            run_command(shlex.split(pipeline), verbose=verbose, env=self._run_env())
         except Exception:
             return False
         return True
@@ -256,7 +262,7 @@ class GStreamerVideo(GStreamer):
         caps = f"{self.caps} ! videoconvert dither=none ! {raw_caps}"
         output = f"location={output_filepath}" if output_filepath else ""
         return PIPELINE_TPL.format(
-            self._wrap_cmd(),
+            self.cmd,
             input_filepath,
             self.parser,
             self.decoder_bin,
@@ -918,7 +924,7 @@ class FluendoFluAC4DecDecoder(GStreamerAudio):
             for param, value in optional_params.items():
                 decoder_bin += f" {param.replace('_', '-')}={value}"
         return PIPELINE_TPL.format(
-            self._wrap_cmd(),
+            self.cmd,
             input_filepath,
             self.parser,
             decoder_bin,
@@ -957,7 +963,7 @@ class FluendoFluEAC3DecDecoder(GStreamerAudio):
             for param, value in optional_params.items():
                 decoder_bin += f" {param.replace('_', '-')}={value}"
         return PIPELINE_TPL.format(
-            self._wrap_cmd(),
+            self.cmd,
             input_filepath,
             self.parser,
             decoder_bin,

--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -37,7 +37,7 @@ import wave
 import zipfile
 from functools import partial
 from threading import Lock
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 TARBALL_EXTS = ("tar.gz", "tgz", "tar.bz2", "tbz2", "tar.xz")
 
@@ -231,14 +231,16 @@ def run_command(
     verbose: bool = False,
     check: bool = True,
     timeout: Optional[int] = None,
+    env: Optional[Dict[str, str]] = None,
 ) -> None:
-    """Runs a command"""
+    """Runs a command. `env`, if given, replaces the environment entirely -
+    pass {**os.environ, ...} to add vars instead of replacing them."""
     sout = subprocess.DEVNULL if not verbose else None
     serr = subprocess.DEVNULL if not verbose else None
     if verbose:
         print(f'\nRunning command "{" ".join(command)}"')
     try:
-        subprocess.run(command, stdout=sout, stderr=serr, check=check, timeout=timeout)
+        subprocess.run(command, stdout=sout, stderr=serr, check=check, timeout=timeout, env=env)
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
         # Developer experience improvement (facilitates copy/paste)
         ex.cmd = " ".join(ex.cmd)
@@ -251,8 +253,9 @@ def run_command_with_output(
     check: bool = True,
     timeout: Optional[int] = None,
     keep_stderr: bool = False,
+    env: Optional[Dict[str, str]] = None,
 ) -> str:
-    """Runs a command and returns std output trace"""
+    """Runs a command and returns std output trace. See run_command() for `env` semantics."""
     serr = subprocess.DEVNULL
     if verbose or keep_stderr:
         serr = subprocess.STDOUT
@@ -260,7 +263,7 @@ def run_command_with_output(
         print(f'\nRunning command "{" ".join(command)}"')
 
     try:
-        output = subprocess.check_output(command, stderr=serr, timeout=timeout, universal_newlines=True)
+        output = subprocess.check_output(command, stderr=serr, timeout=timeout, universal_newlines=True, env=env)
         if verbose and output:
             print(output)
         return output or ""


### PR DESCRIPTION
`0ca8dc6` broke all parsebin decoders: **GST_PLUGIN_FEATURE_RANK**=... prepended to the command string was split by `shlex` and treated as the executable by `subprocess.run`, causing `check()` to fail and all tests to be skipped

Fixed by passing the env var through `subprocess.run`'s native `env` parameter instead cross-platform, no shell tricks