### PR TITLE
fix: revert H.266 decoders to explicit h266parse parser

### DIFF
--- a/fluster/decoders/gstreamer.py
+++ b/fluster/decoders/gstreamer.py
@@ -848,6 +848,7 @@ class FluendoVVCdeCH266Decoder(GStreamerVideo):
     decoder_bin = " fluh266dec "
     provider = "Fluendo"
     api = "SW"
+    parser = "parsebin " if gst_element_exists("h266parse") else "fluh266parse"
 
 
 @register_decoder


### PR DESCRIPTION
parsebin lacks VVC support in system GStreamer, so H.266 decoders need explicit h266parse instead. 

**TODO**: switch back to parsebin once VVC support is fixed ([OCP-8005](https://fluendo.atlassian.net/browse/OCP-8005))

[OCP-8005]: https://fluendo.atlassian.net/browse/OCP-8005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ